### PR TITLE
Handle problematic tokens in other editors

### DIFF
--- a/server/GSCode.NET/LSP/Handlers/SemanticTokensHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/SemanticTokensHandler.cs
@@ -30,34 +30,50 @@ public class SemanticTokensHandler : SemanticTokensHandlerBase
         _documentSelector = documentSelector;
     }
 
-    protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(SemanticTokensCapability capability, ClientCapabilities clientCapabilities)
+    protected override SemanticTokensRegistrationOptions CreateRegistrationOptions(
+        SemanticTokensCapability capability,
+        ClientCapabilities clientCapabilities)
     {
+        var tokenModifiers = capability?.TokenModifiers ?? new Container<SemanticTokenModifier>();
+        var tokenTypes = capability?.TokenTypes;
+
+        if (tokenTypes == null || !tokenTypes.Any())
+        {
+            tokenTypes = new Container<SemanticTokenType>(
+                SemanticTokenType.Namespace,
+                SemanticTokenType.Type,
+                SemanticTokenType.Class,
+                SemanticTokenType.Enum,
+                SemanticTokenType.Interface,
+                SemanticTokenType.Struct,
+                SemanticTokenType.TypeParameter,
+                SemanticTokenType.Parameter,
+                SemanticTokenType.Variable,
+                SemanticTokenType.Property,
+                SemanticTokenType.EnumMember,
+                SemanticTokenType.Event,
+                SemanticTokenType.Function,
+                SemanticTokenType.Method,
+                SemanticTokenType.Macro,
+                SemanticTokenType.Keyword,
+                SemanticTokenType.Modifier,
+                SemanticTokenType.Comment,
+                SemanticTokenType.String,
+                SemanticTokenType.Number,
+                SemanticTokenType.Regexp,
+                SemanticTokenType.Operator
+            );
+        }
+
         return new SemanticTokensRegistrationOptions
         {
             DocumentSelector = _documentSelector,
             Legend = new SemanticTokensLegend
             {
-                TokenModifiers = capability.TokenModifiers,
-                // TokenTypes = [.. capability.TokenTypes, "field"]
-                TokenTypes = new Container<SemanticTokenType>(
-                    SemanticTokenType.Variable,
-                    SemanticTokenType.Parameter,
-                    SemanticTokenType.Property,
-                    SemanticTokenType.Type,
-                    SemanticTokenType.Function,
-                    SemanticTokenType.Class,
-                    SemanticTokenType.Macro,
-                    SemanticTokenType.String,
-                    SemanticTokenType.Namespace,
-                    SemanticTokenType.Method,
-                    SemanticTokenType.Keyword,
-                    new SemanticTokenType("field")
-                )
+                TokenModifiers = tokenModifiers,
+                TokenTypes = tokenTypes
             },
-            Full = new SemanticTokensCapabilityRequestFull
-            {
-                Delta = false
-            },
+            Full = new SemanticTokensCapabilityRequestFull { Delta = false },
             Range = false
         };
     }


### PR DESCRIPTION
When working with other IDEs, the LSP would timeout due to a NullReferenceException. 
This PR fixes that issue, and should now work with other editors.

Tested in Zed editor.

Before the fix (and even using the next branch) it would give the below error:
```OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker: Failed to handle request initialize 0 - System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at GSCode.NET.LSP.Handlers.SemanticTokensHandler.CreateRegistrationOptions(SemanticTokensCapability capability, ClientCapabilities clientCapabilities) in J:\Github\gscode\server\GSCode.NET\LSP\Handlers\SemanticTokensHandler.cs:line 35
   at OmniSharp.Extensions.LanguageServer.Protocol.AbstractHandlers.Base`2.OmniSharp.Extensions.LanguageServer.Protocol.IRegistration<TRegistrationOptions,TCapability>.GetRegistrationOptions(TCapability capability, ClientCapabilities clientCapabilities)
   at OmniSharp.Extensions.LanguageServer.Shared.SupportedCapabilitiesBase.SetRegistrationCapabilityInner[TR,TC](IRegistration`2 capability, TC instance, ClientCapabilities clientCapabilities)
   at System.RuntimeMethodHandle.InvokeMethod(Object target, Void** arguments, Signature sig, Boolean isConstructor)
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
   at System.Reflection.MethodBaseInvoker.InvokeDirectByRefWithFewArgs(Object obj, Span`1 copyOfArgs, BindingFlags invokeAttr)
   at System.Reflection.MethodBaseInvoker.InvokeWithFewArgs(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at OmniSharp.Extensions.LanguageServer.Shared.SupportedCapabilitiesBase.GetRegistrationOptions(Type registrationType, Type capabilityType, IJsonRpcHandler handler)
   at OmniSharp.Extensions.LanguageServer.Shared.SupportedCapabilitiesBase.GetRegistrationOptions(ILspHandlerDescriptor descriptor)
   at OmniSharp.Extensions.LanguageServer.Shared.SharedHandlerCollection.InferKey(ILspHandlerDescriptor descriptor, IJsonRpcHandler handler)
   at OmniSharp.Extensions.LanguageServer.Shared.SharedHandlerCollection.Initialize()
   at OmniSharp.Extensions.LanguageServer.Server.LanguageServer.ReadClientCapabilities(InternalInitializeParams request, ClientCapabilities& clientCapabilities, TextDocumentClientCapabilities& textDocumentCapabilities, NotebookDocumentClientCapabilities& notebookDocumentCapabilities, WorkspaceClientCapabilities& workspaceCapabilities, WindowClientCapabilities& windowCapabilities, GeneralClientCapabilities& generalCapabilities)
   at OmniSharp.Extensions.LanguageServer.Server.LanguageServer.MediatR.IRequestHandler<OmniSharp.Extensions.LanguageServer.Protocol.Models.InternalInitializeParams,OmniSharp.Extensions.LanguageServer.Protocol.Models.InitializeResult>.Handle(InternalInitializeParams request, CancellationToken token)
   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.SemanticTokensDeltaPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at OmniSharp.Extensions.LanguageServer.Server.Pipelines.ResolveCommandPipeline`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestPreProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestPostProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestExceptionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at MediatR.Pipeline.RequestExceptionActionProcessorBehavior`2.Handle(TRequest request, CancellationToken cancellationToken, RequestHandlerDelegate`1 next)
   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.<RouteRequest>g__InnerRoute|7_0(IServiceScopeFactory serviceScopeFactory, Request request, TDescriptor descriptor, Object params, CancellationToken token, ILogger logger)
   at OmniSharp.Extensions.JsonRpc.RequestRouterBase`1.RouteRequest(IRequestDescriptor`1 descriptors, Request request, CancellationToken token)
   at OmniSharp.Extensions.JsonRpc.DefaultRequestInvoker.<>c__DisplayClass10_0.<<RouteRequest>b__5>d.MoveNext() | Method='initialize' RequestId='0'
OmniSharp.Extensions.LanguageServer.Server.LspServerOutputFilter: Tried to send request or notification before initialization was completed and will be sent later OmniSharp.Extensions.JsonRpc.Server.Messages.InternalError | @Request='OmniSharp.Extensions.JsonRpc.Server.Messages.InternalError'
```