### PR TITLE
Implement CodeAction handler and improve diagnostics handling

### DIFF
--- a/server/GSCode.Data/DiagnosticCodes.cs
+++ b/server/GSCode.Data/DiagnosticCodes.cs
@@ -131,6 +131,7 @@ public enum GSCErrorCodes
         DevBlockFunctionOutsideDevBlock = 3064,
         ConsumedThreadedCallResult = 3065,
         BrokenFunctionUsage = 3066,
+        NamespaceDoesNotContainFunction = 3067,
 
         // 8xxx errors are issued by the IDE for conventions
         UnterminatedRegion = 8000,
@@ -267,6 +268,7 @@ public static class DiagnosticCodes
         { GSCErrorCodes.DevBlockFunctionOutsideDevBlock, new("Function '{0}' can only be used inside developer blocks.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.ConsumedThreadedCallResult, new("Consuming the result of a threaded call is unreliable; if the threaded function blocks, the expression will evaluate to 'undefined'.", DiagnosticSeverity.Warning) },
         { GSCErrorCodes.BrokenFunctionUsage, new("Function '{0}' is marked as broken and should not be used.", DiagnosticSeverity.Warning, new[] { DiagnosticTag.Deprecated }) },
+        { GSCErrorCodes.NamespaceDoesNotContainFunction, new("The namespace '{0}' does not contain a function named '{1}'.", DiagnosticSeverity.Error) },
 
         // 8xxx
         { GSCErrorCodes.UnterminatedRegion, new("No corresponding '/* endregion */' found to terminate '{0}' region.", DiagnosticSeverity.Warning) },

--- a/server/GSCode.Data/DiagnosticCodes.cs
+++ b/server/GSCode.Data/DiagnosticCodes.cs
@@ -151,7 +151,7 @@ public enum GSCErrorCodes
 
 public static class DiagnosticCodes
 {
-        private static readonly Dictionary<GSCErrorCodes, DiagnosticCode> diagnosticsDictionary = new()
+    private static readonly Dictionary<GSCErrorCodes, DiagnosticCode> diagnosticsDictionary = new()
     {
         // 1xxx
         { GSCErrorCodes.ExpectedPreprocessorToken, new("'{0}' expected, but instead got '{1}'.", DiagnosticSeverity.Error) },
@@ -235,7 +235,7 @@ public static class DiagnosticCodes
         { GSCErrorCodes.CannotAssignToReadOnlyProperty, new("The property '{0}' cannot be assigned to, it is read-only.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.MissingUsingFile, new("Unable to locate file '{0}' in the workspace or in the shared scripts directory.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.CannotEnumerateType, new("Type '{0}' is not enumerable.", DiagnosticSeverity.Error) },
-        { GSCErrorCodes.FunctionDoesNotExist, new("The function '{0}' could not be resolved in this context and may not exist in built-ins.\nNote: Built-in function checking is based on Treyarch's API, which contains errors. Report falsely flagged functions.", DiagnosticSeverity.Warning) },
+        { GSCErrorCodes.FunctionDoesNotExist, new("The function '{0}' could not be resolved in this context and may not exist in built-ins.\nNote: Built-in function checking is based on Treyarch's API, which contains errors. Report falsely flagged functions.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.ExpectedFunction, new("Expected a function, but instead got '{0}'.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.ReservedSymbol, new("The symbol '{0}' is reserved.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.UnusedVariable, new("The variable '{0}' is declared but never used.", DiagnosticSeverity.Information, new[] { DiagnosticTag.Unnecessary }) },
@@ -287,27 +287,26 @@ public static class DiagnosticCodes
 
         public static Diagnostic GetDiagnostic(Range range, string source, GSCErrorCodes key, params object?[] arguments)
         {
-                if (diagnosticsDictionary.ContainsKey(key))
-                {
-                        DiagnosticCode result = diagnosticsDictionary[key];
-                        return new()
-                        {
-                                Message = string.Format(result.Message, arguments),
-                                Range = range,
-                                Severity = result.Category,
-                                Code = (int)key,
-                                Source = source,
-                                Tags = result.Tags
-                        };
-                }
-
+            if (diagnosticsDictionary.TryGetValue(key, out DiagnosticCode? result))
+            {
                 return new()
                 {
-                        Message = "GSCode.NET Error: could not find an error matching this code.",
-                        Range = range,
-                        Severity = DiagnosticSeverity.Error,
-                        Code = (int)key,
-                        Source = source
+                    Message = string.Format(result.Message, arguments),
+                    Range = range,
+                    Severity = result.Category,
+                    Code = (int)key,
+                    Source = source,
+                    Tags = result.Tags
                 };
-        }
-}
+            }
+
+            return new()
+            {
+                Message = "GSCode.NET Error: could not find an error matching this code.",
+                Range = range,
+                Severity = DiagnosticSeverity.Error,
+                            Code = (int)key,
+                            Source = source
+                        };
+                    }
+                }

--- a/server/GSCode.Data/DiagnosticCodes.cs
+++ b/server/GSCode.Data/DiagnosticCodes.cs
@@ -235,7 +235,7 @@ public static class DiagnosticCodes
         { GSCErrorCodes.CannotAssignToReadOnlyProperty, new("The property '{0}' cannot be assigned to, it is read-only.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.MissingUsingFile, new("Unable to locate file '{0}' in the workspace or in the shared scripts directory.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.CannotEnumerateType, new("Type '{0}' is not enumerable.", DiagnosticSeverity.Error) },
-        { GSCErrorCodes.FunctionDoesNotExist, new("The function '{0}' could not be resolved in this context and may not exist in built-ins.\nNote: Built-in function checking is based on Treyarch's API, which contains errors. Report falsely flagged functions.", DiagnosticSeverity.Error) },
+        { GSCErrorCodes.FunctionDoesNotExist, new("The function '{0}' could not be resolved.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.ExpectedFunction, new("Expected a function, but instead got '{0}'.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.ReservedSymbol, new("The symbol '{0}' is reserved.", DiagnosticSeverity.Error) },
         { GSCErrorCodes.UnusedVariable, new("The variable '{0}' is declared but never used.", DiagnosticSeverity.Information, new[] { DiagnosticTag.Unnecessary }) },

--- a/server/GSCode.NET/LSP/GlobalSymbolRegistry.cs
+++ b/server/GSCode.NET/LSP/GlobalSymbolRegistry.cs
@@ -64,9 +64,16 @@ public sealed class GlobalSymbolRegistry : ISymbolLocationProvider
                 var key = QualifiedSymbolKey.Normalized(ns, name);
                 if (_symbols.TryGetValue(key, out var def))
                     return def;
+
+                // An explicit namespace was given but no exact match exists.
+                // Do NOT fall back to a name-only scan: that would silently
+                // resolve ns::func to an unrelated function that merely shares
+                // the same name in a different namespace, causing GoTo to jump
+                // to the wrong file.
+                return null;
             }
 
-            // Fall back to name-only search
+            // Unqualified reference — search by name only across all namespaces.
             return FindSymbolByNameOnlyCore(name);
         }
         finally

--- a/server/GSCode.NET/LSP/GlobalSymbolRegistry.cs
+++ b/server/GSCode.NET/LSP/GlobalSymbolRegistry.cs
@@ -355,4 +355,34 @@ public sealed class GlobalSymbolRegistry : ISymbolLocationProvider
     }
 
     #endregion
+
+    /// <summary>
+    /// Returns all distinct file paths that define at least one symbol in the given namespace.
+    /// Used by the code action handler to suggest <c>#using</c> directives when a namespace is unknown.
+    /// </summary>
+    /// <param name="namespaceName">The namespace to search for (case-insensitive).</param>
+    /// <returns>A list of file paths, or an empty list if no files define this namespace.</returns>
+    public List<string> FindFilesForNamespace(string namespaceName)
+    {
+        var normalizedNs = namespaceName?.ToLowerInvariant() ?? string.Empty;
+        var result = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        _lock.EnterReadLock();
+        try
+        {
+            foreach (var (key, def) in _symbols)
+            {
+                if (string.Equals(key.Qualifier, normalizedNs, StringComparison.OrdinalIgnoreCase))
+                {
+                    result.Add(def.FilePath);
+                }
+            }
+        }
+        finally
+        {
+            _lock.ExitReadLock();
+        }
+
+        return result.ToList();
+    }
 }

--- a/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
@@ -160,6 +160,21 @@ internal sealed class CodeActionHandler(
                     actions.Add(new CommandOrCodeAction(createAction));
                 }
             }
+
+            // UnknownNamespace: offer to add a #using directive for each file that
+            // exports symbols into the missing namespace. When multiple files define
+            // the same namespace, one code action per file is emitted so the user can
+            // pick the correct dependency.
+            if (errorCode == GSCErrorCodes.UnknownNamespace)
+            {
+                var usingActions = CreateAddUsingForNamespaceActions(
+                    request.TextDocument, diagnostic, content);
+
+                foreach (var usingAction in usingActions)
+                {
+                    actions.Add(new CommandOrCodeAction(usingAction));
+                }
+            }
         }
 
         // Source action: remove all unused #using directives in the file at once.
@@ -576,6 +591,150 @@ internal sealed class CodeActionHandler(
                 }
             }
         };
+    }
+
+    /// <summary>
+    /// Creates one code action per file that defines symbols in the missing namespace.
+    /// Each action inserts a <c>#using</c> directive at the top of the current document
+    /// pointing to the file that provides the namespace.
+    /// </summary>
+    /// <remarks>
+    /// The diagnostic range covers the namespace identifier token (e.g. <c>foo</c> in
+    /// <c>foo::bar()</c>), so <see cref="GetTextInRange"/> extracts the namespace name directly.
+    /// The <c>#using</c> path is derived from the provider file's absolute path by extracting
+    /// everything from the <c>scripts/</c> directory onward and stripping the file extension,
+    /// producing a path like <c>scripts\zm\utility</c>.
+    /// </remarks>
+    private List<CodeAction> CreateAddUsingForNamespaceActions(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        var results = new List<CodeAction>();
+
+        if (string.IsNullOrEmpty(content))
+        {
+            return results;
+        }
+
+        // The diagnostic range covers the namespace identifier token
+        string? namespaceName = GetTextInRange(content, diagnostic.Range);
+        if (string.IsNullOrEmpty(namespaceName))
+        {
+            return results;
+        }
+
+        // Query the global symbol registry for files that export this namespace
+        List<string> filePaths = _scriptManager.SymbolRegistry.FindFilesForNamespace(namespaceName);
+        if (filePaths.Count == 0)
+        {
+            return results;
+        }
+
+        // Find the insertion point: after the last existing #using line, or at (0,0)
+        Position insertPosition = FindUsingInsertPosition(content);
+        bool isFirst = filePaths.Count == 1;
+
+        foreach (string filePath in filePaths)
+        {
+            // Convert the absolute file path to a #using path (e.g. "scripts\zm\utility")
+            string? usingPath = ConvertFilePathToUsingPath(filePath);
+            if (usingPath is null)
+            {
+                continue;
+            }
+
+            string directive = $"#using {usingPath};\n";
+
+            results.Add(new CodeAction
+            {
+                Title = $"Add '#using {usingPath}'",
+                Kind = CodeActionKind.QuickFix,
+                IsPreferred = isFirst,
+                Diagnostics = new Container<Diagnostic>(diagnostic),
+                Edit = new WorkspaceEdit
+                {
+                    Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                    {
+                        [document.Uri] =
+                        [
+                            new TextEdit
+                            {
+                                Range = new Range(insertPosition, insertPosition),
+                                NewText = directive
+                            }
+                        ]
+                    }
+                }
+            });
+
+            // Only the first suggestion is marked as preferred
+            isFirst = false;
+        }
+
+        return results;
+    }
+
+    /// <summary>
+    /// Finds the position where a new <c>#using</c> directive should be inserted.
+    /// Returns the start of the line immediately after the last existing <c>#using</c>
+    /// directive, or <c>(0, 0)</c> if none exist.
+    /// </summary>
+    private static Position FindUsingInsertPosition(string content)
+    {
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+        int lastUsingLine = -1;
+
+        for (int i = 0; i < lines.Length; i++)
+        {
+            string trimmed = lines[i].TrimStart();
+            if (trimmed.StartsWith("#using", StringComparison.Ordinal))
+            {
+                lastUsingLine = i;
+            }
+            // Stop scanning once we pass the header area (first non-blank, non-using,
+            // non-comment line that looks like a definition)
+            else if (trimmed.Length > 0
+                && !trimmed.StartsWith("//", StringComparison.Ordinal)
+                && !trimmed.StartsWith("/*", StringComparison.Ordinal))
+            {
+                break;
+            }
+        }
+
+        // Insert after the last #using, or at the very top
+        return lastUsingLine >= 0
+            ? new Position(lastUsingLine + 1, 0)
+            : new Position(0, 0);
+    }
+
+    /// <summary>
+    /// Converts an absolute file path to the <c>#using</c> directive path format.
+    /// Extracts the portion starting from the <c>scripts/</c> directory and removes
+    /// the file extension, producing paths like <c>scripts\zm\utility</c>.
+    /// Returns <see langword="null"/> when the file is not inside a <c>scripts/</c> hierarchy.
+    /// </summary>
+    private static string? ConvertFilePathToUsingPath(string filePath)
+    {
+        string normalised = filePath.Replace('\\', '/');
+        const string marker = "/scripts/";
+        int idx = normalised.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+
+        if (idx < 0)
+        {
+            return null;
+        }
+
+        // Extract from "scripts/" onward (including the "scripts/" prefix)
+        string relativePath = normalised[(idx + 1)..]; // skip the leading '/'
+
+        // Remove the file extension (.gsc, .csc, .gsh)
+        int dotIndex = relativePath.LastIndexOf('.');
+        if (dotIndex > 0)
+        {
+            relativePath = relativePath[..dotIndex];
+        }
+
+        // Convert to backslash-separated form to match GSC convention
+        return relativePath.Replace('/', '\\');
     }
 
     /// <summary>

--- a/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
@@ -5,6 +5,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol;
 using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
 using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.IO;
 using System.Linq;
 using System.Text;
 
@@ -145,6 +146,19 @@ internal sealed class CodeActionHandler(
             if (action is not null)
             {
                 actions.Add(new CommandOrCodeAction(action));
+            }
+
+            // MissingUsingFile gets a second option: create the file at its expected path
+            // in addition to the existing "remove #using" quick fix.
+            if (errorCode == GSCErrorCodes.MissingUsingFile)
+            {
+                CodeAction? createAction = TryCreateMissingFileAction(
+                    request.TextDocument, diagnostic, content);
+
+                if (createAction is not null)
+                {
+                    actions.Add(new CommandOrCodeAction(createAction));
+                }
             }
         }
 
@@ -562,6 +576,109 @@ internal sealed class CodeActionHandler(
                 }
             }
         };
+    }
+
+    /// <summary>
+    /// Offers to create the missing file referenced by a failing <c>#using</c> directive.
+    /// <para>
+    /// The file is placed in the same scripts root as the current document (the directory
+    /// that contains the <c>scripts/</c> folder). The path hierarchy is:
+    /// <list type="bullet">
+    ///   <item>Mod: <c>&lt;game&gt;\mods\&lt;modname&gt;\scripts\…</c></item>
+    ///   <item>Usermap: <c>&lt;game&gt;\usermaps\&lt;mapname&gt;\scripts\…</c></item>
+    ///   <item>Root: <c>&lt;TA_GAME_PATH or custom raw&gt;\scripts\…</c></item>
+    /// </list>
+    /// </para>
+    /// </summary>
+    private static CodeAction? TryCreateMissingFileAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        // The diagnostic range covers only the path segments of the #using directive
+        // (e.g. "scripts\m_shared\util_shared") — no keyword, no semicolon.
+        string? rawPath = GetTextInRange(content, diagnostic.Range);
+        if (string.IsNullOrEmpty(rawPath))
+        {
+            return null;
+        }
+
+        // Derive the file extension from the current document (.gsc / .csc / .gsh)
+        string currentFilePath = document.Uri.ToUri().LocalPath;
+        string extension = Path.GetExtension(currentFilePath).ToLowerInvariant();
+        if (string.IsNullOrEmpty(extension))
+        {
+            extension = ".gsc";
+        }
+
+        // Normalise separators and append the extension to get the qualified relative path,
+        // matching the format used by GetScriptFilePath (e.g. "scripts/m_shared/util_shared.gsc").
+        string qualifiedRelative = rawPath.Replace('\\', '/') + extension;
+
+        // Find the scripts root: the directory that contains the "scripts/" folder,
+        // using the same heuristic as ParserUtil.ExtractBasePath.
+        string? basePath = ExtractScriptsBasePath(currentFilePath);
+        if (basePath is null)
+        {
+            return null;
+        }
+
+        string newFilePath = Path.GetFullPath(
+            Path.Combine(basePath, qualifiedRelative.Replace('/', Path.DirectorySeparatorChar)));
+
+        DocumentUri newFileUri = DocumentUri.FromFileSystemPath(newFilePath);
+        string fileName = Path.GetFileName(newFilePath);
+
+        return new CodeAction
+        {
+            Title = $"Create file '{fileName}'",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                DocumentChanges = new Container<WorkspaceEditDocumentChange>(
+                    // 1. Create the empty file (no-op if it already exists)
+                    new WorkspaceEditDocumentChange(new CreateFile
+                    {
+                        Uri = newFileUri,
+                        Options = new CreateFileOptions { IgnoreIfExists = true }
+                    })
+                )
+            }
+        };
+    }
+
+    /// <summary>
+    /// Extracts the root path that sits immediately above the <c>scripts/</c> folder in
+    /// <paramref name="filePath"/>. Returns <see langword="null"/> when no such ancestor
+    /// can be found (e.g. the file is not inside any <c>scripts</c> hierarchy).
+    /// </summary>
+    private static string? ExtractScriptsBasePath(string filePath)
+    {
+        string normalised = filePath.Replace('\\', '/');
+        const string marker = "/scripts/";
+        int idx = normalised.LastIndexOf(marker, StringComparison.OrdinalIgnoreCase);
+
+        if (idx < 0)
+        {
+            return null;
+        }
+
+        string basePath = normalised[..idx];
+
+        // On Windows the URI might have a leading slash before the drive letter ("/G:/...")
+        if (OperatingSystem.IsWindows()
+            && basePath.Length > 2
+            && basePath[0] == '/'
+            && basePath[2] == ':')
+        {
+            basePath = basePath[1..];
+        }
+
+        return basePath.Replace('/', Path.DirectorySeparatorChar);
     }
 
     // -------------------------------------------------------------------------

--- a/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/CodeActionHandler.cs
@@ -1,0 +1,708 @@
+using GSCode.Data;
+using GSCode.Parser;
+using Microsoft.Extensions.Logging;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Client.Capabilities;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.Linq;
+using System.Text;
+
+namespace GSCode.NET.LSP.Handlers;
+
+internal sealed class CodeActionHandler(
+    ScriptManager scriptManager,
+    ILogger<CodeActionHandler> logger,
+    TextDocumentSelector documentSelector) : CodeActionHandlerBase
+{
+    private readonly ScriptManager _scriptManager = scriptManager;
+    private readonly ILogger<CodeActionHandler> _logger = logger;
+    private readonly TextDocumentSelector _documentSelector = documentSelector;
+
+    protected override CodeActionRegistrationOptions CreateRegistrationOptions(
+        CodeActionCapability capability, ClientCapabilities clientCapabilities)
+        => new()
+        {
+            DocumentSelector = _documentSelector,
+            ResolveProvider = true,
+            CodeActionKinds = new Container<CodeActionKind>(
+                CodeActionKind.QuickFix,
+                CodeActionKind.SourceOrganizeImports)
+        };
+
+    // Resolve handler — edits are included eagerly so nothing extra is needed here
+    public override Task<CodeAction> Handle(CodeAction request, CancellationToken cancellationToken)
+        => Task.FromResult(request);
+
+    public override async Task<CommandOrCodeActionContainer> Handle(
+        CodeActionParams request, CancellationToken cancellationToken)
+    {
+        var actions = new List<CommandOrCodeAction>();
+
+        // Pre-fetch cached document text once — only needed by a subset of fixes
+        _scriptManager.TryGetCachedContent(request.TextDocument.Uri, out string content);
+
+        foreach (Diagnostic diagnostic in request.Context.Diagnostics)
+        {
+            if (!diagnostic.Code.HasValue || !diagnostic.Code.Value.IsLong)
+            {
+                continue;
+            }
+
+            GSCErrorCodes errorCode = (GSCErrorCodes)(int)diagnostic.Code.Value.Long;
+
+            CodeAction? action = errorCode switch
+            {
+                // Remove the entire #using line — file is unreferenced
+                GSCErrorCodes.UnusedUsing =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove unused #using directive"),
+
+                // Remove the entire #using line — file could not be located
+                GSCErrorCodes.MissingUsingFile =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove unresolvable #using directive"),
+
+                // Remove the variable declaration line — variable is declared but never read
+                GSCErrorCodes.UnusedVariable =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove unused variable declaration"),
+
+                // Remove duplicate macro definition line
+                GSCErrorCodes.DuplicateMacroDefinition =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove duplicate macro definition", isPreferred: true),
+
+                // Remove the duplicate case label line
+                GSCErrorCodes.DuplicateCaseLabel =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove duplicate 'case' label", isPreferred: true),
+
+                // Remove the extra default label line
+                GSCErrorCodes.MultipleDefaultLabels =>
+                    CreateDeleteLineAction(request.TextDocument, diagnostic, "Remove duplicate 'default' label", isPreferred: true),
+
+                // Insert a semicolon at the exact position the parser expected one
+                GSCErrorCodes.ExpectedSemiColon =>
+                    CreateInsertAction(request.TextDocument, diagnostic, diagnostic.Range.End, ";", "Insert missing ';'", isPreferred: true),
+
+                // Prepend the ampersand operator to turn the bare name into a function pointer
+                GSCErrorCodes.StoreFunctionAsPointer =>
+                    CreateInsertAction(request.TextDocument, diagnostic, diagnostic.Range.Start, "&", "Add '&' function pointer operator", isPreferred: true),
+
+                // Prefix the unused parameter name with _ to signal intentional non-use
+                GSCErrorCodes.UnusedParameter =>
+                    CreateInsertAction(request.TextDocument, diagnostic, diagnostic.Range.Start, "_", "Prefix parameter with '_'"),
+
+                // Append () so the macro is invoked rather than referenced bare
+                GSCErrorCodes.MissingMacroParameterList =>
+                    CreateInsertAction(request.TextDocument, diagnostic, diagnostic.Range.End, "()", "Add missing '()' to macro invocation", isPreferred: true),
+
+                // Erase the range the SPA tagged as unreachable
+                GSCErrorCodes.UnreachableCodeDetected =>
+                    CreateDeleteRangeAction(request.TextDocument, diagnostic, diagnostic.Range, "Remove unreachable code", isPreferred: true),
+
+                // Erase the duplicate modifier token
+                GSCErrorCodes.DuplicateModifier =>
+                    CreateDeleteRangeAction(request.TextDocument, diagnostic, diagnostic.Range, "Remove duplicate modifier", isPreferred: true),
+
+                // Erase the unreachable case block
+                GSCErrorCodes.UnreachableCase =>
+                    CreateDeleteRangeAction(request.TextDocument, diagnostic, diagnostic.Range, "Remove unreachable 'case'", isPreferred: true),
+
+                // Replace integer literal 0/1 with the equivalent boolean keyword
+                GSCErrorCodes.PreferBooleanLiteral =>
+                    CreatePreferBooleanLiteralAction(request.TextDocument, diagnostic, content),
+
+                // Convert [ a, b, c ] initialiser syntax to array(a, b, c)
+                GSCErrorCodes.SquareBracketInitialisationNotSupported =>
+                    CreateSquareBracketToArrayAction(request.TextDocument, diagnostic, content),
+
+                // Append a matching /* endregion */ at the end of the document
+                GSCErrorCodes.UnterminatedRegion =>
+                    CreateUnterminatedRegionAction(request.TextDocument, diagnostic, content),
+
+                // Append #endif at the end of the document to close the open directive
+                GSCErrorCodes.UnterminatedPreprocessorDirective =>
+                    CreateAppendLineAction(request.TextDocument, diagnostic, "#endif", content, isPreferred: true),
+
+                // Move the misplaced #using directive to the top of the file
+                GSCErrorCodes.UnexpectedUsing =>
+                    CreateMoveUsingToTopAction(request.TextDocument, diagnostic, content),
+
+                // Remove 'thread' from a call whose result is consumed.
+                // The diagnostic range is a PrefixExprNode [thread_token.start → operand.end],
+                // so Range.Start is always the first character of the 'thread' keyword.
+                // Each diagnostic on the same line has its own distinct range, so each
+                // code action independently removes exactly one 'thread' keyword.
+                GSCErrorCodes.ConsumedThreadedCallResult =>
+                    CreateRemoveThreadKeywordAction(request.TextDocument, diagnostic, content),
+
+                // Generate a stub function definition at the end of the file.
+                // The diagnostic range covers the function name identifier token, so
+                // GetTextInRange gives the name without any message parsing.
+                GSCErrorCodes.FunctionDoesNotExist =>
+                    CreateGenerateFunctionStubAction(request.TextDocument, diagnostic, content),
+
+                _ => null
+            };
+
+            if (action is not null)
+            {
+                actions.Add(new CommandOrCodeAction(action));
+            }
+        }
+
+        // Source action: remove all unused #using directives in the file at once.
+        // Only emitted when there are at least two so it is meaningfully distinct from
+        // the per-diagnostic quick fix already offered above.
+        CodeAction? bulkAction = await TryCreateRemoveAllUnusedUsingsActionAsync(
+            request.TextDocument, cancellationToken);
+
+        if (bulkAction is not null)
+        {
+            actions.Add(new CommandOrCodeAction(bulkAction));
+        }
+
+        _logger.LogDebug("CodeActionHandler produced {Count} action(s) for {Uri}", actions.Count, request.TextDocument.Uri);
+        return new CommandOrCodeActionContainer(actions);
+    }
+
+    // -------------------------------------------------------------------------
+    // Fix factories
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Deletes the entire line that contains the diagnostic (including the trailing newline).
+    /// Suitable for whole-line constructs such as <c>#using</c> directives and simple
+    /// single-statement variable declarations.
+    /// </summary>
+    private static CodeAction CreateDeleteLineAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string title,
+        bool isPreferred = false)
+    {
+        int line = diagnostic.Range.Start.Line;
+
+        return new CodeAction
+        {
+            Title = title,
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = isPreferred,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            // (line, 0) → (line+1, 0) removes the line and its newline
+                            Range = new Range(new Position(line, 0), new Position(line + 1, 0)),
+                            NewText = string.Empty
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Inserts <paramref name="text"/> at <paramref name="position"/> with no range deletion.
+    /// </summary>
+    private static CodeAction CreateInsertAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, Position position,
+        string text, string title, bool isPreferred = false)
+    {
+        return new CodeAction
+        {
+            Title = title,
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = isPreferred,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = new Range(position, position),
+                            NewText = text
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Replaces the given <paramref name="range"/> with an empty string.
+    /// Suitable for removing a single token or an already-isolated block.
+    /// </summary>
+    private static CodeAction CreateDeleteRangeAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, Range range,
+        string title, bool isPreferred = false)
+    {
+        return new CodeAction
+        {
+            Title = title,
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = isPreferred,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = range,
+                            NewText = string.Empty
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Reads the integer literal (<c>0</c> or <c>1</c>) at the diagnostic range and
+    /// replaces it with the equivalent boolean keyword (<c>false</c> or <c>true</c>).
+    /// </summary>
+    private static CodeAction? CreatePreferBooleanLiteralAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string? literal = GetTextInRange(content, diagnostic.Range);
+        if (literal is null)
+        {
+            return null;
+        }
+
+        string replacement = literal.Trim() == "0" ? "false" : "true";
+
+        return new CodeAction
+        {
+            Title = $"Replace with '{replacement}'",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = diagnostic.Range,
+                            NewText = replacement
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Converts a <c>[ a, b, c ]</c> collection initialiser to <c>array(a, b, c)</c>
+    /// by extracting the content between the brackets and wrapping it with <c>array(…)</c>.
+    /// </summary>
+    private static CodeAction? CreateSquareBracketToArrayAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string? bracketExpr = GetTextInRange(content, diagnostic.Range);
+        if (bracketExpr is null || bracketExpr.Length < 2)
+        {
+            return null;
+        }
+
+        // Strip surrounding [ and ] then rewrap as array(...)
+        string inner = bracketExpr[1..^1];
+        string replacement = $"array({inner})";
+
+        return new CodeAction
+        {
+            Title = "Replace with 'array()' initialiser",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = diagnostic.Range,
+                            NewText = replacement
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Appends a <c>/* endregion */</c> comment on a new line at the very end of the
+    /// document to close the region that was opened without a matching end marker.
+    /// </summary>
+    private static CodeAction? CreateUnterminatedRegionAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        // Normalise line endings so split always produces one element per visual line
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+        int lastLineIndex = lines.Length - 1;
+        int lastLineLength = lines[lastLineIndex].Length;
+
+        Position endOfFile = new(lastLineIndex, lastLineLength);
+
+        return new CodeAction
+        {
+            Title = "Add matching '/* endregion */'",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = new Range(endOfFile, endOfFile),
+                            NewText = "\n/* endregion */"
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Builds a single <see cref="CodeActionKind.SourceOrganizeImports"/> action that removes
+    /// every unused <c>#using</c> directive in the document in one operation.
+    /// Returns <see langword="null"/> when fewer than two unused directives are present
+    /// (the per-diagnostic quick fix already covers the single-occurrence case).
+    /// </summary>
+    private async Task<CodeAction?> TryCreateRemoveAllUnusedUsingsActionAsync(
+        TextDocumentIdentifier document, CancellationToken cancellationToken)
+    {
+        Script? script = _scriptManager.GetParsedEditor(document);
+        if (script is null)
+        {
+            return null;
+        }
+
+        List<Diagnostic> allDiagnostics = await script.GetDiagnosticsAsync(cancellationToken);
+
+        List<Diagnostic> unusedUsings = allDiagnostics
+            .Where(d => d.Code.HasValue
+                && d.Code.Value.IsLong
+                && (GSCErrorCodes)(int)d.Code.Value.Long == GSCErrorCodes.UnusedUsing)
+            .ToList();
+
+        if (unusedUsings.Count < 2)
+        {
+            return null;
+        }
+
+        // One delete-line edit per unused using, sorted descending by line so that
+        // removing a higher line does not shift the positions of lower ones.
+        IEnumerable<TextEdit> edits = unusedUsings
+            .OrderByDescending(d => d.Range.Start.Line)
+            .Select(d =>
+            {
+                int line = d.Range.Start.Line;
+                return new TextEdit
+                {
+                    Range = new Range(new Position(line, 0), new Position(line + 1, 0)),
+                    NewText = string.Empty
+                };
+            });
+
+        return new CodeAction
+        {
+            Title = $"Remove all unused #using directives ({unusedUsings.Count})",
+            Kind = CodeActionKind.SourceOrganizeImports,
+            Diagnostics = new Container<Diagnostic>(unusedUsings),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] = edits
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Removes the <c>thread</c> keyword and its trailing whitespace from a threaded call
+    /// whose result is consumed.
+    /// <para>
+    /// The diagnostic is emitted on a <see cref="PrefixExprNode"/> whose range spans
+    /// <c>[thread_token.start, operand.end]</c>, so <c>diagnostic.Range.Start</c> is always
+    /// the first character of the <c>thread</c> keyword. Because each consumed-thread diagnostic
+    /// carries its own unique range, invoking this fix on a line with multiple such warnings
+    /// removes exactly one <c>thread</c> per invocation.
+    /// </para>
+    /// </summary>
+    private static CodeAction? CreateRemoveThreadKeywordAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string? callText = GetTextInRange(content, diagnostic.Range);
+        if (callText is null || !callText.StartsWith("thread", StringComparison.Ordinal))
+        {
+            return null;
+        }
+
+        // Consume "thread" (6 chars) then any immediately following whitespace so the
+        // replacement text is truly empty rather than leaving a stray space.
+        int deleteLen = 6;
+        while (deleteLen < callText.Length && callText[deleteLen] is ' ' or '\t')
+        {
+            deleteLen++;
+        }
+
+        Position deleteEnd = new(
+            diagnostic.Range.Start.Line,
+            diagnostic.Range.Start.Character + deleteLen);
+
+        return new CodeAction
+        {
+            Title = "Remove 'thread' from call",
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = true,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = new Range(diagnostic.Range.Start, deleteEnd),
+                            NewText = string.Empty
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Appends a minimal function stub at the end of the document for a function name
+    /// that could not be resolved. The diagnostic range covers the function identifier
+    /// token, so <see cref="GetTextInRange"/> gives the name directly.
+    /// </summary>
+    private static CodeAction? CreateGenerateFunctionStubAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string? functionName = GetTextInRange(content, diagnostic.Range);
+        if (string.IsNullOrEmpty(functionName))
+        {
+            return null;
+        }
+
+        // Guard: only proceed when the extracted text is a valid plain identifier.
+        // Namespaced calls (ns::func) or anything with odd characters should not produce a stub.
+        if (!functionName.All(c => char.IsAsciiLetterOrDigit(c) || c == '_'))
+        {
+            return null;
+        }
+
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+        int lastLineIndex = lines.Length - 1;
+        int lastLineLength = lines[lastLineIndex].Length;
+        Position endOfFile = new(lastLineIndex, lastLineLength);
+
+        // Append a blank line before the stub so it is visually separated,
+        // then close with a trailing newline.
+        string stub = $"\n\nfunction {functionName}()\n{{\n}}\n";
+
+        return new CodeAction
+        {
+            Title = $"Create function '{functionName}'",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = new Range(endOfFile, endOfFile),
+                            NewText = stub
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    // -------------------------------------------------------------------------
+    // Helpers
+    // -------------------------------------------------------------------------
+
+    /// <summary>
+    /// Appends <paramref name="lineText"/> on a new line at the very end of the document.
+    /// Used for directives that must close an open block, such as <c>#endif</c>.
+    /// </summary>
+    private static CodeAction? CreateAppendLineAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string lineText,
+        string content, bool isPreferred = false)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+        int lastLineIndex = lines.Length - 1;
+        int lastLineLength = lines[lastLineIndex].Length;
+
+        Position endOfFile = new(lastLineIndex, lastLineLength);
+
+        return new CodeAction
+        {
+            Title = $"Add missing '{lineText}'",
+            Kind = CodeActionKind.QuickFix,
+            IsPreferred = isPreferred,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        new TextEdit
+                        {
+                            Range = new Range(endOfFile, endOfFile),
+                            NewText = $"\n{lineText}"
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Moves a misplaced <c>#using</c> directive to the very top of the file using two
+    /// coordinated edits inside one <see cref="WorkspaceEdit"/>: delete the current line,
+    /// then insert it at <c>(0, 0)</c>.
+    /// </summary>
+    private static CodeAction? CreateMoveUsingToTopAction(
+        TextDocumentIdentifier document, Diagnostic diagnostic, string content)
+    {
+        if (string.IsNullOrEmpty(content))
+        {
+            return null;
+        }
+
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+        int diagLine = diagnostic.Range.Start.Line;
+
+        if (diagLine >= lines.Length)
+        {
+            return null;
+        }
+
+        // Capture the raw directive text (strip any trailing \r from CRLF sources)
+        string directiveText = lines[diagLine].TrimEnd('\r');
+
+        return new CodeAction
+        {
+            Title = "Move #using to top of file",
+            Kind = CodeActionKind.QuickFix,
+            Diagnostics = new Container<Diagnostic>(diagnostic),
+            Edit = new WorkspaceEdit
+            {
+                Changes = new Dictionary<DocumentUri, IEnumerable<TextEdit>>
+                {
+                    [document.Uri] =
+                    [
+                        // 1. Delete the misplaced line (including its newline)
+                        new TextEdit
+                        {
+                            Range = new Range(new Position(diagLine, 0), new Position(diagLine + 1, 0)),
+                            NewText = string.Empty
+                        },
+                        // 2. Insert it before the first character of the file
+                        new TextEdit
+                        {
+                            Range = new Range(new Position(0, 0), new Position(0, 0)),
+                            NewText = directiveText + "\n"
+                        }
+                    ]
+                }
+            }
+        };
+    }
+
+    /// <summary>
+    /// Extracts the source text that falls within the given LSP <paramref name="range"/>.
+    /// Returns <see langword="null"/> when the range references lines outside the document.
+    /// </summary>
+    private static string? GetTextInRange(string content, Range range)
+    {
+        // Normalise so we always split on \n only
+        string[] lines = content.ReplaceLineEndings("\n").Split('\n');
+
+        int startLine = range.Start.Line;
+        int endLine = range.End.Line;
+
+        if (startLine >= lines.Length || endLine >= lines.Length)
+        {
+            return null;
+        }
+
+        // Single-line range — common case
+        if (startLine == endLine)
+        {
+            string line = lines[startLine];
+            int startChar = Math.Min(range.Start.Character, line.Length);
+            int endChar = Math.Min(range.End.Character, line.Length);
+            return line[startChar..endChar];
+        }
+
+        // Multi-line range
+        var sb = new StringBuilder();
+        sb.Append(lines[startLine][Math.Min(range.Start.Character, lines[startLine].Length)..]);
+
+        for (int i = startLine + 1; i < endLine; i++)
+        {
+            sb.Append('\n');
+            sb.Append(lines[i]);
+        }
+
+        string lastLine = lines[endLine];
+        sb.Append('\n');
+        sb.Append(lastLine[..Math.Min(range.End.Character, lastLine.Length)]);
+
+        return sb.ToString();
+    }
+}

--- a/server/GSCode.NET/LSP/Handlers/DidChangeWatchedFilesHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/DidChangeWatchedFilesHandler.cs
@@ -19,41 +19,52 @@ public class DidChangeWatchedFilesHandler : DidChangeWatchedFilesHandlerBase
         _scriptManager = scriptManager;
     }
 
-    public override Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
+    public override async Task<Unit> Handle(DidChangeWatchedFilesParams request, CancellationToken cancellationToken)
     {
+        bool needsEditorReparse = false;
+
         foreach (var change in request.Changes)
         {
-            var fileUri = change.Uri;
-            var changeType = change.Type;
-
-            // Filter for GSC/CSC/GSH files only
-            var path = fileUri.GetFileSystemPath();
+            var path = change.Uri.GetFileSystemPath();
             if (!IsScriptFile(path))
             {
                 continue;
             }
 
-            switch (changeType)
+            switch (change.Type)
             {
                 case FileChangeType.Created:
-                    _logger.LogInformation("Script file created externally: {Path}", path);
-                    // If workspace indexing is enabled, the file will be picked up on next scan
+                    // A new file appeared — it may satisfy a previously-unresolvable #using
+                    // in one or more open editor scripts. Because the file was missing at
+                    // parse time it was never tracked as a dependency, so we have no targeted
+                    // dependents list to invalidate. Re-parse all open editors instead.
+                    _logger.LogInformation("Script file created: {Path}", path);
+                    needsEditorReparse = true;
                     break;
 
                 case FileChangeType.Changed:
+                    // Only act on files that are NOT open in the editor; those are handled
+                    // by the DidChange notification. For external dependency changes we
+                    // re-parse open editors so they pick up the updated exports.
                     _logger.LogInformation("Script file modified externally: {Path}", path);
-                    // File content changed outside the editor
-                    // The editor documents take precedence over file system
+                    needsEditorReparse = true;
                     break;
 
                 case FileChangeType.Deleted:
-                    _logger.LogInformation("Script file deleted externally: {Path}", path);
-                    // Remove from any caches if needed
+                    // A dependency was removed — any open editor that #uses it should now
+                    // receive a MissingUsingFile diagnostic.
+                    _logger.LogInformation("Script file deleted: {Path}", path);
+                    needsEditorReparse = true;
                     break;
             }
         }
 
-        return Unit.Task;
+        if (needsEditorReparse)
+        {
+            await _scriptManager.ReparseAllOpenEditorsAsync(cancellationToken);
+        }
+
+        return Unit.Value;
     }
 
     protected override DidChangeWatchedFilesRegistrationOptions CreateRegistrationOptions(DidChangeWatchedFilesCapability capability, ClientCapabilities clientCapabilities)

--- a/server/GSCode.NET/LSP/Handlers/TextDocumentSyncHandler.cs
+++ b/server/GSCode.NET/LSP/Handlers/TextDocumentSyncHandler.cs
@@ -53,23 +53,23 @@ public class TextDocumentSyncHandler : ITextDocumentSyncHandler
         _logger.LogInformation("Document changed ({ChangeType}, {ChangeCount} change(s))", changeType, changeCount);
 
         var sw = Stopwatch.StartNew();
-        var diagnostics = ImmutableArray<Diagnostic>.Empty.ToBuilder();
 
-        IEnumerable<Diagnostic> results = await _scriptManager.UpdateEditorAsync(request.TextDocument, request.ContentChanges, cancellationToken);
+        IEnumerable<Diagnostic> results = await _scriptManager.UpdateEditorAsync(
+            request.TextDocument, request.ContentChanges, cancellationToken);
 
-        foreach(Diagnostic result in results)
-        {
-            diagnostics.Add(result);
-        }
-
+        // Omit Version — if the parse took time and the user kept typing, the document
+        // version has advanced past the one in request.TextDocument.Version.  VS Code
+        // discards publishDiagnostics notifications whose version < current, leaving
+        // stale squiggles on screen.  Omitting it tells the client "always accept."
         _facade.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams()
         {
-            Diagnostics = new Container<Diagnostic>(diagnostics.ToArray()),
-            Uri = request.TextDocument.Uri,
-            Version = request.TextDocument.Version
+            Diagnostics = new Container<Diagnostic>(results.ToArray()),
+            Uri = request.TextDocument.Uri
         });
+
         sw.Stop();
-        _logger.LogInformation("Document change processed in {ElapsedMs} ms with {DiagCount} diagnostics", sw.ElapsedMilliseconds, diagnostics.Count);
+        _logger.LogInformation("Document change processed in {ElapsedMs} ms with {DiagCount} diagnostics",
+            sw.ElapsedMilliseconds, results.Count());
         return Unit.Value;
     }
 
@@ -82,8 +82,7 @@ public class TextDocumentSyncHandler : ITextDocumentSyncHandler
         _facade.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams()
         {
             Diagnostics = resultingDiagnostics.ToArray(),
-            Uri = request.TextDocument.Uri,
-            Version = request.TextDocument.Version
+            Uri = request.TextDocument.Uri
         });
         sw.Stop();
         _logger.LogInformation("Document open processed in {ElapsedMs} ms with {DiagCount} diagnostics", sw.ElapsedMilliseconds, resultingDiagnostics.Count());

--- a/server/GSCode.NET/LSP/ScriptCache.cs
+++ b/server/GSCode.NET/LSP/ScriptCache.cs
@@ -102,14 +102,17 @@ public class ScriptCache
 
         while (currentLine < line && pos < content.Length)
         {
-            int newlinePos = content.IndexOf(Environment.NewLine, pos);
+            // Find the next line break — handle \r\n, \n, and bare \r.
+            // VS Code always sends LF (\n) line endings regardless of the OS,
+            // so we must not rely on Environment.NewLine (which is \r\n on Windows).
+            int newlinePos = content.IndexOf('\n', pos);
             if (newlinePos == -1)
             {
                 // No more newlines found, return -1 to indicate line doesn't exist
                 return -1;
             }
-            // Move past the newline (Environment.NewLine could be \r\n or \n)
-            pos = newlinePos + Environment.NewLine.Length;
+            // Move past the \n
+            pos = newlinePos + 1;
             currentLine++;
         }
 
@@ -120,5 +123,21 @@ public class ScriptCache
     {
         DocumentUri documentUri = document.Uri;
         Scripts.Remove(documentUri, out StringBuilder? _);
+    }
+
+    /// <summary>
+    /// Retrieves the current cached content for the given document URI.
+    /// Returns false if the document is not in the cache.
+    /// </summary>
+    public bool TryGetContent(DocumentUri uri, out string content)
+    {
+        if (Scripts.TryGetValue(uri, out StringBuilder? sb))
+        {
+            content = sb.ToString();
+            return true;
+        }
+
+        content = string.Empty;
+        return false;
     }
 }

--- a/server/GSCode.NET/LSP/ScriptManager.Editor.cs
+++ b/server/GSCode.NET/LSP/ScriptManager.Editor.cs
@@ -74,6 +74,13 @@ public partial class ScriptManager
         return Scripts.TryGetValue(document.Uri, out var script) ? script.Script : null;
     }
 
+    /// <summary>
+    /// Retrieves the current cached source text for the given document.
+    /// Returns false if the document is not open in the editor cache.
+    /// </summary>
+    public bool TryGetCachedContent(DocumentUri uri, out string content)
+        => _cache.TryGetContent(uri, out content);
+
     private async Task<IEnumerable<Diagnostic>> ProcessEditorAsync(Uri documentUri, Script script, string content, CancellationToken cancellationToken = default)
     {
         string filePath = documentUri.LocalPath;

--- a/server/GSCode.NET/LSP/ScriptManager.Editor.cs
+++ b/server/GSCode.NET/LSP/ScriptManager.Editor.cs
@@ -3,7 +3,9 @@ using GSCode.Parser;
 using GSCode.Parser.Data;
 using GSCode.Parser.Lexical;
 using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Document;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using System.Linq;
 
 namespace GSCode.NET.LSP;
 
@@ -72,6 +74,52 @@ public partial class ScriptManager
     public Script? GetParsedEditor(TextDocumentIdentifier document)
     {
         return Scripts.TryGetValue(document.Uri, out var script) ? script.Script : null;
+    }
+
+    /// <summary>
+    /// Re-parses every document that is currently open in the editor and republishes
+    /// its diagnostics. Called when a watched file is created, changed externally, or
+    /// deleted so that diagnostics such as <see cref="GSCode.Data.GSCErrorCodes.MissingUsingFile"/>
+    /// are cleared (or raised) without requiring the user to manually edit each file.
+    /// </summary>
+    public async Task ReparseAllOpenEditorsAsync(CancellationToken cancellationToken = default)
+    {
+        // Snapshot the editor URIs so we don't hold a live enumerator while awaiting
+        var editorUris = Scripts
+            .Where(kv => kv.Value.Type == CachedScriptType.Editor)
+            .Select(kv => kv.Key)
+            .ToList();
+
+        foreach (DocumentUri docUri in editorUris)
+        {
+            // Skip if the document was closed while we were iterating
+            if (!_cache.TryGetContent(docUri, out string content))
+            {
+                continue;
+            }
+
+            await _editorPriority.WaitAsync(cancellationToken);
+            try
+            {
+                if (!Scripts.TryGetValue(docUri, out CachedScript? cached))
+                {
+                    continue;
+                }
+
+                IEnumerable<Diagnostic> diags =
+                    await ProcessEditorAsync(docUri.ToUri(), cached.Script, content, cancellationToken);
+
+                _facade?.TextDocument.PublishDiagnostics(new PublishDiagnosticsParams
+                {
+                    Uri = docUri,
+                    Diagnostics = new Container<Diagnostic>(diags.ToArray())
+                });
+            }
+            finally
+            {
+                _editorPriority.Release();
+            }
+        }
     }
 
     /// <summary>

--- a/server/GSCode.NET/Program.cs
+++ b/server/GSCode.NET/Program.cs
@@ -279,7 +279,8 @@ LanguageServer server = await LanguageServer.From(options =>
 		.AddHandler<SignatureHelpHandler>()
 		.AddHandler<ReferencesHandler>()
 		.AddHandler<ConfigurationHandler>()
-		.AddHandler<DidChangeWatchedFilesHandler>();
+		.AddHandler<DidChangeWatchedFilesHandler>()
+		.AddHandler<CodeActionHandler>();
 	// Allow disposal of the stream if required.
 	if (disposable is not null)
 	{

--- a/server/GSCode.Parser/DFA/TypeFlowAnalyser.Expressions.cs
+++ b/server/GSCode.Parser/DFA/TypeFlowAnalyser.Expressions.cs
@@ -1449,6 +1449,18 @@ internal ref partial struct TypeFlowAnalyser
             return ScrData.Default;
         }
 
+        // Namespace is known but the requested function was not found inside it.
+        // Return ScrData.Default (type-unknown) so the upstream call-site check does
+        // not emit a cascading ExpectedFunction (3036) error — that message
+        // ("expected a function, got 'undefined'") is meaningless when the whole line
+        // is syntactically valid and the only problem is a missing symbol.
+        if (symbol.Type == ScrDataTypes.Undefined)
+        {
+            AddDiagnostic(memberNode.Range, GSCErrorCodes.NamespaceDoesNotContainFunction,
+                namespaceNode.Identifier, memberNode.Identifier);
+            return ScrData.Default;
+        }
+
         if (flags.HasFlag(SymbolFlags.Global) && symbol.Type == ScrDataTypes.Function)
         {
             if (symbol.TryGetFunction(out ScrFunction? function))

--- a/server/GSCode.Parser/Script.Navigation.cs
+++ b/server/GSCode.Parser/Script.Navigation.cs
@@ -170,13 +170,23 @@ public partial class Script
         string currentScriptPath = ScriptUri.ToUri().LocalPath;
         string ns = GetEffectiveNamespace();
 
-        var loc = (qualifier is not null && DefinitionsTable is not null
-                      ? DefinitionsTable.GetFunctionLocation(qualifier, name) ?? DefinitionsTable.GetClassLocation(qualifier, name)
-                      : null)
-               ?? DefinitionsTable?.GetFunctionLocation(ns, name)
+        // When the call site carries an explicit namespace qualifier (e.g. util::init),
+        // only look inside that namespace.  Falling through to the AnyNamespace helpers
+        // would silently resolve to an unrelated function that merely shares the same
+        // name in a different namespace, causing GoTo to jump to the wrong file.
+        (string FilePath, TokenRange Range)? loc;
+        if (qualifier is not null && DefinitionsTable is not null)
+        {
+            loc = DefinitionsTable.GetFunctionLocation(qualifier, name)
+               ?? DefinitionsTable.GetClassLocation(qualifier, name);
+        }
+        else
+        {
+            loc = DefinitionsTable?.GetFunctionLocation(ns, name)
                ?? DefinitionsTable?.GetClassLocation(ns, name)
                ?? DefinitionsTable?.GetFunctionLocationAnyNamespace(name)
                ?? DefinitionsTable?.GetClassLocationAnyNamespace(name);
+        }
 
         return loc is not null
             ? ScriptFileResolver.ResolveDefinitionLocation(currentScriptPath, loc.Value.FilePath, loc.Value.Range.ToRange())


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the language server's diagnostics, namespace resolution, and editor integration. The main focus is on making namespace-qualified function lookups more precise, improving diagnostics for missing or misused symbols, and ensuring that editor diagnostics stay up-to-date when files change outside the editor.

**Namespace resolution and diagnostics:**

* Namespace-qualified function lookups now only resolve within the specified namespace and will not fall back to matching functions with the same name in other namespaces, preventing incorrect "Go To Definition" navigation and symbol resolution. [[1]](diffhunk://#diff-abc1721bcc2056d9532c15d37190914ac4f5f67fe968065aea86714cbab3e122R67-R76) [[2]](diffhunk://#diff-6e3e3d0859a173ba14b15d96c8962f34cc14ebcaf4156909e5950403ab7fb445L173-R189)
* Added a new error code, `NamespaceDoesNotContainFunction`, and diagnostic message for when a namespace is known but a requested function does not exist within it. This prevents misleading or cascading errors. [[1]](diffhunk://#diff-96296dd8ec9d570c2c82590c64368db7d602641cbf14ddca5be3e8b25ba5abcbR134) [[2]](diffhunk://#diff-96296dd8ec9d570c2c82590c64368db7d602641cbf14ddca5be3e8b25ba5abcbR271) [[3]](diffhunk://#diff-0883001add5e71459d08cb1423cc11593ce20128e1b7eb979432bd06788e9745R1452-R1463)
* The severity of the `FunctionDoesNotExist` diagnostic is increased from Warning to Error, and its message is simplified for clarity.

**Editor and file change handling:**

* When a watched file is created, modified, or deleted externally, all open editor documents are automatically re-parsed and their diagnostics are refreshed, ensuring that issues like missing `#using` files are immediately reported or cleared. [[1]](diffhunk://#diff-9bc179768464337ef737f49e9d812ed62ad2f738f46c1d39a5300baf2cbd82ecL22-R67) [[2]](diffhunk://#diff-904163a593803e89fab76d7d607f337c1b9a6013d1f6a0a2c52722acce689f3dR79-R131)
* Added a method to retrieve all files that define a given namespace, supporting code actions that suggest `#using` directives.

**Diagnostics publishing and line handling:**

* Diagnostics notifications no longer include the document version, preventing stale squiggles in VS Code when the user types quickly. [[1]](diffhunk://#diff-31ec258d8e99153ab52e5b4276b47f28182781f365cf9a58a3a25e9dc119c646L56-R72) [[2]](diffhunk://#diff-31ec258d8e99153ab52e5b4276b47f28182781f365cf9a58a3a25e9dc119c646L85-R85)
* Improved line break handling in script content parsing to work correctly with all line ending styles, especially VS Code's default LF (`\n`).
* Added a utility to retrieve the cached content of a document, used by the new re-parse logic.

**Other improvements:**

* Registered the `CodeActionHandler` in the language server to support future code actions.

## Code Actions

The following diagnostic codes now have code actions registered in `CodeActionHandler.cs`.

### Delete Line
| Diagnostic | Action |
|---|---|
| `UnusedUsing` | Remove unused `#using` directive |
| `MissingUsingFile` | Remove unresolvable `#using` directive |
| `UnusedVariable` | Remove unused variable declaration |
| `DuplicateMacroDefinition` | Remove duplicate macro definition ⭐ |
| `DuplicateCaseLabel` | Remove duplicate `case` label ⭐ |
| `MultipleDefaultLabels` | Remove duplicate `default` label ⭐ |

### Insert
| Diagnostic | Action |
|---|---|
| `ExpectedSemiColon` | Insert missing `;` ⭐ |
| `StoreFunctionAsPointer` | Add `&` function pointer operator ⭐ |
| `UnusedParameter` | Prefix parameter with `_` |
| `MissingMacroParameterList` | Add missing `()` to macro invocation ⭐ |

### Delete Range
| Diagnostic | Action |
|---|---|
| `UnreachableCodeDetected` | Remove unreachable code ⭐ |
| `DuplicateModifier` | Remove duplicate modifier ⭐ |
| `UnreachableCase` | Remove unreachable `case` ⭐ |

### Content-Aware
| Diagnostic | Action |
|---|---|
| `PreferBooleanLiteral` | Replace with `false`/`true` |
| `SquareBracketInitialisationNotSupported` | Replace with `array()` initialiser |
| `UnterminatedRegion` | Add matching `/* endregion */` |
| `UnterminatedPreprocessorDirective` | Add missing `#endif` ⭐ |
| `UnexpectedUsing` | Move `#using` to top of file |
| `ConsumedThreadedCallResult` | Remove `thread` from call ⭐ |
| `FunctionDoesNotExist` | Create function stub |

### Multi-Action
| Diagnostic | Additional Action |
|---|---|
| `MissingUsingFile` | Create missing file |
| `UnknownNamespace` | Add `#using <path>` (one action per file that exports the namespace) |

### Bulk / Source Action
- **`UnusedUsing` (×2+)** — *Remove all unused #using directives (N)* — emitted as a `SourceOrganizeImports` action when 2 or more unused `#using` directives are present in the file.

---

⭐ = `isPreferred: true`

These changes together improve the reliability and accuracy of symbol resolution, diagnostics, and editor experience, especially when working with namespaces and external file changes.