### PR TITLE
patch: temporarily disable indexing

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -12,7 +12,12 @@ GSCode's language server requires the .NET 8 Runtime, available at [Download .NE
 
 ## Release Notes
 
-### 0.10 beta (latest)
+### 0.10.1 beta (latest)
+
+- Disabled workspace indexing temporarily due to performance concerns.
+
+### 0.10.0 beta
+
 - Added reference finding (Go to Reference, Find All References)
 - Added workspace indexing of scripts.
 - Fixed switch case analysis with braced bodies.

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
 	"displayName": "GSCode",
 	"description": "IntelliSense for Call of Duty: Black Ops III's GSC & CSC languages.",
 	"icon": "icons/gscode-beta.png",
-	"version": "0.10.0",
+	"version": "0.10.1",
 	"publisher": "blakintosh",
 	"repository": {
 		"type": "git",

--- a/server/GSCode.NET/Program.cs
+++ b/server/GSCode.NET/Program.cs
@@ -87,36 +87,37 @@ LanguageServer server = await LanguageServer.From(options =>
 				}
 			));
 		})
-		.OnInitialize(async (server, request, ct) =>
-		{
-			try
-			{
-				var sm = server.Services.GetRequiredService<ScriptManager>();
+		// Temporarily disabled due to performance issues
+		// .OnInitialize(async (server, request, ct) =>
+		// {
+		// 	try
+		// 	{
+		// 		var sm = server.Services.GetRequiredService<ScriptManager>();
 
-				// Use a long-lived CTS for indexing; do not tie to Initialize request token
-				var indexingCts = new CancellationTokenSource();
-				options.RegisterForDisposal(indexingCts);
-				var indexingToken = indexingCts.Token;
+		// 		// Use a long-lived CTS for indexing; do not tie to Initialize request token
+		// 		var indexingCts = new CancellationTokenSource();
+		// 		options.RegisterForDisposal(indexingCts);
+		// 		var indexingToken = indexingCts.Token;
 
-				if (request.WorkspaceFolders is not null && request.WorkspaceFolders.Any())
-				{
-					foreach (var wf in request.WorkspaceFolders)
-					{
-						string root = wf.Uri.ToUri().LocalPath;
-						_ = Task.Run(() => sm.IndexWorkspaceAsync(root, indexingToken), CancellationToken.None);
-					}
-				}
-				else if (request.RootUri is not null)
-				{
-					string root = request.RootUri.ToUri().LocalPath;
-					_ = Task.Run(() => sm.IndexWorkspaceAsync(root, indexingToken), CancellationToken.None);
-				}
-			}
-			catch (Exception ex)
-			{
-				Log.Error(ex, "Failed to start workspace indexing");
-			}
-		})
+		// 		if (request.WorkspaceFolders is not null && request.WorkspaceFolders.Any())
+		// 		{
+		// 			foreach (var wf in request.WorkspaceFolders)
+		// 			{
+		// 				string root = wf.Uri.ToUri().LocalPath;
+		// 				_ = Task.Run(() => sm.IndexWorkspaceAsync(root, indexingToken), CancellationToken.None);
+		// 			}
+		// 		}
+		// 		else if (request.RootUri is not null)
+		// 		{
+		// 			string root = request.RootUri.ToUri().LocalPath;
+		// 			_ = Task.Run(() => sm.IndexWorkspaceAsync(root, indexingToken), CancellationToken.None);
+		// 		}
+		// 	}
+		// 	catch (Exception ex)
+		// 	{
+		// 		Log.Error(ex, "Failed to start workspace indexing");
+		// 	}
+		// })
 		.AddHandler<TextDocumentSyncHandler>()
 		.AddHandler<SemanticTokensHandler>()
 		.AddHandler<HoverHandler>()

--- a/site/src/lib/components/app/header/header.svelte
+++ b/site/src/lib/components/app/header/header.svelte
@@ -62,7 +62,7 @@
 
 			<Button size="sm" class="gap-2" href="https://marketplace.visualstudio.com/items?itemName=blakintosh.gscode" target="_blank" rel="noopener noreferrer">
 				<Download class="w-4 h-4"/>
-				v0.10.0-beta
+				v0.10.1-beta
 			</Button>
 		</div>
 	{:else}	

--- a/site/src/routes/(gscode)/+page.svelte
+++ b/site/src/routes/(gscode)/+page.svelte
@@ -30,7 +30,7 @@
 
 		<a href="https://marketplace.visualstudio.com/items?itemName=blakintosh.gscode" class="preview-button my-16 text-white lg:text-2xl text-lg" target="_blank" rel="noopener noreferrer">
 			<Download class="w-6 h-6"/>
-			<span>v0.10.0-beta</span>
+			<span>v0.10.1-beta</span>
 		</a>
 	</div>
 	<!-- <div class="flex items-center flex-col py-8 bg-background">


### PR DESCRIPTION
Interim fix for #34 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Temporarily disables language server workspace indexing and bumps the extension to v0.10.1 with corresponding README and site updates.
> 
> - **Server**:
>   - Disable workspace indexing on initialize by commenting out `OnInitialize` indexing logic in `server/GSCode.NET/Program.cs`.
> - **Client/Release**:
>   - Bump version to `0.10.1` in `client/package.json`.
>   - Update `client/README.md` release notes (add `0.10.1` noting indexing disabled).
> - **Site**:
>   - Update displayed version text to `v0.10.1-beta` in `site/src/lib/components/app/header/header.svelte` and `site/src/routes/(gscode)/+page.svelte`.}
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9a614302b17b6b2dd7c2dc031d89c8bece408ea5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->