### PR TITLE
Perf pass over indexing and the lint pipeline, dialect samples, a game picker, and macro-aware completion and signature help

### DIFF
--- a/.claude/skills/gsc-dialect-facts/SKILL.md
+++ b/.claude/skills/gsc-dialect-facts/SKILL.md
@@ -97,6 +97,24 @@ corpora `#animtree` appears in 415 files and **not once at the start of a line**
 belongs in `GscKeywords.BodyDirectives` and not `TopLevelKeywords`. It was in the latter, and a
 line-anchored grep is what made it look unused everywhere — measure this one without `^`.
 
+## BO3 file scope is an EXPRESSION position, not declarations-only
+
+A macro invocation is a call, and BO3 invokes macros at column 0 — `REGISTER_SYSTEM( "aat",
+&__init__, undefined )` appears 477 times in the shipped scripts, expanding (via
+`scripts/shared/shared.gsh`) to `function autoexec __init__sytem__() { … }`. So the argument list of
+that call is an expression sitting outside every function body: **510 function pointers and 467
+`undefined`s** are written at file scope across the corpus.
+
+Any rule that assumes "outside a body, only a declaration or a directive is legal" is wrong on those
+977 sites. It is what made completion's file-scope list keywords-only, and what a legality filter
+there would have kept hiding. Two consequences worth carrying: `undefined`, `true`, `false` and the
+other expression atoms belong at file scope as much as `function` does, and a name completed there
+takes no semicolon, since none of the 447 `REGISTER_SYSTEM` lines carries one.
+
+The macro's own expansion is the only thing that decides whether it may stand alone there. Of BO3's
+3,844 header macros exactly two are shaped like a top-level construct, so a shape test is not a
+useful filter — the language does not stop anyone expanding any of them anywhere.
+
 ## Under `#include`, every same-named function shares one key
 
 The merge dialects key a function as `(null, name)` — no namespace. CoD4's animscripts hold 1,230

--- a/README.md
+++ b/README.md
@@ -31,8 +31,9 @@ exist, how functions resolve, and which engine data files load.
 
 ## Getting started
 
-Open a folder of scripts and GSCode indexes it. Two optional settings tell it where the game's own
-scripts live, so that includes and path calls resolve against them:
+Open a folder of scripts and GSCode indexes it. Run **GSCode: Select Game** to pick the dialect — it
+lists only the games with an implemented dialect and marks the one in force. Two optional settings
+tell it where the game's own scripts live, so that includes and path calls resolve against them:
 
 - `gscode.rawPath` — the game's raw script folder. Set this when the folder you have open is a mod
   or a loose set of scripts. Left empty, only the open workspace folders are indexed.
@@ -48,10 +49,12 @@ game's compiler. The goal is to catch everything the compiler catches at build t
 mistakes that otherwise only surface at runtime.
 
 Before opening an issue, try **Developer: Reload Window**, wait for indexing to finish, and check
-the active game plus `gscode.rawPath`, `gscode.modsPath`, and `gscode.raw.enabled`. If results still
-look stale, run **GSCode: Clear Cache and Reindex**. For server or indexing problems, set
-`gscode.serverLogLevel` to `info` or `verbose` and copy the relevant part of the **GSCode Server**
-output. The [client README](client/README.md) has the full troubleshooting and cache-reset guide.
+the active game (**GSCode: Select Game** shows which one the server actually chose, which is not
+always what the setting names) plus `gscode.rawPath`, `gscode.modsPath`, and `gscode.raw.enabled`.
+If results still look stale, run **GSCode: Clear Cache and Reindex**. For server or indexing
+problems, set `gscode.serverLogLevel` to `info` or `verbose` and copy the relevant part of the
+**GSCode Server** output. The [client README](client/README.md) has the full troubleshooting and
+cache-reset guide.
 
 ### Bug reports
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -38,8 +38,13 @@ A complete ground-up rewrite of the language server and VS Code extension.
 - Corruption-proof whitespace-only formatter (refuses syntax errors; re-checks its own output).
 - Code actions: remove-duplicate-`#using` and add-missing-`#using`, backed by a namespace-usage
   lint.
-- Commands: `gscode.showOutput`, `gscode.restartServer`, `gscode.clearCacheAndReindex`, and
-  `gscode.openApiLibrary` (`shift+f1` in gsc/csc/gsh files).
+- Commands: `gscode.showOutput`, `gscode.restartServer`, `gscode.clearCacheAndReindex`,
+  `gscode.selectGame`, and `gscode.openApiLibrary` (`shift+f1` in gsc/csc/gsh files).
+- **GSCode: Select Game**, a picker for the dialect this workspace targets. The roster comes from
+  the server, so it offers only games with an implemented dialect, and it ticks the game actually
+  in force rather than the one `gscode.game` names — those differ whenever the setting names
+  something the server did not recognise. Previously the picker appeared only if the server
+  noticed a file that did not look like the selected game, and only once per session.
 - In-source suppression carried inside comments: `#pragma disable|restore <code>|all|format`.
   A named code is suppressed at whatever severity it carries, errors and syntax errors included —
   wider than the C# pragma the spelling comes from, which is why `warning` is not part of it (though

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -66,6 +66,13 @@ A complete ground-up rewrite of the language server and VS Code extension.
 
 ### Changed
 - Requires the .NET 10 runtime.
+- Completion outside a function body offers the same names it offers inside one — the macros an
+  `#insert`ed header supplies, the functions and classes in scope — rather than keywords and
+  snippets alone. A `REGISTER_SYSTEM` line and the function pointers and `undefined`s inside its
+  arguments are all completable now, and nothing completed at file scope carries a trailing
+  semicolon.
+- A function pointer completes as `&foo`, without the parentheses a call gets. Applies to
+  `&namespace::foo` too, and only on Black Ops III, where `&` is what makes a pointer.
 - Dialect-specific snippets moved from the extension to the server. A contributed snippet is
   registered per language id and one id covers five games, so `foreach`, `class`, `new`, the
   function declaration, `#precache`, the import directives and the ScriptDoc forms used to be

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -78,6 +78,11 @@ A complete ground-up rewrite of the language server and VS Code extension.
   script function or a builtin had a signature, so typing the arguments to `REGISTER_SYSTEM(` or
   `IS_TRUE(` showed nothing. The macro is read from the file being edited plus the headers it
   `#insert`s, so a header added a keystroke ago counts.
+- A macro's expansion keeps the lines it was written on, in hover as well as signature help. A
+  multi-statement macro used to be joined into one long line along with its backslashes; the
+  backslashes still go, and a macro that declares a function now reads as a declaration. Indentation
+  is redrawn at four spaces a level, so a header indented with tabs reads the same as one indented
+  with spaces.
 - Dialect-specific snippets moved from the extension to the server. A contributed snippet is
   registered per language id and one id covers five games, so `foreach`, `class`, `new`, the
   function declaration, `#precache`, the import directives and the ScriptDoc forms used to be

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -33,6 +33,13 @@ A complete ground-up rewrite of the language server and VS Code extension.
   (including string/hash/localized/anim literals), highlight, semantic tokens, folding,
   selection ranges, document/workspace symbols, code lens, rename, call and type hierarchy,
   inlay hints, document links, formatting (whole/range/on-type), and code actions.
+- Inlay-hint families apply the moment they are toggled: a settings push that changes one asks the
+  client to re-request its hints, rather than leaving the change invisible (and a family switched
+  off still on screen) until the next keystroke or scroll.
+- Macro parameter-name inlay hints: the arguments of a `#define` invocation labelled with the
+  macro's own parameter names, `IS_TRUE( __a: level.ready )`. A third inlay family, separate from
+  the call-site one and off by default (`gscode.inlayHints.macroParameterNames`), because a macro
+  parameter is named for the macro's body rather than for its caller.
 - Type-flow inference for inferred-type inlay hints and local-variable hovers, seeded with
   engine object-field types.
 - Corruption-proof whitespace-only formatter (refuses syntax errors; re-checks its own output).
@@ -53,7 +60,7 @@ A complete ground-up rewrite of the language server and VS Code extension.
 - A settings surface for the above, under `gscode.*`: the game and script roots
   (`game`, `raw.enabled`, `rawPath`, `modsPath`, `rawFileWarningMode`), indexing
   (`workspaceIndexingMode`, `enableWorkspaceCache`, `diagnostics.scope`), the editor features
-  (`outline.showAssignments`, `codeLens.enabled`, the `inlayHints.*` and `completion.*` pairs) and
+  (`outline.showAssignments`, `codeLens.enabled`, the `inlayHints.*` and `completion.*` keys) and
   formatting (`format.padParens`, `format.maxBlankLines`, `format.sortDirectives`,
   `format.alignConsecutive`).
 

--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -73,6 +73,11 @@ A complete ground-up rewrite of the language server and VS Code extension.
   semicolon.
 - A function pointer completes as `&foo`, without the parentheses a call gets. Applies to
   `&namespace::foo` too, and only on Black Ops III, where `&` is what makes a pointer.
+- Signature help answers on a function-like macro, showing its parameter names, the argument the
+  caret is in, what the macro expands to, and its trailing-comment documentation. Previously only a
+  script function or a builtin had a signature, so typing the arguments to `REGISTER_SYSTEM(` or
+  `IS_TRUE(` showed nothing. The macro is read from the file being edited plus the headers it
+  `#insert`s, so a header added a keystroke ago counts.
 - Dialect-specific snippets moved from the extension to the server. A contributed snippet is
   registered per language id and one id covers five games, so `foreach`, `class`, `new`, the
   function declaration, `#precache`, the import directives and the ScriptDoc forms used to be

--- a/client/README.md
+++ b/client/README.md
@@ -18,10 +18,11 @@ Open a folder containing your scripts in VS Code. GSCode activates automatically
 - `.csc` is a client-world script.
 - `.gsh` is a shared header inserted into either world.
 
-The extension defaults to the Black Ops III dialect (`gscode.game: "bo3"`). Select `cod4`, `waw`,
-`mw2`, `bo1`, or `bo3` in Settings when working on another game. The active game is shown in the
-status bar. Changing the game or raw/mod paths prompts you to reload the VS Code window; restarting
-only the language server does not re-read those startup settings.
+The extension defaults to the Black Ops III dialect (`gscode.game: "bo3"`). Run **GSCode: Select
+Game** to switch — it lists the games the server actually supports and ticks the one running now —
+or set `cod4`, `waw`, `mw2`, `bo1`, or `bo3` in Settings. The active game is shown in the status
+bar. Changing the game or raw/mod paths prompts you to reload the VS Code window; restarting only
+the language server does not re-read those startup settings.
 
 ### Game files, raw scripts, and mods
 
@@ -151,6 +152,10 @@ code it suppresses and says where it stops.
 
 - **GSCode: Show Server Output** opens the language-server log.
 - **GSCode: Restart Language Server** restarts a wedged server or picks up a rebuilt server binary.
+- **GSCode: Select Game** picks the Call of Duty dialect this workspace targets, then reloads the
+  window to apply it. The list comes from the server, so it only ever offers games with an
+  implemented dialect, and the tick marks the game the server actually selected rather than what
+  the setting says — the two differ when a setting names something unrecognised.
 - **GSCode: Clear Cache and Reindex** deletes this workspace's cache and reloads the window.
 - **GSCode: Open Documentation for Symbol** opens the matching API page on [gscode.net](https://www.gscode.net/), for the game the server has selected — a Call of Duty 4 workspace opens Call of Duty 4's library, not Black Ops III's. It is also bound to `Shift+F1` in GSC, CSC, and GSH files.
 
@@ -166,7 +171,7 @@ Server** output channel. `gscode.trace.server` can trace the LSP messages exchan
 
 | Symptom | What to check |
 | --- | --- |
-| `#using`, `#include`, or path calls cannot be resolved | Confirm `gscode.game`, `gscode.raw.enabled`, `gscode.rawPath`, and `gscode.modsPath`; reload the window after changing any of them. |
+| `#using`, `#include`, or path calls cannot be resolved | Confirm `gscode.game` (or run **GSCode: Select Game**, which shows the game in force), `gscode.raw.enabled`, `gscode.rawPath`, and `gscode.modsPath`; reload the window after changing any of them. |
 | Completions or references stop at the open file | Make sure `gscode.workspaceIndexingMode` is not `off`, then wait for the status bar to finish indexing. |
 | Diagnostics appear only in some files | Check `gscode.diagnostics.scope`; `open` intentionally excludes closed files, while `all` includes stock raw scripts. |
 | Results look stale after changing paths or game | Use **Developer: Reload Window**. If the index is still wrong, run **GSCode: Clear Cache and Reindex**. |

--- a/client/package.json
+++ b/client/package.json
@@ -312,6 +312,12 @@
 						"description": "Show inferred-type hints on local variable assignments.",
 						"scope": "window"
 					},
+					"gscode.inlayHints.macroParameterNames": {
+						"type": "boolean",
+						"default": false,
+						"description": "Show macro parameter-name hints before the arguments of a #define invocation (e.g. IS_TRUE( __a: level.ready )). Off by default: macro parameters are named for the macro's body rather than for the caller.",
+						"scope": "window"
+					},
 					"gscode.completion.literals": {
 						"type": "boolean",
 						"default": true,

--- a/client/package.json
+++ b/client/package.json
@@ -160,6 +160,10 @@
 				"title": "GSCode: Restart Language Server"
 			},
 			{
+				"command": "gscode.selectGame",
+				"title": "GSCode: Select Game"
+			},
+			{
 				"command": "gscode.clearCacheAndReindex",
 				"title": "GSCode: Clear Cache and Reindex"
 			},

--- a/client/package.json
+++ b/client/package.json
@@ -464,6 +464,9 @@
 		"watch": "tsc -watch -p ./",
 		"lint": "eslint src",
 		"bundle-server": "dotnet publish ../server/src/GSCode.Server/GSCode.Server.csproj -c Release -o ./service",
+		"bundle-server-win": "dotnet publish ../server/src/GSCode.Server/GSCode.Server.csproj -c Release -r win-x64 -o ./service",
+		"bundle-server-linux": "dotnet publish ../server/src/GSCode.Server/GSCode.Server.csproj -c Release -r linux-x64 -o ./service",
+		"bundle-server-osx": "dotnet publish ../server/src/GSCode.Server/GSCode.Server.csproj -c Release -r osx-arm64 -o ./service",
 		"package": "npm run compile && npm run bundle-server && npx --yes @vscode/vsce package"
 	},
 	"devDependencies": {

--- a/client/src/FOLDER.md
+++ b/client/src/FOLDER.md
@@ -1,6 +1,6 @@
 # client/src
 
-The VSCode extension sources. Four small files; the heavy lifting lives in the server.
+The VSCode extension sources. Five small files; the heavy lifting lives in the server.
 
 ## extension.ts
 
@@ -11,7 +11,8 @@ The VSCode extension sources. Four small files; the heavy lifting lives in the s
   channel), `gscode.restartServer` (restarts the language client),
   `gscode.clearCacheAndReindex` (stops the server, removes only this workspace's hashed SQLite
   database and its `-wal`/`-shm` sidecars, then reloads the window for a fresh cold index — behind
-  a modal confirm), `gscode.openApiLibrary` (opens the gscode.net library for the active editor's
+  a modal confirm), `gscode.selectGame` (the game picker, see `gamePicker.ts`),
+  `gscode.openApiLibrary` (opens the gscode.net library for the active editor's
   language; bound to `shift+f1` in gsc/csc/gsh files), and the `gscode.showReferences` bridge for
   code-lens clicks.
 - `registerIndexingStatusBar(context, client)` — the live indexing counter: a spinner whose
@@ -38,7 +39,27 @@ The VSCode extension sources. Four small files; the heavy lifting lives in the s
   completion, completion punctuation, diagnostics scope, formatter knobs).
 - `readSettings()` — reads the current `gscode.*` configuration into that shape.
 
+## gamePicker.ts
+
+- `pickGame(client, log, options)` — the `gscode.selectGame` command. Asks the server for the
+  roster over `gscode/supportedGames`, shows it with the RUNNING game ticked, writes
+  `gscode.game`, and offers the reload that applies it.
+- `pickGameFrom(games, selected, log, title)` — the same picker for a roster already in hand,
+  which is what `gscode/gameMismatch` carries.
+- The roster is never held here. The client used to own that list and it drifted to nine games,
+  four of them cores with no dialect, so picking one wrote a value the setting's own enum rejects
+  and the server resolved it back to BO3. A request that fails is reported rather than falling
+  back to a list — a fallback list IS the failure mode.
+- The tick follows `GameProfile.Active`, not `gscode.game`. The two differ exactly when something
+  is wrong, and ticking a game that is not in use rules out the thing being looked for.
+- A window reload, not `gscode.restartServer`: the game is a command-line argument and the launch
+  arguments are captured when the client is constructed, so a restart relaunches with the game the
+  session started with.
+
 ## reloadPrompt.ts
 
 - `registerReloadPrompt(...)` — offers a window reload when a change needs one to take effect,
   rather than leaving the editor in a state the server can no longer describe.
+- `suppressReloadPromptOnce()` — skips the next prompt, for a command that writes one of those
+  settings and prompts about it itself. The game picker is the only caller; without it, picking a
+  game produces two notifications about one edit.

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -5,6 +5,7 @@ import * as vscode from "vscode";
 import { LanguageClient } from "vscode-languageclient/node";
 import { createLanguageClient } from "./server";
 import { registerReloadPrompt } from "./reloadPrompt";
+import { pickGame, pickGameFrom } from "./gamePicker";
 
 let client: LanguageClient | undefined;
 
@@ -94,6 +95,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
                 log.error(`Failed to clear cache: ${String(error)}`);
             }
             await vscode.commands.executeCommand("workbench.action.reloadWindow");
+        }),
+    );
+
+    // Pick the game this workspace targets.
+    //
+    // The setting has always existed and the picker has always existed; what was missing was a way
+    // to REACH the picker on purpose. It only appeared when the server happened to notice a file
+    // that did not look like the selected game, and then only once per session — so someone who
+    // dismissed it, or whose scripts are ambiguous, had to go and find gscode.game in settings.
+    //
+    // Sits beside Clear Cache and Reindex because it ends the same way: the game is a launch
+    // argument, so applying it is a window reload rather than anything the running server can do.
+    context.subscriptions.push(
+        vscode.commands.registerCommand("gscode.selectGame", async () => {
+            await pickGame(created, log, { title: "Select the game this workspace targets" });
         }),
     );
 
@@ -467,17 +483,12 @@ function registerIndexingStatusBar(
                 return;
             }
 
-            const picked = await vscode.window.showQuickPick(
-                games.map((g) => ({ label: g.label, id: g.id, picked: g.id === params.selectedGame })),
-                { title: "Select the game this workspace targets", placeHolder: "Call of Duty game" },
-            );
-
-            if (picked) {
-                await vscode.workspace
-                    .getConfiguration("gscode")
-                    .update("game", picked.id, vscode.ConfigurationTarget.Workspace);
-                log.info(`Game version set to ${picked.id}.`);
-            }
+            // The same picker the gscode.selectGame command opens, given the roster this
+            // notification already carries. It was a second copy of the pick-and-write here, and
+            // the copies had already diverged: this one wrote to Workspace unconditionally, which
+            // throws when no folder is open, and neither offered the reload that makes the write
+            // do anything.
+            await pickGameFrom(games, params.selectedGame, log, "Select the game this workspace targets");
         },
     );
 

--- a/client/src/gamePicker.ts
+++ b/client/src/gamePicker.ts
@@ -1,0 +1,127 @@
+import * as vscode from "vscode";
+import { LanguageClient } from "vscode-languageclient/node";
+import { suppressReloadPromptOnce } from "./reloadPrompt";
+
+/** One game the server says may be picked. */
+interface SupportedGame {
+    id: string;
+    label: string;
+}
+
+/** The gscode/supportedGames response: the roster, and which profile is actually running. */
+interface SupportedGamesResponse {
+    selectedGame: string;
+    selectedDisplayName: string;
+    games: SupportedGame[];
+}
+
+/**
+ * Shows the game picker and applies the choice.
+ *
+ * The roster is ASKED FOR every time rather than kept here. That is not caution about staleness —
+ * it is the bug this file exists to not repeat. The client used to hold its own list, it drifted to
+ * nine games with four of them cores that have no dialect implemented, and picking one of those
+ * wrote a `gscode.game` value the setting's own enum rejects, which the server then silently
+ * resolved back to Black Ops III. The server is the only side that knows which profiles are
+ * supported, so a request that fails is reported rather than falling back to a list — a fallback
+ * list IS the failure mode.
+ *
+ * The tick goes on what the SERVER selected, not on what `gscode.game` says. The two differ exactly
+ * when something is wrong: an unrecognised name falls back to BO3, so the setting reads as what was
+ * asked for while the server runs something else. A picker that ticks a game which is not in use
+ * rules out the very thing the user is trying to find.
+ *
+ * @returns the id that was written, or undefined when nothing changed.
+ */
+export async function pickGame(
+    client: LanguageClient,
+    log: vscode.LogOutputChannel,
+    options: { title: string },
+): Promise<string | undefined> {
+    let roster: SupportedGamesResponse;
+    try {
+        roster = await client.sendRequest<SupportedGamesResponse>("gscode/supportedGames", {});
+    } catch (error) {
+        log.error(`Could not ask the server which games it supports: ${String(error)}`);
+        await vscode.window.showErrorMessage(
+            "GSCode could not reach the language server to list the available games.",
+        );
+        return undefined;
+    }
+
+    return applyRoster(roster.games ?? [], roster.selectedGame, log, options.title);
+}
+
+/**
+ * The half of the picker that works from a roster already in hand.
+ *
+ * gscode/gameMismatch carries the roster with it, so the offer to switch after a mismatch has
+ * everything it needs and must not make a second round trip to ask the same question again.
+ */
+export async function pickGameFrom(
+    games: SupportedGame[],
+    selectedGame: string,
+    log: vscode.LogOutputChannel,
+    title: string,
+): Promise<string | undefined> {
+    return applyRoster(games, selectedGame, log, title);
+}
+
+async function applyRoster(
+    games: SupportedGame[],
+    selectedGame: string,
+    log: vscode.LogOutputChannel,
+    title: string,
+): Promise<string | undefined> {
+    if (games.length === 0) {
+        log.warn("The server offered no supported games; not showing a picker.");
+        return undefined;
+    }
+
+    // description rather than `picked`, which does nothing in a single-select QuickPick — it is a
+    // multi-select affordance, and reads as a no-op checkmark that never appears.
+    const items = games.map((game) => ({
+        label: game.label,
+        description: game.id === selectedGame ? "$(check) current" : undefined,
+        id: game.id,
+    }));
+
+    const chosen = await vscode.window.showQuickPick(items, {
+        title,
+        placeHolder: "Call of Duty game",
+    });
+
+    if (chosen === undefined || chosen.id === selectedGame) {
+        return undefined;
+    }
+
+    // Workspace scope when there is one, because a workspace targets a game — a mod is for one
+    // title. Falling back to Global is not a preference: `update` on the workspace target throws
+    // when no folder is open, so an untitled window would fail rather than pick anything.
+    const target = vscode.workspace.workspaceFolders?.length
+        ? vscode.ConfigurationTarget.Workspace
+        : vscode.ConfigurationTarget.Global;
+
+    // The reload prompt watches gscode.game and would fire on this write. It is the right prompt
+    // for someone editing the setting by hand and a duplicate here, since asking is the next thing
+    // this function does.
+    suppressReloadPromptOnce();
+    await vscode.workspace.getConfiguration("gscode").update("game", chosen.id, target);
+    log.info(`Game set to ${chosen.id} (${vscode.ConfigurationTarget[target]}).`);
+
+    // A window reload, not gscode.restartServer. The game is a COMMAND LINE argument — the bundled
+    // data resolves while the container is built, before the initialize handshake — and the launch
+    // arguments are captured when the LanguageClient is constructed. A restart therefore relaunches
+    // with the game this session started with, and the setting would appear to do nothing.
+    const choice = await vscode.window.showInformationMessage(
+        `GSCode is now set to ${chosen.label}. Reload the window to apply it.`,
+        "Reload Window",
+        "Later",
+    );
+
+    if (choice === "Reload Window") {
+        await vscode.commands.executeCommand("workbench.action.reloadWindow");
+    }
+
+    return chosen.id;
+}

--- a/client/src/reloadPrompt.ts
+++ b/client/src/reloadPrompt.ts
@@ -20,6 +20,21 @@ const RESTART_REQUIRED: ReadonlyArray<{ section: string; label: string }> = [
 ];
 
 /**
+ * Set by a command that writes one of the above and prompts about it ITSELF.
+ *
+ * The game picker is the case: it writes gscode.game and immediately asks to reload, so the generic
+ * prompt below would be a second notification saying the same thing about the same edit. One shot
+ * rather than a scope, because the write and the change event are one turn apart and anything
+ * longer-lived would swallow a real edit made while it was open.
+ */
+let suppressNext = false;
+
+/** Skips the next restart-required prompt. See {@link suppressNext}. */
+export function suppressReloadPromptOnce(): void {
+    suppressNext = true;
+}
+
+/**
  * Prompts to reload the window when one of the above changes.
  *
  * A window reload rather than `gscode.restartServer`, which is NOT sufficient here: the server's
@@ -43,6 +58,12 @@ export function registerReloadPrompt(
                 .map((setting) => setting.label);
 
             if (changed.length === 0 || prompting) {
+                return;
+            }
+
+            if (suppressNext) {
+                suppressNext = false;
+                log.info(`Restart-required setting changed by a command that prompts itself: ${changed.join(", ")}`);
                 return;
             }
 

--- a/client/src/settings.ts
+++ b/client/src/settings.ts
@@ -19,6 +19,7 @@ export interface GscodeSettings {
     "codeLens.enabled": boolean;
     "inlayHints.parameterNames": boolean;
     "inlayHints.inferredTypes": boolean;
+    "inlayHints.macroParameterNames": boolean;
     "completion.literals": boolean;
     "completion.fieldScope": string;
     "completion.callPunctuation": string;
@@ -46,6 +47,7 @@ export function readSettings(): GscodeSettings {
         "codeLens.enabled": config.get<boolean>("codeLens.enabled", true),
         "inlayHints.parameterNames": config.get<boolean>("inlayHints.parameterNames", true),
         "inlayHints.inferredTypes": config.get<boolean>("inlayHints.inferredTypes", true),
+        "inlayHints.macroParameterNames": config.get<boolean>("inlayHints.macroParameterNames", false),
         "completion.literals": config.get<boolean>("completion.literals", true),
         "completion.fieldScope": config.get<string>("completion.fieldScope", "owner"),
         "completion.callPunctuation": config.get<string>("completion.callPunctuation", "parensAndSemicolon"),

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -85,9 +85,10 @@ GSC/CSC/GSH language registrations, TextMate grammar, semantic-token scope mappi
 quick-suggestion defaults. Two log channels: "GSCode" (`LogOutputChannel`, extension-host
 lifecycle) and "GSCode Server" (the server's stderr/Serilog). A status-bar item shows the live
 indexing counter driven by `gscode/indexingStarted|Progress|Complete` notifications. Commands:
-`gscode.showOutput`, `gscode.restartServer`, `gscode.clearCacheAndReindex`,
-`gscode.openApiLibrary` (`shift+f1` in GSC, CSC, and GSH files), and the
-`gscode.showReferences` bridge for code-lens clicks. Settings flow to the server via
+`gscode.showOutput`, `gscode.restartServer`, `gscode.clearCacheAndReindex`, `gscode.selectGame`
+(the game picker, whose roster comes from the server over `gscode/supportedGames` so the client
+never keeps its own list of which dialects exist), `gscode.openApiLibrary` (`shift+f1` in GSC,
+CSC, and GSH files), and the `gscode.showReferences` bridge for code-lens clicks. Settings flow to the server via
 `initializationOptions.gscode` and `workspace/didChangeConfiguration`.
 
 ## Dev-time tooling

--- a/server/ARCHITECTURE.md
+++ b/server/ARCHITECTURE.md
@@ -58,7 +58,8 @@ whoever asks — otherwise renaming a header macro from a `.gsc` leaves every `.
 - **Sync + diagnostics**: incremental text sync with debounced re-analysis (`TextSyncHandler`),
   push-model `publishDiagnostics` merging parse diagnostics with the cross-file lints — all of them,
   through `Analysis/WorkspaceLints.Analyze`, which is the one entry point and currently runs
-  twenty-five rules. Naming a single lint here read as if it were the whole merged set.
+  twenty-six rules — seventeen called directly and nine more sharing `NodeLintPass`'s single AST
+  walk. Naming a single lint here read as if it were the whole merged set.
 - **Read**: hover (with inferred local types), definition, references (incl. literals),
   document highlight, document links, document/workspace symbols, folding, selection ranges,
   semantic tokens (full/delta/range).

--- a/server/GAME_PROFILES.md
+++ b/server/GAME_PROFILES.md
@@ -112,6 +112,11 @@ no bundled data).
 parentheses would call it. `&` = BO3 makes the pointer explicit (`level.f = &foo;` / `&ns::foo`), and
 a bare `ns::foo` is always a call.
 
+Completion reads this axis too, not just the parser: after a BO3 `&` a suggestion is inserted as the
+bare name, since `&foo()` would call the function and point at what it returns. The gate has to be
+the style rather than the character, because in the `::` line an `&` is arithmetic — the shipped
+scripts hold 4,564 `&name` pointers in BO3 and none in CoD4.
+
 **Import style and resolution are two claims, not one.** `ImportStyle` is purely lexical — whether
 the directive is spelled `#using` or `#include` — and that is all the lexer, directive completion and
 shape detection need. `ResolvesByNamespace` is the deeper question: whether a function's *identity*

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -1305,6 +1305,48 @@ machine with fewer cores the cold column moves and the conclusion with it.
 The cold index, the phase shares, the lint pass and completion are all untouched — this is the other
 arm of the fork. The keystroke path never reads the cache at all.
 
+### 2026-08-22: the warm arm was holding its own blobs for the session
+
+Every memory figure in this file is a COLD index. `MemoryProbeTests` has two probes and neither
+could see the warm arm: one attaches no cache at all, and the one that does opens a fresh
+`gscode-probe-<guid>.db` per run, so `LoadAll` returns nothing and every file is analysed. It
+measures the cache being WRITTEN. The restore snapshot only exists where the database already has
+rows, and until `EachGame_WarmIndexWithCache_ThenWatchRetainedMemory` was added, the bytes it costs
+had never been on a scale.
+
+`WorkspaceIndexer` held that snapshot in a field set once by `UseCache` and never cleared, and the
+server registers the indexer as a singleton — so every gzipped blob `LoadAll` read stayed reachable
+for the session, long after the last file that could restore from one was indexed. `ProcessFile`
+consults it only under `allowRestore`; phase two and the watcher's `IndexFile` both pass false. It
+is dead the moment `IndexAsync` returns.
+
+Populate, drain, throw everything away except the database file, index again warm, then one sample
+after a forced blocking collection with the indexer kept alive:
+
+| retained after a warm index | before | after |
+|---|---:|---:|
+| bo3, 1,085 files | 82.2 MB | **68.8 MB** |
+| cod4, 904 files | 74.4 MB | **61.0 MB** |
+
+**13.4 MB on both, 16% and 18% of what the workspace costs to keep.** The figure is smaller than
+the database on disk — 21.0 MB for bo3, 23.0 for cod4 — and should be: the file carries the schema,
+the `deps` table and SQLite's own indices, while what was pinned is the record column alone.
+
+`GC.KeepAlive(indexer)` is what makes the probe answer the question asked. The server's indexer
+outlives every index it runs; a probe that lets it be collected measures the database only and reads
+clean whatever the indexer is keeping.
+
+Releasing it alone would have made a workspace-folder change a cold index, since that handler is the
+only caller that indexes twice in a session. `ReloadRestoreSnapshot` re-reads it there instead —
+16–21 ms on these two corpora, on a path taken by hand, to keep the other case free.
+
+**The header-cache merge in the same pass freed nothing measurable, and the probe says so.** The
+indexer kept a private `ConcurrentDictionary<path, Lazy<InsertedFile?>>` beside the `InsertCache` it
+was already handed for macros, so BO3's 114 distinct headers were held twice. Merging them reads
+68.8 and 61.0 — the same two numbers to the decimal. A hundred small files is not 13 MB, and the
+merge is kept for the duplicate it removes and for three defects the surviving cache does not have
+(ordinal path comparison, no revalidation, a failed read cached for good), not for memory.
+
 ## Measured: STARTUP, which is not indexing and had never been separated from it
 
 `Ready Ns after start` has been in the log for a while and every reading of it was attributed to
@@ -1515,6 +1557,8 @@ cold one** — the WARM START section explains why and what the remaining lever 
 0.3–0.4 s off it with a RID-specific publish that is not the default.
 | Steady-state memory (cold, before compaction) | 1,105 files | 390.3 MB | < 400 MB | just inside |
 | Steady-state memory (warm) | 1,105 files | 212.2 MB | < 400 MB | yes |
+| Retained after a warm index, harness, 2026-08-22 | 1,085 files (bo3) | 68.8 MB | < 400 MB | yes |
+| Retained after a warm index, harness, 2026-08-22 | 904 files (cod4) | 61.0 MB | < 400 MB | yes |
 | Live managed set (either path) | 1,105 files | ~115 MB | — | — |
 
 From the test harness rather than the server, 2026-08-12 — a different question, as the section on

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -988,8 +988,8 @@ Measured on bo3, 1,085 files, uninstrumented, two runs per configuration:
 | Workstation, gen0 budget raised to 16 MB | 2,016 / 2,112 ms |
 | Workstation, gen0 budget raised to 64 MB | 1,553 / 1,526 ms |
 | Workstation, gen0 budget raised to 256 MB | 1,336 / 1,406 ms |
-| **Server GC, 4 heaps (shipped)** | **768 / 768 ms** |
-| Server GC, 8 heaps | 564 / 638 / 601 / 602 / 702 ms |
+| Server GC, 4 heaps | 768 / 768 ms |
+| **Server GC, 8 heaps (shipped)** | **564 / 638 / 601 / 602 / 702 ms** |
 | Server GC, 12 heaps | 722 / 632 ms |
 | Server GC, unbounded (24) | 768 / 733 ms |
 | Server GC, 2 heaps | 1,051 / 1,333 ms |
@@ -1003,44 +1003,30 @@ and because the memory table below was taken alongside it.
 16x on Workstation recovers only a third of the gap, so the problem is that the threads share one
 heap rather than that they collect too often. `ConserveMemory` costs nothing here and stays.
 
-### Why four heaps and not one per core
+### Why eight heaps and not one per core
 
-Unbounded is not faster — 733–768 ms against 601–702 for eight — and above eight each heap's own
-large-object heap starts showing up as fragmentation. The heap count buys throughput with the memory
-the server RESTS at, which for a process that sits open all day is the number worth protecting:
+**Measured on the real server, not on the probe.** The earlier version of this section chose four
+heaps to protect a working set that turned out not to exist: `MemoryProbeTests` never runs the
+post-index LOH compaction that `Program.cs` performs at the indexing → serving transition, and that
+compaction returns the pages the heap count was appearing to cost. Driving the bundled server over
+stdio and reading its own log lines, bo3, 1,085 files:
 
-| | cold index | live | fragmented | resting working set |
-|---|---:|---:|---:|---:|
-| Workstation (before) | 2,177 / 2,182 ms | 51.1 MB | 0.1 MB | 127 MB |
-| **Server, 4 heaps** | **768 / 768 ms** | **51.0–51.1 MB** | **0.6–0.7 MB** | **200–201 MB** |
-| Server, 8 heaps | 564 / 638 ms | 51.0–51.1 MB | 0.6–0.7 MB | 281 MB |
-| Server, 12 heaps | 632 / 722 ms | 51.0 MB | 48.6 MB | 396–413 MB |
-| Server, unbounded (24) | 733 / 768 ms | 51.1 MB | 34.9 MB | 247 MB |
+| heaps | indexing | peak while indexing | **resting, after compaction** |
+|---|---|---:|---:|
+| Workstation (before) | 2.6–2.7 s | — | 127 MB |
+| 4 | 0.5 / 0.6 / 0.6 s | 309–334 MB | 125.4–125.9 MB |
+| **8 (shipped)** | **0.4 / 0.5 s** | 320–342 MB | **125.0–126.8 MB** |
+| one per core (24) | 0.4 / 0.5 s | 392–453 MB | 128.3–128.9 MB |
 
-**Four is the setting that ships.** It keeps most of the speedup — 2.8x against eight's 3.5x — for
-half the extra footprint, and the difference between them is 150–200 ms on a path that runs once at
-startup against 80 MB the process holds for as long as it is open. Eight is the right answer if a
-cold index is ever the thing being waited on; the resting set is what a user actually lives with.
+**Every setting rests at the same place**, 125–129 MB, and so does Workstation. Retained memory is
+55.1–55.2 MB live at all of them, fragmentation 0.0 after the compaction. What the heap count moves
+is the PEAK during indexing and the time it takes: one per core peaks 60–130 MB higher for no gain,
+four is a tenth of a second slower than eight for a peak within a few MB of it.
 
-**Retained memory does not move at any setting** — 51.0–51.1 MB live, identical to Workstation, the
-same 641 GSC and 325 CSC records held. That was the constraint the `ArrayPool` attempt failed and this
-one meets: nothing is retained that was not retained before. Fragmentation does not move either, at
-four or eight.
-
-**Neither does the PEAK.** Both settings measure 436–464 MB immediately after indexing and drain to
-their resting figure within about five seconds, so the difference is entirely in what the runtime
-gives back, not in what the index costs to run.
-
-Two caveats on the working-set column: the probe never runs the post-index LOH compaction that
-`Program.cs` performs at the indexing → serving transition, which is the mechanism that returned 446
-MB on bo1 above; and at four or eight heaps fragmentation is already at Workstation levels, so there
-is nothing for a compaction to reclaim beyond the pages themselves. Confirm the served number from
-the status-bar tooltip rather than from this table.
-
-`System.GC.HeapCount` is 4, set in both `runtimeconfig.template.json` files — the server's and the test
-project's — so the probe keeps measuring what ships. **Unverified on a machine with fewer than eight
-cores**: the runtime is expected to clamp the count to the processor count, and that has not been
-tested here.
+So the memory column that argued for four does not survive contact with the shipping path. This is
+the same lesson as the fragmentation gate two sections up — measuring the right quantity in the
+wrong process — and the correction here is the same shape: read the server's own log, not the
+probe's table.
 
 ### What this does NOT change
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -242,6 +242,57 @@ the two field-write rules keep the cheap walk they had. That leaves `TypeMismatc
 with recording on, so the file is walked twice — about 470 ms against the 467–570 ms measured above,
 which buys nothing and adds a second cache state. One memo on the richer answer is the shape.
 
+### 2026-08-19: the child walk allocated once per node visited
+
+`AstSearch.ChildrenOf` was a `yield return` iterator, so every node VISITED allocated a state
+machine — and the tree is walked once per rule by fifteen lints, plus the reference, rename,
+inlay-hint and parameter-typing passes. bo3's 980 scripts are 1,049,221 nodes.
+
+Priced first with three probes in one run, each a bare full-tree walk that visits and does nothing:
+
+| bare walk of every script | bo3, 862 files |
+|---|---|
+| through the iterator | 128–145 ms |
+| direct recursion, same switch, no enumerable | 35–47 ms |
+| direct recursion with leaves short-circuited BEFORE the switch | same as the row above |
+
+The last row is what named the cause. Short-circuiting identifiers and literals — most of the nodes
+in any tree — ahead of the thirty-case type switch changed nothing, so the switch was not the cost
+and the allocation was. The probe order was then reversed and the ratio held, which rules out the
+first walk simply paying to warm the tree into cache for the others.
+
+`ChildrenOf` now returns a STRUCT enumerable that each caller's `foreach` binds to by shape, so the
+walk allocates nothing and all 22 call sites are unchanged. Measured as four A/B pairs with the
+ORDER ALTERNATED between pairs — three pairs run orig-then-mine had every untouched rule reading
+about 25% slower in the second half, which is an ordering artefact and not an effect:
+
+| | orig | after |
+|---|---|---|
+| the 14 rules that walk the AST | 1,783 ms | **1,423 ms (−20%)** |
+| the 7 rules that do not | 287 ms | 338 ms (+18%, unexplained) |
+| lint pass total | 2,328–2,598 ms | **2,081–2,335 ms** |
+
+The total falls in all four pairs — 3%, 6%, 10%, 20% — for a median of 9%, and twelve of the
+fourteen walking rules fall individually, by 11% to 40%. **The non-walking rules rising 18% is not
+explained.** It works against the change rather than for it, so the walking-rule figure is a floor.
+
+**The remaining 2x is the enumerator, not a copy.** With the struct in place the same bare walk
+costs 80–93 ms against 43–58 ms for direct recursion. A second variant carrying only the node, with
+the shape switch moved into the enumerator's constructor so that a 56-byte struct is not copied per
+node, measured the same ratio — 1.6–1.9x against 1.7–2.0x — so the copy was not the cost, and the
+more readable version was kept. Closing that gap means fusing the switch into each walk, which is
+what "one shared walk instead of fifteen" would do and this change deliberately does not.
+
+Behaviour was pinned before any timing was taken: every node's child sequence over all 980 bo3
+scripts, 1,049,221 nodes, dumped with type and position and byte-identical on both sides. The
+`Category=Corpus` sweep then printed identical output, and `ChildEnumerationTests` pins the child
+order per shape — including the two that a position-counting walk would get wrong, a `for` with
+omitted clauses and a `default:` label that contributes no child — plus one test asserting that a
+whole-tree walk allocates zero bytes, which is the property the struct exists for.
+
+This is NOT an index-path change. Outside the lints, `ChildrenOf` serves rename, references, inlay
+hints and the parameter typer, all per-request; indexing does not call it.
+
 ## Measured: COMPLETION, and why it is NOT worth optimising
 
 `CorpusPerfTests.Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -198,6 +198,50 @@ builds. It is also why one corpus cannot stand in for the other here.
 bo3's 95 ms worst file — a single-shot measurement at that — is the closest anything comes. Do not
 optimise on these numbers. They are here so that the next 2x has something to be a 2x *of*.
 
+### 2026-08-19: the three type rules now share one inference walk
+
+They had three walks between them over the same tree — `TypeMismatchLint` called `InferValues`,
+`PreferBooleanLiteralLint` and `ReadOnlyWriteLint` each called `InferAssignments` — with a `FlowTyper`
+shared between them that memoised nothing. `InferValues` was already a superset, since a
+`ScriptTypes` carries the assignments and the field writes alongside the per-expression map, so it
+now memoises per `ParseResult` and all three read one answer. Keyed by REFERENCE: a `ParseResult` is
+a record, so structural equality would compare two whole trees to settle what identity settles
+exactly, and a keystroke produces a new one, so a stale answer cannot be served.
+
+Measured as three INTERLEAVED A/B pairs in one session, instrumented, bo3 only. Interleaved because
+the first attempt ran three of each back to back and the twenty-one untouched rules drifted 29%
+between the halves — larger than the effect being measured, and a reminder that "same session, same
+machine" is not the same claim as "same conditions".
+
+| pair | the three rules | control (21 other rules) | their share of the pass |
+|---|---|---|---|
+| 1 | 851 → **467** ms | 1,888 → 2,083 ms | 31.1% → **18.3%** |
+| 2 | 798 → **512** ms | 1,878 → 1,893 ms | 29.8% → **21.3%** |
+| 3 | 832 → **570** ms | 1,832 → 2,048 ms | 31.2% → **21.8%** |
+
+**Read the share: 30% → 20%, in three pairs, with non-overlapping bands.** Normalised against the
+control the three rules fall 36–50% (median 39%); unnormalised, 31–45%. The control still drifts
++1% to +12% within a pair, which is why the share is the admissible number and not the milliseconds.
+
+Per rule, medians of three: `ReadOnlyWriteLint` 191 → 0.8 ms, since it now reads a memo and does
+nothing else; `TypeMismatchLint` 352 → 179 ms, the residue being its own AST walk rather than
+inference; `PreferBooleanLiteralLint` 279 → **340** ms, because it runs first and therefore pays for
+the whole walk, including the per-expression recording it does not read. Net about −295 ms.
+
+The lint total falls in all three pairs, 2,689–2,763 → 2,430–2,642 ms, and that is NOT claimed: the
+bands touch and the 700 ms band above says what a single total is worth. Nothing moved at the tail —
+median 0.62–0.68 → 0.57–0.65 ms, p99 35.9–39.4 → 34.8–38.9 ms. It was never a latency fix; the p99
+was already ten times inside the debounce.
+
+Findings are unchanged, which is the bar rather than a bonus: the bo3 `Category=Corpus` sweep printed
+byte-identical output on both sides — 31 tests over 980 scripts, every count and every reported line
+the same, only the xUnit timestamps differing.
+
+**Rejected, by reasoning rather than measurement:** memoising the *assignment* pass separately, so
+the two field-write rules keep the cheap walk they had. That leaves `TypeMismatchLint` walking again
+with recording on, so the file is walked twice — about 470 ms against the 467–570 ms measured above,
+which buys nothing and adds a second cache state. One memo on the richer answer is the shape.
+
 ## Measured: COMPLETION, and why it is NOT worth optimising
 
 `CorpusPerfTests.Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -33,6 +33,31 @@ Their corpus roots are read from `GSCODE_CORPUS_<GAME>`. Those variables are usu
 USER level, so a child process inherits every game whether you want it or not — clear the three you
 are not sweeping, or `GameCorpusFixture.Available()` will pick them up.
 
+## Where bo3 stands after the 2026-08-19 pass
+
+One uninstrumented run of the whole perf category at the end of that day's work, so the sections
+below — which are each a before/after pair of one change — have a single reading to be read against.
+Compared with the last figures recorded for the same quantities:
+
+| | recorded before | 2026-08-19 |
+|---|---:|---:|
+| lint pass, 980 files | 2,191 ms | **1,332 ms** |
+| lint median / p99 / max | 0.61 / 23.1 / 95.1 ms | **0.31 / 19.0 / 47.0 ms** |
+| completion, 6,381 requests | p99 4.22–4.26 ms | **p99 2.12 ms**, median 0.30 |
+| analysis, 980 files | 612 ms | 685 ms |
+| cold index, 1,085 files | 1,714–1,732 ms | 1,620 ms |
+
+The lint pass and completion are the two that moved, and both are the sum of the changes below
+rather than of any one of them: the typer memo, the allocation-free child walk, the nine-into-one
+per-node pass, and the namespace index. Analysis and the cold index are unchanged within noise,
+which is what they should be — nothing in that pass touched the lex, preprocess or parse phases, and
+the parse work of that day added measurement only.
+
+**Single run, so read the shares and the distributions.** The entry-count line is what makes the
+completion row admissible: 4,211 of 6,381 requests returned over 500 entries, median 1,930, so the
+sample is still landing on the statement-scope arm that queries the store rather than on the cheap
+arms.
+
 ## Measured: where analysis time goes
 
 `--filter "Category=Perf"` times every script in a game individually and splits each into the four

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -954,16 +954,84 @@ once per index, unconditionally, on a thread nobody is waiting on.
 
 Two things this measurement also settled:
 
-- **Do not switch to Server GC.** Per-core heaps would multiply the fragmentation, and
-  Workstation GC is the right choice for a language server. The 2026-08-05 `ArrayPool` result
-  is the same lesson from another angle: anything that keeps per-core state across the indexing
-  threads trades holes for retention.
+- **Do not switch to Server GC** — **REVERSED 2026-08-19, see below.** The reasoning was that
+  per-core heaps would multiply the fragmentation, and it is correct as far as it goes: unbounded
+  Server GC on a 24-thread machine does leave 35 MB of large-object holes where Workstation leaves
+  0.1. What it missed is that the heap count is a DIAL rather than a switch, and that nothing had
+  measured what the single heap was costing in throughput. The 2026-08-05 `ArrayPool` result is
+  still the lesson it was: that one traded holes for RETENTION, which this does not.
 - **Cache restore is not skipping `NameTable` interning.** That worry predicted a warm start
   carrying duplicate strings, which would show up as a *higher* warm live set. It came in 3.9
   MB *lower*, so the concern is closed.
 
 If cold ever climbs again without fragmentation climbing with it, that is the leak-hunt
 signal — a genuinely higher live set means the analysis path is retaining something.
+
+## Measured: the GC, which was three quarters of the cold index
+
+The cold-index sections above all say the same thing — `index.analyse` is 86–93% of thread-time —
+and none of them asked whether that time is the analysis. It was not. The same analysis measured
+per-file by the sequential sweep costs about 0.7 ms; inside the parallel index it was costing about
+39 ms of thread-time per file. A fifty-fold gap between the same code measured two ways is not a
+property of the code.
+
+It was the garbage collector. Indexing runs at `ProcessorCount - 1` and allocates a token array, a
+`PToken` stream, an AST and extraction builders for every file, and under Workstation GC all of
+those threads collect against one heap.
+
+Measured on bo3, 1,085 files, uninstrumented, two runs per configuration:
+
+| configuration | cold index |
+|---|---:|
+| Workstation, as shipped since the beginning | 2,177 / 2,182 ms |
+| Workstation, `GCConserveMemory` off | 2,156 / 2,238 ms |
+| Workstation, gen0 budget raised to 16 MB | 2,016 / 2,112 ms |
+| Workstation, gen0 budget raised to 64 MB | 1,553 / 1,526 ms |
+| Workstation, gen0 budget raised to 256 MB | 1,336 / 1,406 ms |
+| **Server GC, 8 heaps** | **601 / 602 / 702 ms** |
+| Server GC, 12 heaps | 722 / 632 ms |
+| Server GC, unbounded (24) | 768 / 733 ms |
+| Server GC, 4 heaps | 1,315 / 1,237 ms |
+| Server GC, 2 heaps | 1,051 / 1,333 ms |
+
+**Roughly 3.4x, and the gen0 rows are what identify the cause.** Raising the collection budget by
+16x on Workstation recovers only a third of the gap, so the problem is that the threads share one
+heap rather than that they collect too often. `ConserveMemory` costs nothing here and stays.
+
+### Why eight heaps and not one per core
+
+Unbounded is not faster — 733–768 ms against 601–702 — and it costs memory, because each heap keeps
+its own large-object heap:
+
+| | live | fragmented | LOH free/size | working set |
+|---|---:|---:|---:|---:|
+| Workstation (before) | 51.1 MB | 0.1 MB | 0.0 / 9.8 MB | 127 MB |
+| **Server, 8 heaps** | **51.1 MB** | **0.7 MB** | **0.0 / 9.8 MB** | **281 MB** |
+| Server, 12 heaps | 51.0 MB | 48.6 MB | 47.9 / 57.7 MB | 396–413 MB |
+| Server, unbounded | 51.1 MB | 34.9 MB | 34.3 / 44.1 MB | 247 MB |
+
+**Retained memory does not move at any setting** — 51.0–51.1 MB live, identical to Workstation, with
+the same 641 GSC and 325 CSC records held. That was the constraint the `ArrayPool` attempt failed and
+this one meets: nothing is being retained that was not retained before.
+
+**The cost is working set: 127 MB → 281 MB.** That is pages the runtime has not returned rather than
+objects being held, and it is the honest price of this change. Two things to know about the figure:
+the probe never runs the post-index LOH compaction that `Program.cs` performs at the indexing →
+serving transition, which is exactly the mechanism that returned 446 MB on bo1 above; and eight heaps
+is the setting where fragmentation stays at Workstation levels, so there is nothing for a compaction
+to reclaim beyond the pages themselves. Confirm the served number from the status-bar tooltip rather
+than from this table.
+
+`System.GC.HeapCount` is set in both `runtimeconfig.template.json` files — the server's and the test
+project's — so the probe keeps measuring what ships. **Unverified on a machine with fewer than eight
+cores**: the runtime is expected to clamp the count to the processor count, and that has not been
+tested here.
+
+### What this does NOT change
+
+The phase shares, the lint pass and completion are all measured by sequential sweeps, so none of
+them moves: this is a change to what happens when 23 threads allocate at once. The keystroke path
+allocates on one thread and was never contended.
 
 ## Reading the reports
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -84,16 +84,22 @@ flag's own cost is visible rather than folded in:
 | bo3 *(instrumented)* | 980 | 980 ms | 0.19 ms | 27% | 20% | 35% | 18% |
 | bo1 | 2,960 | 3,111 ms | 0.05 ms | 34% | 9% | 41% | 16% |
 
-**Shares are stable to about a point only within a phase, not across a run.** The three-run cod4
-table further down establishes that for `extract` and it does not generalise: `lex` and `parse` move
-4–5 points between the two runs above, which are the same code minutes apart. So read a 4-point
-difference as nothing. Two moves here survive both runs and are therefore real:
+**Corrected 2026-08-22 — shares are NOT stable to a point, and one conclusion below rested on it.**
+This paragraph used to say they were stable to about a point within a phase, that a 4-point
+difference was nothing, and that two moves survived both runs and were therefore real. Five runs of
+one build say `lex` moves ten points and `extract` five to eight; see the section on it further
+down. Only `parse` holds to a point or two. So:
 
-- **bo3 `extract` 12% → 18–20%**, against `preprocess` falling 31% → 20–23%. Extraction's share on
-  the `#insert` dialect has roughly doubled since the figure above it was taken.
-- cod4's total falling by half (1,556 → 816 ms) with its median falling 3x. The distribution is now
-  sharply bimodal — median 0.05 ms against a p99 of 15.3 ms — so the median says little and the
-  slowest 1% carry 24% of the total.
+- **bo3 `extract` 12% → 18–20%** is retracted. The move is inside the instrument's own spread, and
+  the five-run table reads 21 / 13 / 18 / 15 / 18 on code that did not change. Nothing was built on
+  it, but it stood as a finding for ten days.
+- cod4's total falling by half (1,556 → 816 ms) with its median falling 3x **stands**, on the
+  distribution rather than on the share: median 0.05 ms against a p99 of 15.3 ms, so the median says
+  little and the slowest 1% carry 24% of the total. A 2x total against a 26% run-to-run spread is
+  outside the noise where a 6-point share move is not.
+
+Read the sub-scope milliseconds where a number has to be trusted; read this table for which phase is
+worth opening, not for by how much one moved.
 
 **These are not comparable with figures recorded before 2026-07-30.** The total used to be a
 separate stopwatch around a second `Analyze()` call; it is now the SUM of the four phase timings.
@@ -132,6 +138,139 @@ worth nothing: every token's kind, offset, length and range was dumped for eleve
 sources covering each changed path plus 4,000 seeded-random strings over a GSC alphabet, before and
 after, 182,821 lines byte-identical. The corpus sweep then reported the same counts on both sides —
 2 of 894 on cod4, 2 of 980 on bo3, 6 of 2,960 on bo1, with the formatter's gates clean.
+
+### 2026-08-22: the extract move was the instrument, not the code
+
+The table above names "bo3 `extract` 12% → 18–20%" as one of two moves that "survive both runs and
+are therefore real". It does not survive four. Five instrumented sweeps of the same corpus on the
+same machine within twenty minutes, the last four on a byte-identical build:
+
+| bo3 | run 1 | run 2 | run 3 | run 4 | run 5 |
+|---|---:|---:|---:|---:|---:|
+| lex | 26% | 40% | 30% | 31% | 35% |
+| preprocess | 41% | 35% | 39% | 43% | 37% |
+| parse | 12% | 12% | 13% | 12% | 11% |
+| **extract** | **21%** | **13%** | **18%** | **15%** | **18%** |
+
+| cod4 | run 1 | run 2 | run 3 | run 4 | run 5 |
+|---|---:|---:|---:|---:|---:|
+| lex | 32% | 42% | 45% | 45% | 35% |
+| preprocess | 15% | 17% | 15% | 15% | 21% |
+| parse | 26% | 19% | 19% | 22% | 19% |
+| **extract** | **27%** | **21%** | **22%** | **17%** | **25%** |
+
+**`lex` moves ten points and `extract` five to eight, on identical code.** The totals move with them
+— cod4 read 1,251 / 1,331 / 1,461 / 1,162 ms across four runs of one build, a 26% spread. So the
+paragraph above, which says shares are "stable to about a point only within a phase" and that a
+4-point difference is nothing, understates the noise by roughly a factor of two, and the conclusion
+drawn from a 6-point move was drawn from inside it.
+
+`parse` is the exception and is stable to a point or two on both corpora, which is what makes the
+rest readable as noise rather than as the machine being busy: a busy machine would move all four.
+
+**The sub-scope milliseconds are the trustworthy half of this report.** `extract.declarations` on
+cod4 read 261 / 256 / 266 / 238 / 268 ms across the same five runs — a 12% spread against the phase
+share's 10 points. Read those, and read the phase table only for what it was built to show: which
+phase is worth opening, not by how much one moved.
+
+bo3's own sub-scopes are noisier (64–113 ms) for the reason the file gives elsewhere: at 0.065–0.116
+ms per file the quantity is small enough that one GC pause is a third of it. **This harness cannot
+settle a constant factor on bo3's extract phase.** A repetition bench can, and the expression fast
+path further up is the worked example.
+
+Two scopes were added while chasing this, and they are worth keeping even though the answer turned
+out to be "no effect":
+
+- **`extract.build`** — the six builders sealed into arrays. It was the suspect, because the five
+  scopes did not add up to the phase on bo3 (about a fifth unattributed) while covering cod4 to
+  within one percent. It is 2 ms on bo3 and 5 on cod4. The gap was noise, not a stage.
+- **`extract.invocations`** — the pre-walk loop over every macro invocation the preprocessor saw,
+  headers included, to keep the few from this file. Under 0.5 ms on both. The shape is wrong (its
+  cost is set by what was INSERTED, not by the file) and it does not matter at these sizes.
+
+### 2026-08-22: the two unsharded gates, which cost nothing
+
+`LanguageStore.Upsert` takes a striped path gate and then calls four indexes. Two were sharded in
+the COMMIT GATE pass below; `NamespaceIndex` and `ClassGraph` still hold one process-wide `Lock`
+each, taken by every commit AND by the readers a keystroke uses. The same scaling argument that
+justified sharding the other two applies to them on paper, so they were measured before anything
+was done about it. One scope per index, inside the path gate, two cold-index runs each:
+
+| of cold-index thread-time | bo3 | cod4 |
+|---|---:|---:|
+| `commit.upsert` | 9.4% / 6.1% | 10.2% / 8.2% |
+| `upsert.reference` *(sharded)* | 5.0% / 2.8% | 6.1% / 5.4% |
+| `upsert.declaration` *(sharded)* | 0.7% / 0.3% | 0.4% / 0.1% |
+| **`upsert.class`** *(one lock)* | **0.5% / 0.3%** | **0.0% / 0.0%** |
+| **`upsert.namespace`** *(one lock)* | **0.1% / 0.1%** | **0.3% / 0.0%** |
+
+**Together they are 0.1–0.8%, and 9–10 ms per run.** Sharding them would buy nothing measurable and
+add two more shard arrays to maintain. Not done, and this is the record of why — the next person to
+notice a process-wide lock in the commit path should read this row before opening the file.
+
+It also settles where the commit cost actually is: `upsert.reference` is half to two thirds of
+`commit.upsert` on both dialects, and it is already sharded 64 ways. What is left there is the work
+itself — a file's diff is thousands of keys — not contention.
+
+### 2026-08-22: the cache costs 70 ms of STARTUP, and it is the open
+
+`Program.cs` does four things between `OnStarted` firing and the indexing task being queued: sweeps
+the legacy cache directory, hashes the bundled data files into a build identity, opens the database,
+and reads the blobs. All four are ahead of the `Task.Run`, so they are startup latency the user
+waits through rather than indexing, and the server's log rolls them into one `cache 0.1s` figure
+that cannot say which to attack. `CacheOpen_WhereTheStartupTimeGoes` splits them.
+
+| bo3, empty database | first run in a cold process | warm |
+|---|---:|---:|
+| legacy sweep | 3.5 ms | 2.9–3.3 ms |
+| build identity (3.9 MB hashed) | 6.6 ms | 5.7–7.2 ms |
+| **open** | **231.8 ms** | **59.7–64.3 ms** |
+| `LoadAll` | 0.6 ms | 0.4–0.6 ms |
+| **total** | **242.5 ms** | **68.7–75.4 ms** |
+
+**It is the open, by 85–95%, and neither of the two things that look expensive.** Hashing 3.9 MB of
+JSON is 6 ms and the blob read is under one — on a POPULATED database `LoadAll` is 13–54 ms, which
+is still not the headline.
+
+A second `SqliteCache.Open` in the same process costs 27–31 ms against the first one's 60, so about
+half of a warm open is `Microsoft.Data.Sqlite` initialising its native provider on first use — an
+assembly load, a native library load and the JIT behind them. The server opens exactly one cache, so
+it pays that half every start. The 232 ms figure is the same work with the provider's native library
+cold in the OS file cache, which is what a user's first start after an update actually gets.
+
+Against `Ready 1.3 s`, that is 5% warm and 18% cold, all of it serial and all of it in front of an
+indexing pass that could have been running. Moving the block inside the `Task.Run` takes every
+millisecond of it off the startup thread. **Not done here**, because `cacheHolder.Set` would then
+land ~70 ms later than it does, and a `gscode/clearCache` arriving in that window would be told
+"No workspace cache is open" while the cache opened behind it — leaving a cache the user asked to
+delete. That wants a readiness handshake in `CacheHolder`, which is a change to make deliberately
+rather than as a side effect of a timing fix.
+
+### 2026-08-22: enumeration and analysis still do not overlap
+
+`IndexAsync` materialises the whole target list before `Parallel.ForEachAsync` starts, and
+`EnumerateFilesWithExtensions` is itself eager — it fans out across top-level subdirectories and
+returns a `List`. So the find stage runs to completion with no CPU in flight, and then the analysis
+runs with no I/O in flight.
+
+What that costs depends entirely on the workspace, which is why the three figures below look like
+they disagree:
+
+| | `index.enumerate` | of cold-index WALL |
+|---|---:|---:|
+| bo3 corpus (`share\raw`) | 40–44 ms | 7.5% |
+| cod4 corpus (`raw`) | 11 ms | 2.2% |
+| **bo3 as a whole install, from a real server log** | **742 ms** | **more than half a start** |
+
+The corpus rows are the floor and the server row is the case the pruning work below was done for: a
+workspace folder that is the game install is 295,640 files to find 1,105 scripts. Against an analyse
+phase of roughly 500 ms, overlapping the two would take that start from about 1.25 s to about 0.8.
+
+**Not done here**, and the obstacle is not the plumbing. `progress.Started(targets.Count)` needs the
+total up front, and a streamed enumeration does not have one until it finishes — so overlapping
+means the client's indexing progress becomes indeterminate until the walk completes, which is a
+change to what the status bar shows rather than a change to how fast anything is. Worth doing, worth
+deciding first.
 
 ## Sub-phases: inside `parse`
 
@@ -770,9 +909,17 @@ Three runs of identical code and methodology, cod4:
 | max | 49.3 ms | 55.8 ms | 51.9 ms |
 | extract share | 17% | 16% | 16% |
 
-**Shares are stable to about a point; absolutes swing by a quarter.** The noise is largely common to
-all four phases, so it cancels in a ratio and does not in a total. Read shares, sub-phase ratios and
-order-of-magnitude differences as real, and treat any single absolute number as indicative.
+**Corrected 2026-08-22: shares are stable to about a point in THIS table and nowhere else.** The
+three runs above hold `extract` to 17 / 16 / 16, and that reading was generalised into a rule the
+rest of the file then leaned on. Five later runs, cod4 and bo3, put `extract` at 27 / 21 / 22 / 17 /
+25 and `lex` at 32 / 42 / 45 / 45 / 35 — five and ten points, on one build. `parse` is the only
+phase that holds to a point or two across both sets, and one phase behaving is not the four
+behaving. See the section on it near the top of this file.
+
+What survives is the shape of the argument, not the number in it: the noise is largely common to all
+four phases, so it cancels in a ratio further than it does in a total, and absolutes swing by a
+quarter to a third. Read order-of-magnitude differences and sub-scope milliseconds as real, and
+treat both a single absolute AND a single-digit share move as indicative.
 
 The practical consequence: this harness will find a structural problem — it caught a quadratic doc
 lookup that was half of extraction — and will NOT settle a 10% constant-factor tune. Measuring one of
@@ -816,6 +963,8 @@ The scopes, and what a high figure means:
 | `extract.doc` | doc-comment association for one declaration | should be flat per call; if it scales with file size, something is scanning |
 | `extract.macros` | macro definitions and uses to references | proportional to `#define`/`#insert` use |
 | `extract.duplicates` | the duplicate-function report | dictionary-keyed, should stay near zero |
+| `extract.invocations` | keeping this file’s macro invocations out of the inserted ones | set by what was INSERTED, not by the file; well under a millisecond on every corpus |
+| `extract.build` | the six builders sealed into immutable arrays | sized by what the file REFERENCES; added because the scopes above did not add up to the phase on bo3, and it turned out they did — the gap was noise |
 
 ### What this found
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -108,6 +108,51 @@ sources covering each changed path plus 4,000 seeded-random strings over a GSC a
 after, 182,821 lines byte-identical. The corpus sweep then reported the same counts on both sides —
 2 of 894 on cod4, 2 of 980 on bo3, 6 of 2,960 on bo1, with the formatter's gates clean.
 
+## Sub-phases: inside `parse`
+
+`parse` has been the largest analysis phase since the lex work landed, and until 2026-08-19 nothing
+measured inside it — `extract` had five scopes and the parser had none, so "parse is a third of
+analysis" was the end of the story rather than the start of one.
+
+Three scopes, all in instrumented builds only:
+
+| scope | covers | reads as |
+|---|---|---|
+| `parse.function` | one function declaration, parameters and body | the bulk of parsing; declarations do not nest |
+| `parse.class` | one class, its members included | rare on bo3 — 38 of them — and nested `parse.function` scopes are inside it |
+| `parse.expression` | one OUTERMOST expression, entered from a statement | the share of parsing that is expressions rather than structure |
+
+`parse.expression` counts only the outermost entry, by a depth counter that exists in instrumented
+builds alone. A scope at every level would nest inside itself, and the report sums nested scopes, so
+`a + b * c` would be charged once per level of its own depth.
+
+Two instrumented runs on bo3, 980 files:
+
+| | run 1 | run 2 |
+|---|---:|---:|
+| analysis total | 1,608 ms | 1,276 ms |
+| `parse` share of phases | 26% | 29% |
+| `parse.function` (15,601 calls) | 395 ms | 357 ms |
+| `parse.expression` (151,568 calls) | 294 ms | 228 ms |
+| `parse.class` (38 calls) | 23 ms | 11 ms |
+
+**Parsing is function bodies, and two thirds of a body is expressions.** `parse.function` accounts
+for essentially the whole phase, and `parse.expression` is 62–74% of that, over 151,568 outermost
+expressions — about 155 per file. The call counts are identical between runs, which is what makes
+the two comparable at all.
+
+Nothing here is superlinear, so there is no repeat of the doc-lookup find. The candidate the numbers
+DO name is the precedence chain: `ParseExpression` descends `ParseTernary`, ten levels of
+`ParseBinary`, `ParseUnary`, `ParsePostfix` and `ParsePrimary` before it can return, so a bare
+identifier still pays for the full descent — around fifteen frames to parse one token. A
+fast path there is the next thing to try in this phase, and it is a change to the parser's core, so
+it wants the token-stream pinning the lexer work used rather than a corpus sweep alone.
+
+The scope timings are inflated by their own instrumentation more than most: `parse.expression` runs
+151,568 times per sweep, so its `Begin`/`End` pair is a larger fraction of what it reports than for
+a scope that runs once per file. Read the SHARE, and do not compare these milliseconds with an
+uninstrumented total.
+
 ## Measured: the CROSS-FILE LINTS, which cost more than the parse
 
 The table above times `ScriptAnalysis.Analyze` only. Everything the editor runs ON TOP of that

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -293,6 +293,47 @@ whole-tree walk allocates zero bytes, which is the property the struct exists fo
 This is NOT an index-path change. Outside the lints, `ChildrenOf` serves rename, references, inlay
 hints and the parameter typer, all per-request; indexing does not call it.
 
+### 2026-08-19: the flow typer's environment cloning is NOT worth attacking
+
+`FlowTyper` clones the whole local environment at nine sites — both arms of an `if`, both
+`isdefined` narrowings, a dev block, each loop body, each `switch` case, and the no-default path —
+so the obvious guess is that a function with branchy control flow pays O(branches × locals) copies
+on every keystroke. It is now the most expensive single rule in the lint pass, since
+`PreferBooleanLiteralLint` runs first and therefore carries the shared inference walk.
+
+**Measured, and the guess was wrong.** A counting probe around `Clone`:
+
+| | bo3, 862 files |
+|---|---|
+| clones per sweep | 71,862 (about 83 per file) |
+| of those, an EMPTY environment | 7,727 |
+| fewer than 8 entries | 49,713 |
+| 8 or more | 14,422 |
+
+Nine tenths of the clones copy fewer than eight entries. The scope reported 62–93 ms, and most of
+that is the probe's own `Begin`/`End` pair on a path that runs 72,000 times — a sub-hundred-nanosecond
+copy cannot be measured by a mechanism that costs more than the thing it measures. There is no
+structural cost here to remove, so no persistent map, copy-on-write scope chain or undo journal was
+built: each would add real complexity to buy a slice of something too small to see.
+
+Two other things this settled, both worth not retrying:
+
+- **The walk types each expression once.** `TypeExpressionForEffects` and `TypeOf` were suspected of
+  typing an assignment's value twice — they do not, and a double-typing would have been the find.
+  What remains is genuine per-expression work: the type switch, the environment lookups, and the
+  `_recorded` insert.
+- **Case-insensitive hashing is not the lever either.** GSC names are case-insensitive so every
+  environment is `StringComparer.OrdinalIgnoreCase`, which hashes far more slowly than `Ordinal`, and
+  interning names to a canonical form would allow the cheap comparer. Swapping the comparer as a
+  measurement (semantically wrong, so measurement only) reported 399 and 481 ms against a clean
+  order-balanced baseline of 340–395 ms — noise, in the wrong direction, and no signal to justify a
+  cross-cutting change to `NameTable` and every environment.
+
+What is left in the inference walk is `_recorded`: about 60 ms of it, from the before/after pair
+where `PreferBooleanLiteralLint` cost 279 ms without recording and 340 ms with it. Removing that
+means `TypeMismatchLint` getting its values without a whole-file map — which is the same shape as
+fusing rule work into one walk, and belongs with that change rather than here.
+
 ## Measured: COMPLETION, and why it is NOT worth optimising
 
 `CorpusPerfTests.Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -1088,6 +1088,100 @@ timeline reconstruction.
 more when cold, since it is directories not visited at all, but no cold measurement is recorded here
 — dropping the Windows file cache is not something this harness does.
 
+## Measured: the WARM start, which was never timed and was slower than no cache at all
+
+Every figure above this line is a cold index. The warm path — the one a user takes on every start
+after their first — had one recorded number, 2.6 s, read off the server's log by hand before the
+server GC, the pruned enumeration and the one-pass reader landed. Nothing re-measured it, and
+`ColdIndex_WhereTheTimeGoes` says why in its own comment: it attaches no cache on purpose, because
+"a warm run measures the restore path instead, which is a different question with a different
+answer". The question was then never asked.
+
+It could not have been answered from the server either. `Program.cs` called
+
+```csharp
+indexer.UseCache(workspaceCache, workspaceCache.LoadAll());
+```
+
+and `LoadAll` is an ARGUMENT, so it ran to completion before the stopwatch that times indexing was
+started. The whole restore was outside every measurement the server takes and outside the
+`(find …, analyse …)` split that was added to make indexing legible.
+
+`WarmIndex_WhereTheTimeGoes` now times it. Each game indexes once into a fresh database, drains the
+writer, then throws everything away except the file and indexes again with a new resolver, NameTable
+and store — so only the database crosses between the two runs. Uninstrumented, one run, cold control
+taken in the same process minutes apart:
+
+| | files | cache read | index | **warm start** | cold index |
+|---|---:|---:|---:|---:|---:|
+| bo3 | 1,085 | 1,509 ms | 150 ms | **1,659 ms** | 390 ms |
+| cod4 | 904 | 720 ms | 242 ms | **962 ms** | 236 ms |
+| bo1 | 2,963 | 2,747 ms | 473 ms | **3,220 ms** | 718 ms |
+
+**The cache made startup four times slower than not having one.** The restore was 85–91% of a warm
+start, all of it on one thread — gzip inflation and a JSON parse per record — in front of a parallel
+index that does the entire job from source in 390 ms. The two arms of the fork had diverged: every
+optimisation of the last month landed on the cold one, and the warm one was still doing 2016's work
+on a single core.
+
+### What changed, and what it was worth
+
+Two changes, in that order. The first is obvious and the second is the one that matters.
+
+**Deserializing in parallel.** `RecordSerializer.Deserialize` touches no shared state, so the rows
+come off the connection serially — `SqliteDataReader` is not thread-safe and a blob is valid only
+until the next `Read` — and the expensive half fans out at `ProcessorCount - 1`. Restore fell to
+410 / 554 / 599 ms. That is 3.7x on bo3 and 4.6x on bo1, and it still did not beat the cold index on
+any of the three.
+
+**Not deserializing at all until the file is known to be current.** The freshness check is a content
+hash, `content_hash` has been its own column since the schema was written, and the indexer already
+had the file's text in hand on a parallel worker. So `LoadAll` now returns `CachedEntry` — the hash
+and the blob, unopened — and the inflate and parse happen inside the indexer's per-file loop, behind
+the check. A file that changed costs one hash and never touches its blob.
+
+| | files | cache read | index | **warm start** | cold index |
+|---|---:|---:|---:|---:|---:|
+| bo3 | 1,085 | 13 ms | 464 ms | **477 ms** | 369 ms |
+| cod4 | 904 | 27 ms | 510 ms | **537 ms** | 210 ms |
+| bo1 | 2,963 | 54 ms | 847 ms | **902 ms** | 813 ms |
+
+**3.5x, 1.8x and 3.6x on the warm start**, and the serial stage is gone: 13–54 ms to read the blobs,
+against 720–2,747 ms to read and materialise them.
+
+### The cache still does not pay for itself on this machine, and the reason is the format
+
+Read the last two columns rather than the improvement. A warm start is still no faster than a cold
+one on a 24-core box — 477 against 369 on bo3, 537 against 210 on cod4, 902 against 813 on bo1.
+
+The instrumented breakdown says why. `index.restore` is now 90–98% of warm thread-time: 9,086 ms on
+bo3 across 1,085 files, which is the same order as the analysis it replaces. **Inflating and parsing
+a record costs about what lexing, preprocessing, parsing and extracting the source costs.** The cache
+is not saving work so much as trading one parse for another.
+
+That leaves it earning its place only on the machines where total CPU matters more than wall-clock —
+restore is roughly 5x less thread-time than analysis, so a four-core laptop still wins where a
+twenty-four-core desktop breaks even. Which is a reason to keep it, not a reason to be pleased with
+it.
+
+**Gzip is not the cost, and was measured rather than assumed.** Storing the JSON uncompressed:
+
+| | warm start, gzipped | uncompressed | cache file |
+|---|---:|---:|---|
+| bo3 | 477 ms | 489 ms | 21.0 → 106.0 MB |
+| cod4 | 537 ms | 654 ms | 23.0 → 132.5 MB |
+| bo1 | 902 ms | 913 ms | 63.6 → 328.4 MB |
+
+Flat to worse, for five times the disk. The compression was reverted. The remaining lever, if the
+cache is ever to beat a cold index outright, is the JSON itself — a compact binary record, not a
+different compressor. Nobody should reach for that without re-running the table above first: on a
+machine with fewer cores the cold column moves and the conclusion with it.
+
+### What this does NOT change
+
+The cold index, the phase shares, the lint pass and completion are all untouched — this is the other
+arm of the fork. The keystroke path never reads the cache at all.
+
 ## Reading the reports
 
 Each game writes `temp/gscode-perf-<game>.html`; `GSCODE_PERF_REPORT` overrides the directory.
@@ -1170,7 +1264,11 @@ in-process, while the server indexes cold at `ProcessorCount - 1`:
 2. Launch the extension against the tools root (see the client `.env` debug flow, or install the
    packaged extension).
 3. For cold vs warm: delete `%APPDATA%\gscode\cache\*.db`, start once (cold), restart (warm), and
-   read the "indexing complete" line each time.
+   read the "indexing complete" line each time. That line now splits out `cache`, so a warm start is
+   readable without a second measurement.
+
+   The harness answers the same question without the editor: `WarmIndex_WhereTheTimeGoes` populates a
+   database, drains the writer and indexes again, reporting the cache read and the index separately.
 4. For the steady-state working set, hover the status bar once the process settles. That is the only
    readout — it is pushed as a notification, not logged.
 
@@ -1218,7 +1316,8 @@ Measured on the local BO3-tools machine (corpus not committed):
 | Scenario | Corpus size | Measured | Budget | Within budget |
 |---|---|---|---|---|
 | Cold index | 1,105 files | 5.5 s | < 60 s | yes |
-| Warm start | 1,105 files | 2.6 s | < 5 s | yes |
+| Warm start *(stale; see the warm-start section)* | 1,105 files | 2.6 s | < 5 s | yes |
+| Warm start, harness, 2026-08-20 | 1,085 files (bo3) | 477 ms | < 5 s | yes |
 | Steady-state memory (cold, before compaction) | 1,105 files | 390.3 MB | < 400 MB | just inside |
 | Steady-state memory (warm) | 1,105 files | 212.2 MB | < 400 MB | yes |
 | Live managed set (either path) | 1,105 files | ~115 MB | — | — |

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -167,16 +167,65 @@ expressions — about 155 per file. The call counts are identical between runs, 
 the two comparable at all.
 
 Nothing here is superlinear, so there is no repeat of the doc-lookup find. The candidate the numbers
-DO name is the precedence chain: `ParseExpression` descends `ParseTernary`, ten levels of
-`ParseBinary`, `ParseUnary`, `ParsePostfix` and `ParsePrimary` before it can return, so a bare
-identifier still pays for the full descent — around fifteen frames to parse one token. A
-fast path there is the next thing to try in this phase, and it is a change to the parser's core, so
-it wants the token-stream pinning the lexer work used rather than a corpus sweep alone.
+DO name is the descent: `ParseExpression` reaches `ParsePrimary` through `ParseExpressionCore`,
+`ParseTernary`, `ParseTernaryCore`, `ParseBinary`, `ParseCallChain`, `ParseUnary`, `ParseUnaryCore`
+and `ParsePostfix`, so a bare identifier pays eight calls and three `EnterNesting`/`ExitNesting`
+pairs to produce one node. A fast path there was the next thing to try in this phase, and being a
+change to the parser's core it wanted the token-stream pinning the lexer work used rather than a
+corpus sweep alone. It is done, below.
+
+**Corrected 2026-08-20.** That paragraph used to say "ten levels of `ParseBinary` … around fifteen
+frames". It was wrong for as long as it stood: `ParseBinary` is precedence CLIMBING — one method
+with a loop and a `ParseBinary(precedence + 1)` back edge — not ten nested methods, and the back
+edge only fires when an operator is actually there. Nothing was decided on the strength of the wrong
+number, but it overstated the prize by roughly half, which is what a figure nobody re-derives does
+over time.
 
 The scope timings are inflated by their own instrumentation more than most: `parse.expression` runs
 151,568 times per sweep, so its `Begin`/`End` pair is a larger fraction of what it reports than for
 a scope that runs once per file. Read the SHARE, and do not compare these milliseconds with an
 uninstrumented total.
+
+### 2026-08-20: the leaf fast path, which the sweep cannot see and a repetition bench can
+
+Most expressions in a script are one token. `foo( a, 1, "x" )` is three expressions and not one of
+them has an operator in it; nor does an array index, nor the right side of a field assignment. Each
+took the whole descent above.
+
+`ParseExpressionInner` now takes the nesting claim, and then — when the NEXT token is `,` `)` `]` or
+`;` and the current one is a name or a literal — builds the node directly. The follower set is the
+whole argument, and it was checked one skipped level at a time rather than assumed: none of those
+four is an assignment operator, none is `?`, none has a binary precedence, none begins a method call
+(that needs `thread`, `childthread`, `call`, an identifier or `[[`), and none is a postfix operator,
+so `.` `[` `(` `++` `--` `->` are all excluded. The two lookahead forms `ParsePrimary` would check
+for, `name::name` and an inline `path
+ame`, both need a token these four are not. `:` is left out
+deliberately: a ternary's arms and a `case` label go through `ParseTernary`, not through here.
+
+**The corpus sweep cannot measure this, and that is as much the finding as the change is.** Three
+instrumented baseline runs put `parse.expression` at 220, 211 and 97 ms, with call counts identical
+to the digit; four runs of the changed build gave 96, 193, 223 and 215. The two distributions sit on
+top of each other. This is the warning further down — the harness finds structural problems and does
+not settle constant factors — arriving in practice rather than in principle.
+
+What settles it is repetition, which the sweep deliberately does not do: preprocess BO3's 60 largest
+files once, then parse those token streams 20 times per trial, five trials, with a forced collection
+between them. Two sessions each side, first trial dropped as tiered-JIT warm-up:
+
+| | trials |
+|---|---|
+| before | 441 / 433 / 438 / 447 / 454 / 457 / 445 / 452 / 435 ms |
+| after | **412 / 399 / 407 / 406 / 398 / 396 / 397 / 399 / 399 / 398 ms** |
+
+**Roughly 11% off the parse phase, and the two ranges do not overlap.** Read it as a parse-phase
+number and not an analysis one: parse is 26–29% of analysis, so this is about 3% of a file's
+analysis and invisible in anything downstream of it.
+
+Behaviour was pinned the way the lexer work was, since a parser that is faster and wrong is worth
+nothing. Every node of every parse tree — its type and its start and end position — plus every
+parser diagnostic was dumped for all five game corpora on both sides: **11,122,507 lines, byte
+identical.** The `Category=Corpus` gates then passed in 1 m 14 s, and the 779 parser unit tests with
+them.
 
 ## Measured: the CROSS-FILE LINTS, which cost more than the parse
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -988,41 +988,56 @@ Measured on bo3, 1,085 files, uninstrumented, two runs per configuration:
 | Workstation, gen0 budget raised to 16 MB | 2,016 / 2,112 ms |
 | Workstation, gen0 budget raised to 64 MB | 1,553 / 1,526 ms |
 | Workstation, gen0 budget raised to 256 MB | 1,336 / 1,406 ms |
-| **Server GC, 8 heaps** | **601 / 602 / 702 ms** |
+| **Server GC, 4 heaps (shipped)** | **768 / 768 ms** |
+| Server GC, 8 heaps | 564 / 638 / 601 / 602 / 702 ms |
 | Server GC, 12 heaps | 722 / 632 ms |
 | Server GC, unbounded (24) | 768 / 733 ms |
-| Server GC, 4 heaps | 1,315 / 1,237 ms |
 | Server GC, 2 heaps | 1,051 / 1,333 ms |
+
+The 4-heap row was first measured at 1,237–1,315 ms and re-measured at 768 ms twice in a later
+session; the earlier pair was taken while the machine was drifting, which the control groups
+elsewhere in this file caught doing the same thing. The later pair is quoted because it is repeated
+and because the memory table below was taken alongside it.
 
 **Roughly 3.4x, and the gen0 rows are what identify the cause.** Raising the collection budget by
 16x on Workstation recovers only a third of the gap, so the problem is that the threads share one
 heap rather than that they collect too often. `ConserveMemory` costs nothing here and stays.
 
-### Why eight heaps and not one per core
+### Why four heaps and not one per core
 
-Unbounded is not faster — 733–768 ms against 601–702 — and it costs memory, because each heap keeps
-its own large-object heap:
+Unbounded is not faster — 733–768 ms against 601–702 for eight — and above eight each heap's own
+large-object heap starts showing up as fragmentation. The heap count buys throughput with the memory
+the server RESTS at, which for a process that sits open all day is the number worth protecting:
 
-| | live | fragmented | LOH free/size | working set |
+| | cold index | live | fragmented | resting working set |
 |---|---:|---:|---:|---:|
-| Workstation (before) | 51.1 MB | 0.1 MB | 0.0 / 9.8 MB | 127 MB |
-| **Server, 8 heaps** | **51.1 MB** | **0.7 MB** | **0.0 / 9.8 MB** | **281 MB** |
-| Server, 12 heaps | 51.0 MB | 48.6 MB | 47.9 / 57.7 MB | 396–413 MB |
-| Server, unbounded | 51.1 MB | 34.9 MB | 34.3 / 44.1 MB | 247 MB |
+| Workstation (before) | 2,177 / 2,182 ms | 51.1 MB | 0.1 MB | 127 MB |
+| **Server, 4 heaps** | **768 / 768 ms** | **51.0–51.1 MB** | **0.6–0.7 MB** | **200–201 MB** |
+| Server, 8 heaps | 564 / 638 ms | 51.0–51.1 MB | 0.6–0.7 MB | 281 MB |
+| Server, 12 heaps | 632 / 722 ms | 51.0 MB | 48.6 MB | 396–413 MB |
+| Server, unbounded (24) | 733 / 768 ms | 51.1 MB | 34.9 MB | 247 MB |
 
-**Retained memory does not move at any setting** — 51.0–51.1 MB live, identical to Workstation, with
-the same 641 GSC and 325 CSC records held. That was the constraint the `ArrayPool` attempt failed and
-this one meets: nothing is being retained that was not retained before.
+**Four is the setting that ships.** It keeps most of the speedup — 2.8x against eight's 3.5x — for
+half the extra footprint, and the difference between them is 150–200 ms on a path that runs once at
+startup against 80 MB the process holds for as long as it is open. Eight is the right answer if a
+cold index is ever the thing being waited on; the resting set is what a user actually lives with.
 
-**The cost is working set: 127 MB → 281 MB.** That is pages the runtime has not returned rather than
-objects being held, and it is the honest price of this change. Two things to know about the figure:
-the probe never runs the post-index LOH compaction that `Program.cs` performs at the indexing →
-serving transition, which is exactly the mechanism that returned 446 MB on bo1 above; and eight heaps
-is the setting where fragmentation stays at Workstation levels, so there is nothing for a compaction
-to reclaim beyond the pages themselves. Confirm the served number from the status-bar tooltip rather
-than from this table.
+**Retained memory does not move at any setting** — 51.0–51.1 MB live, identical to Workstation, the
+same 641 GSC and 325 CSC records held. That was the constraint the `ArrayPool` attempt failed and this
+one meets: nothing is retained that was not retained before. Fragmentation does not move either, at
+four or eight.
 
-`System.GC.HeapCount` is set in both `runtimeconfig.template.json` files — the server's and the test
+**Neither does the PEAK.** Both settings measure 436–464 MB immediately after indexing and drain to
+their resting figure within about five seconds, so the difference is entirely in what the runtime
+gives back, not in what the index costs to run.
+
+Two caveats on the working-set column: the probe never runs the post-index LOH compaction that
+`Program.cs` performs at the indexing → serving transition, which is the mechanism that returned 446
+MB on bo1 above; and at four or eight heaps fragmentation is already at Workstation levels, so there
+is nothing for a compaction to reclaim beyond the pages themselves. Confirm the served number from
+the status-bar tooltip rather than from this table.
+
+`System.GC.HeapCount` is 4, set in both `runtimeconfig.template.json` files — the server's and the test
 project's — so the probe keeps measuring what ships. **Unverified on a machine with fewer than eight
 cores**: the runtime is expected to clamp the count to the processor count, and that has not been
 tested here.

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -485,6 +485,10 @@ the three queries that scan every record to find the ~20 a `#using` list names. 
 first; the reason it exists is that the same reasoning predicted a problem here and was wrong about
 the size of it.
 
+**The `NamespaceIndex` half was built on 2026-08-19** — for `ArgumentCountLint`, which asks the same
+question on a path that is not completion — and completion got a 2x out of it anyway. See the
+section below; the `RelativePathIndex` half is still unbuilt and still unmeasured.
+
 ### Reading the entry-count line
 
 The sweep also reports how many entries came back, and that line is what makes the timings
@@ -520,6 +524,51 @@ the macro half is empty, and its scripts assign through `level.` rather than to 
 sampled functions in `animscripts\battlechatter.gsc` declare 12, 15 and 7 assignments and only 1, 1
 and 2 of them are locals. Two entries per request is not a measurement. That the numbers barely
 moved there is the expected answer, not a sign the feature is missing on that dialect.
+
+### 2026-08-19: the namespace index, built for a lint and paid off in completion
+
+`DatabaseQueries.FunctionsInNamespace` walked every record and every function in each — about 30,000
+symbols on BO3 — keeping the few dozen in one namespace, and it is asked once per namespace a file
+can see. `NamespaceIndex` maps a namespace to the files declaring into it, maintained in
+`LanguageStore.Upsert` beside the declaration and reference indexes, so the query reads a few dozen
+records instead of the store.
+
+It was built for `ArgumentCountLint`, the most expensive rule left in the lint pass after the shared
+walk landed. Three A/B pairs, order alternated:
+
+| | base | with the index |
+|---|---|---|
+| `ArgumentCountLint` | 209–241 ms | **162–205 ms** (median −20%) |
+| lint pass total | 1,513–1,547 ms | 1,419–1,534 ms |
+
+That is a real but noisy win: the three pairs read −33%, −11% and −11%, so the median is worth more
+than any one of them.
+
+**Completion is the result that matters, and it was not the target.** Same three pairs, bo3, 6,381
+requests each side with the count identical to the digit:
+
+| | base | with the index |
+|---|---|---|
+| median | 0.45–0.46 ms | **0.35–0.36 ms** |
+| p90 | 2.09–2.25 ms | **1.11–1.19 ms** |
+| p99 | 5.03–5.23 ms | **2.46–2.57 ms** |
+| total | 5,633–5,794 ms | **2,996–3,030 ms** |
+
+**A 2x, with non-overlapping bands on every statistic** — the cleanest measurement in this file. It
+is exactly the quadratic the completion section above predicted and declined to fix: statement-scope
+completion on the namespace dialect calls `FunctionsInNamespace` once per own namespace plus once per
+imported namespace, and each of those calls used to read the whole store.
+
+The reasoning that declined it still stands, and is worth keeping straight: a p99 of 5 ms was fifty
+times inside the debounce, so fixing it for completion's sake would have bought the user nothing. The
+index is here because a second caller asked the same question, and the completion improvement is a
+side effect of a change that had its own justification. That is the distinction to preserve when the
+`RelativePathIndex` comes up — it needs its own caller and its own measurement, not this result as a
+precedent.
+
+Findings unchanged: the bo3 `Category=Corpus` sweep prints byte-identical output, which also settles
+the one behavioural risk. The query returns records in index order now rather than store order, and
+nothing downstream depends on that order.
 
 ## Measured: COLD INDEXING, the first-run path
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -628,9 +628,10 @@ and are listed but never added to the total.
 
 Achieved parallelism is 20.6–21.0x against a ceiling of 23. Three things this settles:
 
-- **Enumeration is not the bottleneck.** The `roots × globs` duplicate walk in
-  `PathResolver.EnumerateIndexTargets` costs 121–130 ms on BO3 and 30 ms on CoD4. Removing the
-  duplication entirely would save perhaps 85 ms of a 2,100 ms run.
+- **Enumeration is not the bottleneck** — **true only of the corpus fixture; see the section on
+  FINDING the files.** The `roots × globs` duplicate walk in `PathResolver.EnumerateIndexTargets`
+  costs 121–130 ms on BO3 and 30 ms on CoD4 when the root is a `raw` folder. A real workspace folder
+  is often the game INSTALL, and then enumeration is the largest single cost in a cold index.
 - **`index.commit` is the one worth attention**, and much more so on CoD4 — a fifth to a quarter of
   thread-time against BO3's tenth. That is `BuildRecord` plus `LanguageStore.Upsert`, which takes one
   process-wide write gate and holds it across per-file hashing in three index diffs. A global lock is
@@ -1033,6 +1034,59 @@ probe's table.
 The phase shares, the lint pass and completion are all measured by sequential sweeps, so none of
 them moves: this is a change to what happens when 23 threads allocate at once. The keystroke path
 allocates on one thread and was never contended.
+
+## Measured: FINDING the files, which a corpus fixture cannot see
+
+Every enumeration figure in this file was taken with a `raw` folder as the root, because that is
+what `GSCODE_CORPUS_<GAME>` points at. A user's workspace folder is whatever they opened in the
+editor, and for a modder that is routinely the game install — at which point `OutermostRoots` drops
+the derived `raw` and `mods` roots as contained by it, correctly, and the walk covers everything:
+
+| | files | directories |
+|---|---:|---:|
+| bo3 `share\\raw` | 6,831 | 426 |
+| bo3 `mods` | 787 | 309 |
+| **the whole install** | **295,640** | **12,776** |
+| of which `share\\assetconvert` | 170,328 | |
+| of which `texture_assets` | 4,329 | |
+
+**295,640 files walked to find 1,105 scripts.** It was reported as part of "indexing", so it read as
+slow analysis; the log line said 2.8 s and the analysis was under half a second of it.
+
+Two changes, measured on that install, warm, two runs each — all four variants return the same 1,105
+files:
+
+| | enumeration |
+|---|---:|
+| as it was | 741–792 ms |
+| fanned out across top-level subtrees | 483–504 ms |
+| skipping the two tool-output trees | 277–281 ms |
+| **both, as shipped** | **231–233 ms** |
+
+The pruning is what does it, and `assetconvert` plus `texture_assets` is the whole list:
+`GameProfile.ToolOutputDirectories`. `zone`, `sound` and `video` were measured too and are NOT
+skipped — they cost nothing on top of these two, and each is a name a mod could plausibly give a
+scripts folder. A directory wrongly skipped is a file that silently never gets indexed, which is a
+worse failure than a slow walk. The fan-out stays because it is free and helps a wide tree, but it
+is the smaller half: one subtree can hold most of the files, and here one does.
+
+End to end, driving the bundled server over stdio with the install as the workspace folder, the same
+shape the user's session has:
+
+```
+Workspace indexing complete: 1105 files in 0.7s (find 0.3s, analyse 0.4s at 22.1x, 0 from cache)
+Ready 1.4s after start
+```
+
+against 2.8 s before. **The split is now in the log**, which is the durable part of this: enumeration
+is serial and scales with the WORKSPACE, analysis is parallel and scales with the SCRIPTS, and the
+parallelism figure separates "each file is slow" from "the workers are not running". None of that
+was visible in a single "indexing complete" number, and working it out took a log file and a
+timeline reconstruction.
+
+**These are warm-cache figures.** The user's 2.8 s was a first walk of that tree; the pruning helps
+more when cold, since it is directories not visited at all, but no cold measurement is recorded here
+— dropping the Windows file cache is not something this harness does.
 
 ## Reading the reports
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -58,6 +58,33 @@ completion row admissible: 4,211 of 6,381 requests returned over 500 entries, me
 sample is still landing on the statement-scope arm that queries the store rather than on the cheap
 arms.
 
+### 2026-08-22: re-measured after the builtin library was rewritten
+
+The `t7` libraries grew by roughly 13,000 lines net when the unverified builtin docs were rewritten
+from call-site evidence and 115 signatures were corrected. Two paths read that data on every
+request — `ArgumentCountLint` and the completion producers — so the figures above were re-taken to
+find out whether the bigger library cost anything. It does not.
+
+| | 2026-08-19 | 2026-08-22, after the rewrite |
+|---|---:|---:|
+| lint pass, bo3, 980 files | 1,332 ms | **1,168 ms** |
+| lint median / p99 / max | 0.31 / 19.0 / 47.0 ms | **0.33 / 12.5 / 47.1 ms** |
+| completion, bo3, 6,381 requests | p99 2.12 ms, median 0.30 | **p99 1.64 ms**, median 0.29 |
+| `ArgumentCountLint`, bo3 | 162–205 ms | **144 ms** |
+
+An INSTRUMENTED run, where 2026-08-19 was not, so the two are not strictly comparable and the claim
+here is only the weak one it needs to be: nothing regressed. cod4's lint profile has moved
+underneath, and `UnusedIncludeLint` is now its most expensive rule at 215 ms, ahead of
+`NodeLintPass` at 182 ms.
+
+**One figure is left unexplained rather than claimed.** Analysis came in at 451 ms on bo3 and
+600 ms on cod4, against the 685 ms and 1,556 ms recorded above and in the phase table below — 30 to
+60% lower. Nothing in this branch went near lex, preprocess or parse, so a real improvement of that
+size has no mechanism, and a warm OS file cache is the likelier reading: the other three corpora had
+been swept half an hour earlier. This is the same shape as the extract claim retracted below, which
+is exactly why it is not being written down as a win. It wants a cold-cache pair before it means
+anything.
+
 ## Measured: where analysis time goes
 
 `--filter "Category=Perf"` times every script in a game individually and splits each into the four

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -677,9 +677,16 @@ and 980 scripts.
 ## Measured: COMPLETION, and why it is NOT worth optimising
 
 `CorpusPerfTests.Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced
-call sites per file, with a finished index, the parse done outside the stopwatch, and each position
-warmed before the timed run. One row per REQUEST rather than per file, because the question is
-whether one keystroke is answered in time and a per-file sum answers nothing anybody waits for.
+call sites per file **plus one file-scope position**, with a finished index, the parse done outside
+the stopwatch, and each position warmed before the timed run. One row per REQUEST rather than per
+file, because the question is whether one keystroke is answered in time and a per-file sum answers
+nothing anybody waits for.
+
+The file-scope sample was added on 2026-08-18 and the reason is worth keeping: the positions come
+from the extraction's call references, and a call only ever appears inside a function body, so the
+sweep measured one of completion's two arms and could not see the other at all. That was harmless
+while file scope returned a static word list before any store query ran, and stopped being harmless
+the moment it ran the same queries a body does.
 
 It was written expecting to find the lint problem again. `FunctionsInNamespace` walks the whole
 record store once **per namespace**, and on a namespace dialect statement-scope completion calls it
@@ -693,6 +700,9 @@ The shape is real and it is visible in the numbers. It does not matter.
 | bo3 (1,085 files, **namespace** dialect) | 6,381 | 0.42 ms | 2.03 ms | **4.22 ms** | 24.2 ms |
 | cod4 (904 files, merge dialect) | 6,944 | 0.20 ms | 0.34 ms | 1.03 ms | 16.4 ms |
 | bo1 (2,963 files, merge dialect) | 21,157 | 0.44 ms | 0.64 ms | 1.47 ms | 31.4 ms |
+
+The request counts in that table predate the file-scope sample, so a rerun now reports roughly one
+more per file (7,361 on bo3, 7,838 on cod4) — see the 2026-08-18 entry below.
 
 Reconfirmed 2026-08-12 on all three, and it is the most stable measurement in this file: bo3
 p99 4.26 ms, cod4 1.09 ms, bo1 1.57 ms, with the entry-count line identical to the digit. Nothing
@@ -734,7 +744,8 @@ section below; the `RelativePathIndex` half is still unbuilt and still unmeasure
 The sweep also reports how many entries came back, and that line is what makes the timings
 admissible rather than decorative. `Complete` has around ten arms and most return almost nothing —
 a path segment list, an asset type list, an empty result where the position was not a completion
-site. Only the statement-scope arm queries the store.
+site. Only the statement-scope arm queries the store, and since 2026-08-18 it serves file scope as
+well as bodies, so a file-scope sample lands on it rather than short-circuiting.
 
 At 66–74% of requests returning over 500 entries (median 847–1,404), the sample is landing on that
 arm. A sweep that quietly hit cheap arms would report fast completions and have measured nothing,
@@ -764,6 +775,38 @@ the macro half is empty, and its scripts assign through `level.` rather than to 
 sampled functions in `animscripts\battlechatter.gsc` declare 12, 15 and 7 assignments and only 1, 1
 and 2 of them are locals. Two entries per request is not a measurement. That the numbers barely
 moved there is the expected answer, not a sign the feature is missing on that dialect.
+
+### 2026-08-18: file scope gained the body's list, and the noise floor was measured
+
+File scope used to return keywords and snippets and nothing else — a `!insideFunction` early return
+sat above every store query — so completion outside a function body cost almost nothing and answered
+almost nothing. Removing it puts the macros, the functions in scope, the classes and the builtins at
+that position too, which is a real quantity of new work on a path with no debounce.
+
+Measured as a BEFORE/AFTER PAIR in one session on one machine, sampler change in both halves so the
+request sets are identical (7,361 bo3, 7,838 cod4):
+
+| | median | p90 | p99 |
+|---|---:|---:|---:|
+| bo3 before | 0.363 ms | 2.059 ms | 4.228 ms |
+| bo3 after | **0.473 ms** | 2.094 ms | 4.207 ms |
+| cod4 before | 0.195 ms | 0.342 ms | 1.008 ms |
+| cod4 after | 0.203 ms | 0.337 ms | 1.096 ms |
+
+**The median moves and the tail does not**, which is the shape to expect: file-scope requests were
+the cheap half of the sample and are now ordinary ones, while the p99 is set by the per-namespace
+store walk that this did not touch.
+
+**Read the median here with the noise floor in hand, because it is the same size as the effect.**
+Two later runs of IDENTICAL code — both with the function-pointer arm below in place, taken back to
+back — gave bo3 medians of 0.556 and 0.499 ms and p99s of 5.12 and 4.45 ms. So bo3 run-to-run spread
+is about ±0.06 ms at the median and ±0.7 ms at p99: the 0.11 ms above is real but only about twice
+the spread, and any future single-run comparison claiming less than that has measured the machine.
+CoD4 is the steadier of the two and its ±0.008 ms here says nothing either way.
+
+That pair is also the whole measurement of the function-pointer arm, which is why it has no row: at
+one to three token lookbacks per request it sits well under the floor, and the two runs bracket the
+before-figure in both directions.
 
 ### 2026-08-19: the namespace index, built for a lint and paid off in completion
 
@@ -809,6 +852,12 @@ precedent.
 Findings unchanged: the bo3 `Category=Corpus` sweep prints byte-identical output, which also settles
 the one behavioural risk. The query returns records in index order now rather than store order, and
 nothing downstream depends on that order.
+
+Both halves of this pair were taken with file scope still on the early return, so the absolute
+figures belong to the smaller list of the section above it rather than to the one shipping now. The
+2x is a ratio between two runs of the same tree and survives that; the millisecond values do not
+carry across to the section above, which is the same one-session-one-machine rule the rest of this
+file is read under.
 
 ## Measured: COLD INDEXING, the first-run path
 

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -334,6 +334,61 @@ where `PreferBooleanLiteralLint` cost 279 ms without recording and 340 ms with i
 means `TypeMismatchLint` getting its values without a whole-file map — which is the same shape as
 fusing rule work into one walk, and belongs with that change rather than here.
 
+### 2026-08-19: nine rules, one walk
+
+Nine lints each descended the whole file on their own to ask one question per node, so a
+thousand-node tree was traversed nine times to answer nine independent questions about each node.
+They qualified because each one's walk was PURE PASS-THROUGH — look at the node, recurse into every
+child unconditionally — which is what makes fusing them a rearrangement rather than a rewrite.
+`NodeLintPass` now visits each node once and asks all nine.
+
+Three A/B pairs, order alternated, instrumented, bo3:
+
+| pair | the nine rules | control (the other rules) | lint total |
+|---|---|---|---|
+| 1 | 1,151 → **703** ms | 1,115 → 1,476 ms | 2,299 → 2,199 ms |
+| 2 | 1,212 → **702** ms | 1,274 → 1,381 ms | 2,515 → 2,106 ms |
+| 3 | 1,176 → **719** ms | 1,237 → 1,472 ms | 2,448 → 2,224 ms |
+
+**−40% on the nine, and the after side is stable to 2%** — 703, 702, 719 — which is the tightest
+band anything in this file has produced. The lint total falls in all three pairs, median −10%.
+
+The after side splits into the flow typer's inference walk, which the pass carries because
+`TypeMismatchLint` needs it, and the nine rules' own per-node work:
+
+| | before | after |
+|---|---|---|
+| nine walks + inference | 1,151–1,212 ms | — |
+| `lint.NodeLintPass` (inference + nine judgements, one walk) | — | 578 ms |
+| `ConstDeclarationLint`'s declaration-level pass | inside its 184 ms | 132 ms |
+| `PreferBooleanLiteralLint`'s field writes | inside its 443 ms | 0.5 ms |
+
+Inference is roughly 400 ms of that 578, so the nine rules' walking and predicates together fell
+from about 750 ms to about 180 ms. That is the shape the bare-walk probe predicted: the traversal
+was nearly all of what these rules cost.
+
+**The control rose 8–32%, which is the second time that has happened** — the same pattern as the
+struct-enumerable change, in the same direction, on rules that were not touched either time. Two
+sightings make it a real property of this sweep rather than a coincidence, and it is still
+unexplained; a plausible reading is that rules running later meet a different cache and GC state
+once the rules ahead of them stop allocating and stop walking. It works against the measured win in
+both cases, so the target figures are floors.
+
+**What was left out, and why.** `ThreadedResultLint` threads a "value is consumed" flag down its
+descent. `UnusedLocalLint`, `UnusedBindingLint` and `UnassignedVariableLint` build per-function
+state, so their walk is scoped to a declaration rather than to the file. `ArgumentCountLint` and
+`DevBlockCallLint` carry a lookup cache and a namespace set, and the second reads reference entries
+rather than the tree. None of those is pass-through, so none of them is a rearrangement.
+
+Each rule keeps its own `Analyze`, which still walks on its own — that is what its unit tests
+exercise and what an offline caller with a single file uses — and the shared pass calls the same
+per-node methods, so there is one copy of each judgement rather than two that can drift.
+
+This change is what the sort in `WorkspaceLints.InReadingOrder` was for: fusing the walks
+interleaves the rules' findings, and without a sort the corpus sweep would have reported that as a
+difference. With it, the bo3 `Category=Corpus` sweep prints byte-identical output across 31 tests
+and 980 scripts.
+
 ## Measured: COMPLETION, and why it is NOT worth optimising
 
 `CorpusPerfTests.Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -1182,6 +1182,64 @@ machine with fewer cores the cold column moves and the conclusion with it.
 The cold index, the phase shares, the lint pass and completion are all untouched — this is the other
 arm of the fork. The keystroke path never reads the cache at all.
 
+## Measured: STARTUP, which is not indexing and had never been separated from it
+
+`Ready Ns after start` has been in the log for a while and every reading of it was attributed to
+indexing. It is not. Driving the published server over stdio against BO3's 1,105 scripts, warm
+cache, the two numbers in that log pair are:
+
+```
+Workspace indexing complete: 1085 files in 0.6s (cache 0.1s, find 0.0s, analyse 0.5s at 20.9x, 1,085 from cache)
+Ready 1.3s after start
+```
+
+**Half of a start is not indexing.** It is process creation, assembly loading, host construction and
+the JIT compiling the lex/preprocess/parse/extract pipeline on the way to its first file. Nothing in
+this document had ever looked at it, because every harness in `CorpusPerfTests` runs inside a process
+that is already up.
+
+### ReadyToRun
+
+`PublishReadyToRun` precompiles the IL, so the pipeline arrives already native. Five alternating
+runs of each build, warm cache, same machine and session:
+
+| | Ready | index inside it |
+|---|---|---|
+| framework-dependent, no RID (as shipped) | 1.3 / 1.3 / 1.3 / 1.3 / 1.3 s | 0.6 s |
+| `-r win-x64`, ReadyToRun | **1.0 / 0.9 / 0.9 / 1.0 / 1.0 s** | 0.5–0.6 s |
+
+**0.3–0.4 s, about a quarter of the start, and it does not vary.** The index inside is unchanged on
+both sides, which is what makes this attributable: the change cannot have made analysis faster, and
+it did not. The same gap appears whether the host is the apphost or `dotnet GSCode.Server.dll`,
+which is the form the extension actually launches.
+
+The first run of a freshly published R2R build reads 2.0 s rather than 1.0 — a bigger file, cold in
+the OS cache. Every reading here is warm, and the first-ever start on a user's machine pays that
+once either way.
+
+It also makes the bundle smaller, which precompiled native code does not obviously suggest:
+**48 MB → 29 MB.** A RID-less publish carries `runtimes/` for all 22 platforms the SQLite package
+supports; naming one keeps that platform's native library and drops the other 21.
+
+### Why it is not on by default
+
+A RID-specific bundle runs on one platform, and `npm run bundle-server` produces one cross-platform
+`service/` folder for one `.vsix`. Switching the default means shipping a `.vsix` per target
+platform through VS Code's `targetPlatform`, which is a packaging and CI change rather than a server
+one.
+
+So the csproj enables it only when a `RuntimeIdentifier` is given, and `bundle-server-win`,
+`bundle-server-linux` and `bundle-server-osx` opt in. `bundle-server` is byte-for-byte what it was —
+verified by publishing both: the default still writes `runtimes/` for 22 platforms and all 23 `Api/`
+data files.
+
+### What is left in startup after that
+
+About 0.9 s, of which the index is 0.5–0.6. Roughly 0.3 s is runtime start and host construction
+before the first log line appears. Nothing has been attributed inside that yet, and it wants a
+different tool than this file's harness — an ETW trace or `DOTNET_JitTimeLogFile`, not a stopwatch
+in a test.
+
 ## Reading the reports
 
 Each game writes `temp/gscode-perf-<game>.html`; `GSCODE_PERF_REPORT` overrides the directory.
@@ -1265,7 +1323,8 @@ in-process, while the server indexes cold at `ProcessorCount - 1`:
    packaged extension).
 3. For cold vs warm: delete `%APPDATA%\gscode\cache\*.db`, start once (cold), restart (warm), and
    read the "indexing complete" line each time. That line now splits out `cache`, so a warm start is
-   readable without a second measurement.
+   readable without a second measurement - and note `Ready` on the line after it, which includes the
+   startup the STARTUP section is about and which indexing is only the last part of.
 
    The harness answers the same question without the editor: `WarmIndex_WhereTheTimeGoes` populates a
    database, drains the writer and indexes again, reporting the cache read and the index separately.
@@ -1318,6 +1377,19 @@ Measured on the local BO3-tools machine (corpus not committed):
 | Cold index | 1,105 files | 5.5 s | < 60 s | yes |
 | Warm start *(stale; see the warm-start section)* | 1,105 files | 2.6 s | < 5 s | yes |
 | Warm start, harness, 2026-08-20 | 1,085 files (bo3) | 477 ms | < 5 s | yes |
+
+Driving the published server over stdio, BO3 as the workspace, 2026-08-20 - the same shape a user's
+session has, and the only place `Ready` can be read:
+
+| | cold | warm |
+|---|---|---|
+| `Workspace indexing complete` | 0.5 s (cache 0.1, find 0.0, analyse 0.3 at 21.3x) | 0.6 s (1,085 from cache) |
+| `Ready ... after start` | 1.2 s | 1.3 s |
+
+Two things to read off that pair rather than off either number. **A warm start is not faster than a
+cold one** - the WARM START section explains why and what the remaining lever is. And **half of
+`Ready` is not indexing at all**; the STARTUP section measures what the other half is, and takes
+0.3-0.4 s off it with a RID-specific publish that is not the default.
 | Steady-state memory (cold, before compaction) | 1,105 files | 390.3 MB | < 400 MB | just inside |
 | Steady-state memory (warm) | 1,105 files | 212.2 MB | < 400 MB | yes |
 | Live managed set (either path) | 1,105 files | ~115 MB | — | — |

--- a/server/PERF.md
+++ b/server/PERF.md
@@ -684,7 +684,9 @@ Achieved parallelism is 20.6–21.0x against a ceiling of 23. Three things this 
 - **`index.commit` is the one worth attention**, and much more so on CoD4 — a fifth to a quarter of
   thread-time against BO3's tenth. That is `BuildRecord` plus `LanguageStore.Upsert`, which takes one
   process-wide write gate and holds it across per-file hashing in three index diffs. A global lock is
-  exactly what inflates thread-time at 21x parallelism.
+  exactly what inflates thread-time at 21x parallelism. **Both gates were removed 2026-08-20 — see
+  the COMMIT GATE section — and the wall-clock did not move, which is the more useful half of that
+  finding.**
 - **`index.enqueue` is free** — but this measurement attaches no cache, so it says nothing about the
   SQLite writer. Measuring that needs a run with `UseCache`.
 
@@ -714,7 +716,8 @@ The stage shares moved, in opposite directions:
 - **`index.commit` improved and is no longer the headline.** cod4 fell from a fifth-to-a-quarter of
   thread-time to an eighth. It is still 99% `commit.upsert` — 1,334 of 1,392 ms on cod4, 5,099 of
   5,191 on bo1 — so the process-wide write gate is still the shape of it, and bo1's 19.7x is the
-  lowest parallelism of the three, which is what a contended global lock looks like.
+  lowest parallelism of the three, which is what a contended global lock looks like. *(Both gates
+  are gone as of 2026-08-20; parallelism did not respond, and the COMMIT GATE section says why.)*
 - **`index.read` is the new one to watch.** Its share roughly tripled on both games and is 18.3% on
   bo1 — 1.4–2.2 ms per file, and this sweep runs fourth, so every file was already in the OS cache.
   Instrumentation inflates `analyse`, which would push read's share *down*, so the figure is
@@ -1137,6 +1140,77 @@ timeline reconstruction.
 more when cold, since it is directories not visited at all, but no cold measurement is recorded here
 — dropping the Windows file cache is not something this harness does.
 
+## Measured: the COMMIT gate, where the contention was real and the wall-clock was not
+
+`index.commit` has been called "the one worth attention" in this file since the first cold-index
+breakdown, and it kept coming back. Re-measured 2026-08-20, instrumented, one run:
+
+| | `index.commit` | of which `commit.upsert` |
+|---|---:|---:|
+| bo3 | 1,473 ms, 10.2% of thread-time | 1,269 ms, 8.7% |
+| **cod4** | **2,069 ms, 29.3%** | **2,019 ms, 28.6%** |
+| bo1 | — | 13.5% |
+
+CoD4 was back at its worst recorded level. Two process-wide locks were behind it, one inside the
+other.
+
+**`LanguageStore`'s write gate was the wrong shape.** One `Lock` for the whole store, held across
+the record swap and all four index diffs. The race it exists to stop is between two writers of the
+SAME file — read-previous and swap are separate steps, so two upserts of one path could diff against
+one version. Two writers of DIFFERENT files share nothing there, because every index below
+serialises its own dictionary under its own lock. So the gate was serialising every index diff in
+the workspace against every other one to protect a per-path invariant. It is now striped across 64
+locks by path hash: same file still collides, different files collide only on a hash coincidence,
+and correctness is unchanged either way.
+
+**`ReferenceIndex` was one dictionary under one lock.** With the store gate striped, that became the
+next bottleneck immediately — cod4 only fell 28.6% → 24.9%. A file's diff is thousands of keys and
+it held that lock for all of them. Sharded 64 ways by key hash, taking a shard lock per key instead:
+an uncontended `Lock` is a few nanoseconds and a file has thousands of keys, so the acquisitions
+cost microseconds against the milliseconds the single gate spent waiting. The trade is sound only
+because no invariant spans two keys — each key's entry is complete on its own and nothing reads a
+group of them expecting one instant.
+
+| `commit.upsert`, thread-time | before | store gate striped | + index sharded |
+|---|---:|---:|---:|
+| bo3 | 1,269 ms (8.7%) | 623 ms (4.8%) | 1,015 ms (7.3%) |
+| **cod4** | **2,019 ms (28.6%)** | 1,630 ms (24.9%) | **469 ms (8.4%)** |
+| bo1 | 2,631 ms (13.5%) | 2,631 ms (13.5%) | **1,411 ms (7.2%)** |
+
+**4.3x on CoD4.** The bo3 column moves around because it is one run per cell and bo3 was never the
+contended case; read cod4 and bo1, where the direction is unambiguous and large.
+
+### And the wall-clock did not move, which is the part worth writing down
+
+Three cold-index runs each side, uninstrumented:
+
+| | before | after |
+|---|---|---|
+| bo3 | 644 / 627 / 628 ms | 642 / 570 / 632 ms |
+| cod4 | 361 / 318 / 315 ms | 391 / 295 / 321 ms |
+| bo1 | 1,041 / 1,067 / 1,014 ms | 1,007 / 1,178 / 965 ms |
+
+Achieved parallelism is 20.3–20.8x on both sides against a ceiling of 23. The lint sweep does not
+move either, and should not: it is sequential, so it has no contention to remove.
+
+**A thread waiting on a lock spends thread-time without spending wall-clock.** The waits were real
+and are gone, but they were not on the critical path: at twenty-three cores there was enough other
+analysis to run while a thread queued for the gate, so removing the queue freed CPU that nothing was
+short of. This is the reason `index.commit`'s share kept reading as alarming while the totals never
+responded to it, and it is worth remembering the next time a thread-time share is used to pick a
+target.
+
+What it does buy is not visible to any harness here. The gate it removes was taken by
+`FilesFor` as well as by the committing threads — so during a workspace index, a keystroke's lint
+was queueing behind every file being committed. Both sweeps that could measure that are sequential
+and run against a finished index, so neither has ever had the two happening at once. The change is
+kept on that argument and on the scaling one — a process-wide write gate at 20x parallelism is a
+limit whatever this machine's slack happens to hide — and not on a wall-clock number, because there
+is not one.
+
+Verified rather than assumed: 2,269 unit tests and the `Category=Corpus` gates over five games, all
+passing, with the sweep taking 49 s of real work.
+
 ## Measured: the WARM start, which was never timed and was slower than no cache at all
 
 Every figure above this line is a cold index. The warm path — the one a user takes on every start
@@ -1372,7 +1446,7 @@ in-process, while the server indexes cold at `ProcessorCount - 1`:
    packaged extension).
 3. For cold vs warm: delete `%APPDATA%\gscode\cache\*.db`, start once (cold), restart (warm), and
    read the "indexing complete" line each time. That line now splits out `cache`, so a warm start is
-   readable without a second measurement - and note `Ready` on the line after it, which includes the
+   readable without a second measurement — and note `Ready` on the line after it, which includes the
    startup the STARTUP section is about and which indexing is only the last part of.
 
    The harness answers the same question without the editor: `WarmIndex_WhereTheTimeGoes` populates a
@@ -1427,18 +1501,18 @@ Measured on the local BO3-tools machine (corpus not committed):
 | Warm start *(stale; see the warm-start section)* | 1,105 files | 2.6 s | < 5 s | yes |
 | Warm start, harness, 2026-08-20 | 1,085 files (bo3) | 477 ms | < 5 s | yes |
 
-Driving the published server over stdio, BO3 as the workspace, 2026-08-20 - the same shape a user's
+Driving the published server over stdio, BO3 as the workspace, 2026-08-20 — the same shape a user's
 session has, and the only place `Ready` can be read:
 
 | | cold | warm |
 |---|---|---|
 | `Workspace indexing complete` | 0.5 s (cache 0.1, find 0.0, analyse 0.3 at 21.3x) | 0.6 s (1,085 from cache) |
-| `Ready ... after start` | 1.2 s | 1.3 s |
+| `Ready … after start` | 1.2 s | 1.3 s |
 
 Two things to read off that pair rather than off either number. **A warm start is not faster than a
-cold one** - the WARM START section explains why and what the remaining lever is. And **half of
+cold one** — the WARM START section explains why and what the remaining lever is. And **half of
 `Ready` is not indexing at all**; the STARTUP section measures what the other half is, and takes
-0.3-0.4 s off it with a RID-specific publish that is not the default.
+0.3–0.4 s off it with a RID-specific publish that is not the default.
 | Steady-state memory (cold, before compaction) | 1,105 files | 390.3 MB | < 400 MB | just inside |
 | Steady-state memory (warm) | 1,105 files | 212.2 MB | < 400 MB | yes |
 | Live managed set (either path) | 1,105 files | ~115 MB | — | — |

--- a/server/samples/FOLDER.md
+++ b/server/samples/FOLDER.md
@@ -1,0 +1,123 @@
+# samples — one worked example per game, per language world
+
+Hand-written scripts that show the whole surface of a dialect and of the diagnostics, checked
+against their own comments by `SampleScriptTests` in `GSCode.Server.Tests`. They are meant to be
+OPENED: this is what you load to see hover, completion, go-to-definition, semantic tokens and every
+rule firing on one page, and what a screenshot of the extension is taken from.
+
+They are also the golden corpus for those things. A demo file with nothing asserting its output
+stops being true within two releases and nobody notices, so the demo and the fixture are one
+artifact rather than two that drift apart.
+
+No game install is needed. Each game's folder IS its raw root, indexed through the real
+`WorkspaceIndexer` over a `PhysicalFileSystem`, so `#using`/`#include`/`#insert` resolution and the
+cross-file lints are exercised exactly as the editor exercises them.
+
+## Layout
+
+One folder per game, flat, and that folder IS the raw root. Every script therefore has a
+single-segment path, and a directive reads `#include gscode_target` rather than
+`#include maps\mp\gscode_target`.
+
+| game | root | worlds sampled |
+|---|---|---|
+| `cod4` | `cod4/` | `.gsc` |
+| `waw`  | `waw/`  | `.gsc` `.csc` |
+| `mw2`  | `mw2/`  | `.gsc` |
+| `bo1`  | `bo1/`  | `.gsc` `.csc` |
+| `bo3`  | `bo3/`  | `.gsc` `.csc` `.gsh` |
+
+The one thing flatness changes is how a PATH CALL is judged. `gscode_no_such_file::whatever()` has
+a single segment, so it could name a file or a namespace, and the answer is 5013 — a function no
+script location declares. A multi-segment `maps\mp\gscode_no_such_file::whatever()` is
+unambiguously a path and is reported against the path instead, as 5009. The pre-BO3 lints files
+carry a note at that line; it is the only place the layout is visible in a diagnostic.
+
+Which worlds a game owes is not a list kept here — it is `GameProfile.ScriptExtensions`, and
+`EveryLanguageWorldTheGameHasIsSampled` reads the profile rather than this table. A game that gains
+`HasClientScripts` fails that test until its `.csc` showcase exists, and a `.csc` under a game
+without the flag fails it from the other side.
+
+## The four roles
+
+Errors and demonstration fight each other, so they are separated rather than interleaved.
+
+| file | job |
+|---|---|
+| `gscode.*` | the showcase. Produces ZERO diagnostics, so it stays the file where "does hover still work" is a fair question |
+| `gscode_lints.*` | one deliberate 4000/5000-range finding at a time. Still parses cleanly, so every rule is judged against a complete tree |
+| `gscode_broken.*` | the 1000/2000/3000 ranges |
+| `gscode_target.*`, `gscode_unused.*`, `gscode_unresolved.gsc` | the second and third files the cross-file rules need in order to have an opinion at all |
+
+`gscode_unresolved.gsc` exists in every game and is always alone with its broken import, for the
+reason in the last section.
+
+`gscode_broken` is kept apart because a syntax error puts the parser into recovery, and several
+lints stand down entirely on a file the parser could not read — `ExpressionStatementLint` says so in
+its own summary. Mixed together, most of the 5000 range would still look tested and would be proving
+nothing.
+
+BO3 is the only game with a `.gsh`. Every game with client scripts has a full `.csc` set —
+showcase, lints, target and unused — but WaW's and BO1's client lints files pin only the
+world-agnostic rules, and leave the calls that need a trusted client library in place with no
+`expect`.
+
+**There is no `gscode_broken.csc`, and there IS a `gscode_broken.gsh`.** The two follow from one
+line, `lenient` in `ParseResult.Analyze`:
+
+- `Lexer.Lex` and `Syntax.Parser.Parse` take the PROFILE and never the language, so a client
+  script's 1000/2000/3000 output is byte-identical to a server script's. A `.csc` copy of the broken
+  file would run the same code over the same input and assert the same thing twice.
+- `.gsh` is the one world the parse forks on. `lenient` is set for headers alone and drops the whole
+  3000 range together with the 4000-range extraction diagnostics, because a header is a FRAGMENT —
+  it is inserted into the middle of another file and does not have to parse standalone. The lexer
+  and preprocessor stay strict, which matters most there, since a header is where macros are
+  declared.
+
+`bo3/gscode_broken.gsh` pins both halves: four preprocessor diagnostics it must still report, and
+three parser errors it must not. The second half is an ABSENCE, and absences are the assertions that
+rot quietly — so it was checked rather than assumed. The same text under a `.gsc` extension reports
+3001 and 3007, which is what makes the silence evidence about the world rather than about the text.
+
+## Writing an expectation
+
+The specification lives in the sample, one line above the code that produces it.
+
+```gsc
+// expect 5008 — assigned and never read
+unused_thing = 4;
+```
+
+A run of consecutive `expect` comments all anchor to the first line below them that is not one,
+which is how a line carrying two diagnostics is written. Ordinary prose comments may sit inside the
+run. `expect-anywhere` drops the line requirement, for a diagnostic with no line to stand above.
+
+Only the CODE is asserted. Severity and message are edited far more often than a rule's identity,
+and pinning them would turn a wording change into a failing suite.
+
+The test asserts BOTH directions. A missing diagnostic is a rule that regressed; an EXTRA one is the
+more valuable half, since the showcase files expect nothing at all and any finding there is a false
+positive caught on code written to be correct.
+
+## Adding a rule to the samples
+
+Put the case in the game where it can actually fire, and say in the file why that is the game.
+Several rules cannot be shown everywhere:
+
+- **5026 and 5012** are the `#include` model's, and cannot exist under `#using`. They live in the
+  pre-BO3 samples; BO3's answer to the same mistake is 5000.
+- **4000/4001/4006, 4002/4003, 5021, and the whole 2000 range** need `#precache`, classes and the
+  preprocessor, so they are BO3's alone. CoD4's file pins 2016 instead — the diagnostic that says
+  the preprocessor is not in this dialect.
+- **5013/5014/5019/5023/5025** stand down on WaW, MW2 and BO1, whose bundled libraries are not
+  marked complete or signature-reliable. Their lints files carry a gate note and leave the calls in
+  place with no `expect`, so that curating one of those libraries FAILS the sample and asks for it
+  to be updated. That is the only reminder a gate like this ever gets.
+- **5006** needs a builtin the data marks dev-only. CoD4's library carries an explicit
+  `"devOnly": false` on every entry, which beats the fallback list in `DevOnlyBuiltins`, so only
+  BO3 can pin it today.
+
+One rule cannot share a file with the others: an unresolvable import suppresses the whole import
+pass, so **5009** lives alone in each game's `gscode_unresolved.gsc`. Moved back into
+`gscode_lints`, it would silently delete 5001 there (5012 and 5026 on the pre-BO3 games) and the
+suite would still be green.

--- a/server/samples/bo1/gscode.csc
+++ b/server/samples/bo1/gscode.csc
@@ -1,0 +1,51 @@
+// BO1 (Treyarch CSC) — the client-side showcase.
+//
+// Same grammar as this game's .gsc showcase, so this file does not repeat it. What it demonstrates
+// is everything the extension does DIFFERENTLY once the world is the client:
+//
+//   * a different engine library. Completion, hover and signature help are answered from the
+//     client API, and a server-only engine function does not resolve here;
+//   * a different set of Radiant keys. Treyarch's pre-BO3 games keep the client-side keys in a
+//     SECOND file, clientkeys.txt, where BO3 marks them with a `client` prefix in one file — two
+//     spellings of the same fact, and the reason the key data records a side at all;
+//   * separate import resolution. `#include gscode_target` finds gscode_target.csc from
+//     this file and gscode_target.gsc from the .gsc — two files, one path.
+//
+// There is no gscode_lints.csc for this game. The client-side rules all reason about engine
+// functions, and Black Ops's client library is not marked complete or signature-reliable, so every one
+// of them stands down here — see the gate note in gscode_lints.gsc. A lints file would assert that
+// nothing is reported, which is not a fact about the client world.
+//
+// This file must produce ZERO diagnostics.
+
+#include gscode_target;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: The client-side entry point."
+"CallOn: level"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	client_state();
+	includes();
+}
+
+client_state()
+{
+	origin = ( 0, 0, 0 );
+	structure = spawnstruct();
+	structure.origin = origin;
+
+	return structure;
+}
+
+// Resolves to gscode_target.csc, not to the .gsc of the same path.
+includes()
+{
+	return client_target_helper( 1 );
+}

--- a/server/samples/bo1/gscode.gsc
+++ b/server/samples/bo1/gscode.gsc
@@ -1,0 +1,309 @@
+// BO1 (Treyarch GSC) — the showcase.
+//
+// Every construct the BO1 dialect has, and correct: this file must produce ZERO diagnostics.
+//
+// Read it beside server/samples/bo3/gscode.gsc to see what the dialect actually
+// costs. This is the true base of the language, and most of what people think of as GSC arrived
+// later:
+//
+//   * no `function` keyword — a declaration is a name, a parameter list and a brace;
+//   * no `#using`, no `#namespace`, no `#insert`, no `#precache`, no `#define` and no `#if`. The
+//     preprocessor does not exist in this dialect, and a `#define` here is reported as such;
+//   * no classes, no `new`, no `->`;
+//   * no `foreach`, even though BO1 (2010) is NEWER than MW2 (2009), which has it. `foreach` is an
+//     Infinity Ward addition and the Treyarch line does not get one until BO3. Modelling the
+//     dialects as a timeline would hand it to BO1 and be wrong. Iteration goes through
+//     GetArrayKeys;
+//   * no `do`/`while`, no `const`, no `autoexec`/`private`, no `vararg`;
+//   * `::` is the function pointer, and a bare qualified name IS the pointer — parentheses would
+//     call it. BO3 spells the same thing `&foo`;
+//   * a path may be written inline at a call: gscode_target::target_by_path(), which
+//     reaches a file this one never included;
+//   * ScriptDoc is `///ScriptDocBegin` inside an ordinary block comment, not BO3's `/@ … @/`.
+
+#include gscode_target;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: Calls every demonstration below, so nothing here is unreachable."
+"CallOn: level"
+"SPMP: MP"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	literals();
+	operators();
+	control_flow();
+	calls_and_pointers();
+	events();
+	includes();
+
+	/#
+	dev_only();
+	#/
+}
+
+/*
+///ScriptDocBegin
+"Name: helper( <first>, <second> )"
+"Summary: Adds two numbers. There are no default parameters in this dialect."
+"MandatoryArg: <first> : the left operand"
+"MandatoryArg: <second> : the right operand"
+///ScriptDocEnd
+*/
+helper( first, second )
+{
+	return first + second;
+}
+
+// ---------------------------------------------------------------------------
+// Literals. Hash strings ARE here: `#"…"` is a Treyarch feature that arrives
+// with this game and carries on into BO3, and the whole Infinity Ward line has
+// none. Still no `const`.
+// ---------------------------------------------------------------------------
+
+literals()
+{
+	integer = 42;
+	real = 3.14;
+	hex = 0xFF;
+	text = "plain string";
+	localized = &"MENU_QUIT";
+	hashed = #"hashed_string";
+
+	yes = true;
+	no = false;
+	nothing = undefined;
+
+	vector = ( 0, 0, 1 );
+
+	array = [];
+	array[ 0 ] = "by index";
+	array[ "key" ] = "by key";
+
+	structure = spawnstruct();
+	structure.field = 10;
+
+	bundle = [];
+	bundle[ 0 ] = integer;
+	bundle[ 1 ] = real;
+	bundle[ 2 ] = hex;
+	bundle[ 3 ] = text;
+	bundle[ 4 ] = localized;
+	bundle[ 5 ] = hashed;
+	bundle[ 6 ] = yes;
+	bundle[ 7 ] = no;
+	bundle[ 8 ] = nothing;
+	bundle[ 9 ] = vector;
+	bundle[ 10 ] = array;
+	bundle[ 11 ] = structure;
+
+	return bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Operators. No `===` / `!==`: identity comparison is Treyarch's.
+// ---------------------------------------------------------------------------
+
+operators()
+{
+	left = 7;
+	right = 3;
+
+	added = left + right;
+	subtracted = left - right;
+	multiplied = left * right;
+	divided = left / right;
+	remainder = left % right;
+
+	bit_and = left & right;
+	bit_or = left | right;
+	bit_xor = left ^ right;
+	shifted_left = left << 1;
+	shifted_right = left >> 1;
+	bit_not = ~left;
+	negated = -left;
+
+	equal = left == right;
+	unequal = left != right;
+	less = left < right;
+	less_or_equal = left <= right;
+	greater = left > right;
+	greater_or_equal = left >= right;
+
+	both = ( left > 0 ) && ( right > 0 );
+	either = ( left > 0 ) || ( right > 0 );
+	inverted = !equal;
+
+	left++;
+	left--;
+	left += 1;
+	left -= 1;
+	left *= 2;
+	left /= 2;
+
+	if ( unequal && less && less_or_equal && greater && greater_or_equal && both && either
+		&& inverted && isdefined( left ) )
+	{
+		return added + subtracted + multiplied + divided + remainder
+			+ bit_and + bit_or + bit_xor + shifted_left + shifted_right + bit_not + negated;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Control flow. No `foreach` and no `do`/`while`; an array is walked through
+// its keys.
+// ---------------------------------------------------------------------------
+
+control_flow()
+{
+	count = 0;
+
+	if ( count == 0 )
+	{
+		count = 1;
+	}
+	else if ( count == 1 )
+	{
+		count = 2;
+	}
+	else
+	{
+		count = 3;
+	}
+
+	if ( count > 0 )
+		count--;
+
+	while ( count < 4 )
+	{
+		count++;
+		if ( count == 2 )
+		{
+			continue;
+		}
+	}
+
+	for ( index = 0; index < 4; index++ )
+	{
+		if ( index == 3 )
+		{
+			break;
+		}
+	}
+
+	for ( ;; )
+	{
+		break;
+	}
+
+	items = [];
+	items[ "first" ] = "a";
+	items[ "second" ] = "b";
+
+	keys = getarraykeys( items );
+	for ( index = 0; index < keys.size; index++ )
+	{
+		count += items[ keys[ index ] ].size;
+	}
+
+	switch ( count )
+	{
+		case 0:
+		case 1:
+			count = 10;
+			break;
+		case "string_case":
+			count = 20;
+			break;
+		default:
+			count = 30;
+			break;
+	}
+
+	wait 0.05;
+	waittillframeend;
+
+	assert( count > 0 );
+
+	prof_begin( "control_flow" );
+	prof_end( "control_flow" );
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// Calls, threads and pointers. `::` without parentheses IS the pointer.
+// ---------------------------------------------------------------------------
+
+calls_and_pointers()
+{
+	plain = helper( 1, 2 );
+
+	pointer = gscode_target::target_helper;
+	through_pointer = [[ pointer ]]( 1 );
+
+	by_path = gscode_target::target_by_path();
+
+	entity = spawnstruct();
+	entity method_style();
+	entity thread method_style();
+	entity thread [[ pointer ]]( 1 );
+	thread method_style();
+
+	return plain + through_pointer + by_path.size;
+}
+
+method_style()
+{
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Notify, waittill and endon — unchanged since the first game.
+// ---------------------------------------------------------------------------
+
+events()
+{
+	level endon( "game_ended" );
+
+	thread waiter();
+
+	level waittill( "custom_event", first, second );
+	level waittillmatch( "custom_event", 1 );
+
+	return first + second;
+}
+
+waiter()
+{
+	wait 0.1;
+	level notify( "custom_event", 1, 2 );
+}
+
+// ---------------------------------------------------------------------------
+// The included file. `target_helper` is called by BARE name: #include merges
+// it into this file's scope rather than qualifying it.
+// ---------------------------------------------------------------------------
+
+includes()
+{
+	return target_helper( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Dev blocks — present from the first game.
+// ---------------------------------------------------------------------------
+
+/#
+dev_only()
+{
+	println( "dev build" );
+}
+#/

--- a/server/samples/bo1/gscode_broken.gsc
+++ b/server/samples/bo1/gscode_broken.gsc
@@ -1,0 +1,88 @@
+// BO1 (Treyarch GSC) — the lexer and parser errors.
+//
+// Kept away from gscode_lints.gsc for the reason that file explains: a syntax error puts the parser
+// into recovery, several lints stand down entirely on a file the parser could not read, and
+// everything below the error is judged against a tree that is missing pieces.
+//
+// This dialect has no preprocessor, so there is no 2000 range here beyond the one diagnostic that
+// says exactly that — and that one lives in gscode_lints.gsc, because it does not break the parse.
+
+// ---------------------------------------------------------------------------
+// A keyword from a later dialect, in a position the parser has no production
+// for. This is the other half of 5025: where `vectorscale( … )` in
+// gscode_lints.gsc is a call the parser accepts and the rule simply explains, a
+// `foreach` header is not something the BO1 grammar can read at all.
+//
+// 5025 still names it — the rule works from the WORD, not from a well-formed
+// call — but it arrives buried in a cascade of syntax errors, and that is the
+// difference worth seeing. It is also what a user porting a BO3 script actually
+// gets, and the reason the two cases live in two different files: this cascade
+// would take the rest of gscode_lints.gsc down with it.
+// ---------------------------------------------------------------------------
+
+keyword_from_a_later_dialect()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 3000 — expected ')' but found 'in'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3003 — and then no statement at all
+	// expect 5016 — `item` and `in` both read as variables nothing assigns
+	// expect 5016
+	foreach ( item in items )
+	{
+		items[ 1 ] = item;
+	}
+	// expect 3001 — recovery never gets back in step, so the closing brace has nothing to close
+}
+
+// ---------------------------------------------------------------------------
+// 3000 range proper.
+// ---------------------------------------------------------------------------
+
+missing_semicolon()
+{
+	// expect 3014 — a statement ends with a semicolon
+	value = 1
+
+	return value;
+}
+
+bad_assignment_target()
+{
+	// expect 3012 — a literal is not somewhere a value can be stored
+	1 = 2;
+
+	// expect 3013 — an assignment in a condition is almost always a typo for ==
+	if ( value = 1 )
+	{
+		return value;
+	}
+}
+
+missing_expression()
+{
+	// expect 3002 — nothing to the right of the operator
+	return 1 +;
+}
+
+// ---------------------------------------------------------------------------
+// 1000 range — the lexer, and the block that never closes. Last, because
+// nothing after it is read as anything.
+// ---------------------------------------------------------------------------
+
+unterminated_string()
+{
+	// expect 1000 — no closing quote before the end of the line
+	// expect 3014 — so the statement never ends either
+	return "this string never ends;
+}
+
+unterminated_block()
+// expect 3007 — this brace is never closed, and neither is the file
+{
+	// expect 5008 — the one lint that still has something to say down here
+	value = 1;

--- a/server/samples/bo1/gscode_lints.csc
+++ b/server/samples/bo1/gscode_lints.csc
@@ -1,0 +1,158 @@
+// BO1 (Treyarch CSC) — the client-side findings.
+//
+// The client world is not a different language. The grammar is the same grammar, the flow rules are
+// the same code walking the same tree, and every diagnostic below would read identically in the
+// .gsc — which is exactly why this file is worth having: it is the proof that the world does not
+// quietly change the answer.
+//
+// What the world DOES change is which rules speak at all, and on this game the answer is blunt.
+// Every client-side rule reasons about engine functions, and Black Ops's client library is not marked
+// complete or signature-reliable, so all of them stand down:
+//
+//   * 5013 / 5014 — a call resolving to neither a client script function nor a client engine
+//     function. This is the rule the client world exists to make interesting, since a SERVER-only
+//     engine name should be as unknown here as a name nobody has. It cannot be shown until the
+//     client library is trusted.
+//   * 5023 — a client engine call's argument count, which needs signatures.
+//   * 5019 — assigning the result of a client engine function that returns nothing.
+//   * 5002 — a literal 0/1 passed where the client library declares a bool.
+//
+// The calls that would trip them are left below with no `expect`, so the day this game's client
+// library is curated, this sample fails and asks to be brought up to date.
+//
+// There is no gscode_broken.csc, here or anywhere. The lexer and the parser do not know what a
+// client script is — the world is decided from the extension, after the text is read — so a
+// client-side copy of those errors would run the same code over the same input and assert the same
+// thing twice.
+
+// Included and never used.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// ---------------------------------------------------------------------------
+// The rules that would need a trusted client library. No `expect` on any of
+// them, on purpose — see the note above.
+// ---------------------------------------------------------------------------
+
+untrusted_library()
+{
+	NoSuchClientFunction();
+
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals, which do not care which world they are in.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// `level` is the engine's on the client side too. The global object names come from the
+	// profile, not from the world, so both worlds of a game share them.
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	return items;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings. Neither is world-specific.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/bo1/gscode_lints.gsc
+++ b/server/samples/bo1/gscode_lints.gsc
@@ -1,0 +1,235 @@
+// BO1 (Treyarch GSC) — the deliberate findings.
+//
+// The same arrangement as the BO3 lints file: one mistake at a time, each declared by the
+// `// expect <code>` comment above it, and the file still parses cleanly so every rule is judged
+// against a complete tree.
+//
+// What is different is which rules can fire at all. Two whole families are missing here because the
+// dialect has nothing for them to be about — no #precache, so no 4000/4001/4006; no classes, so no
+// 5021 and no 4002/4003 — and two exist ONLY here, because they are about the include model that
+// BO3 replaced. Those two are 5012 and 5026, and they are the reason this file is not a translation
+// of the BO3 one.
+
+// Included and never used. The `#include` twin of BO3's 5001.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// Note what is NOT included: gscode_target. That is what 5026 below rests on.
+
+// ---------------------------------------------------------------------------
+// The dialect boundary. These are not mistakes in another game.
+// ---------------------------------------------------------------------------
+
+// The preprocessor arrives with BO3. Reported once for the file rather than once per directive, and
+// the macro still EXPANDS — telling the author the directive does not exist while silently dropping
+// its effect would produce a second, invented error at every use.
+// expect 2016 — #define is not in this dialect
+#define NOT_IN_THIS_DIALECT 1
+
+main()
+{
+	// `vectorscale` is one of BO3's intrinsics. Here it is an ordinary identifier, so this line
+	// reads as a call to a function that does not exist.
+	//
+	// Before this rule it was reported as a missing ENGINE function, which sent people looking for
+	// a builtin that never existed in any game. Naming the real problem — a word that is a keyword
+	// in a LATER dialect — is the whole of what 5025 adds.
+	scaled = vectorscale( ( 0, 0, 1 ), 64 );
+
+	// A word that is a keyword in a later dialect is not always a call. `foreach` is Infinity Ward's
+	// MW2 addition, and writing one here is a SYNTAX error rather than a diagnostic about the
+	// dialect — the parser has no production for it, so there is nothing left to name. That case
+	// lives in gscode_broken.gsc, where a cascade cannot take the rest of this file with it.
+
+	return scaled;
+}
+
+// ---------------------------------------------------------------------------
+// What is NOT reported here, and why it is our data rather than the dialect.
+//
+// Black Ops is a Supported game whose bundled engine library is not marked complete
+// or signature-reliable — the wordfile it was built from lists names without
+// arity, and the list itself is known to be short. Every rule that reasons
+// about ENGINE functions therefore stands down on this game, so that the editor
+// never blames a user for a hole in our data:
+//
+//   * 5025 — a word that is a keyword only in a later dialect. It reaches the
+//     user through the same resolution path, so it is gated with the rest.
+//   * 5026 — a name declared in a file this one does not include. A real engine
+//     function absent from our data would otherwise be reported as a missing include.
+//   * 5014 — a call matching no script function and no known engine function.
+//   * 5023 — an engine call's argument count, which needs signatures to check.
+//
+// The calls below are left in place, uncommented and carrying no `expect`, so
+// that the day Black Ops's library is curated this sample fails and asks to be
+// brought up to date. That is the only reminder a gate like this ever gets.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// The include model.
+// ---------------------------------------------------------------------------
+
+calls_that_do_not_resolve()
+{
+	// Declared in gscode_target.gsc, which this file does not include. The analyser can
+	// find it — hover and go-to-definition both work on this line — but the game's compiler will
+	// not link the call, so the script does not load. That gap is what the rule exists for.
+	target_never_included();
+
+	// Nothing anywhere declares this, which is a different story and a different code.
+	NoSuchEngineFunction();
+
+	// A path call names its file outright, so it needs no #include.
+	//
+	// What it is reported AS depends on how many segments the path has, and the samples sit at the
+	// boundary. A multi-segment path — maps\mp\gscode_no_such_file::whatever() — is unambiguously
+	// a path, so a missing one is reported against the PATH, once for the file rather than once per
+	// call. A single segment is not: with the samples rooted flat, `gscode_no_such_file` could be a
+	// file or a namespace, and the call is judged as a function that no script location declares.
+	//
+	// Both answers are defensible and only one of them names the actual problem, so this line is
+	// worth keeping an eye on.
+	// expect 5013 — no script location declares it
+	gscode_no_such_file::whatever();
+
+	abs();
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals — the same rules as every other dialect.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	// expect 5019 — ClearAllCorpses returns nothing, so this assigns undefined
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only builtins — 5006 — cannot be shown on this game, and the reason is
+// our data rather than the dialect.
+//
+// The rule reports an engine function that only exists in a development build
+// being called from release code, and the call below is exactly that: Print3d
+// is dev-only in every game that has it. It is not reported here because
+// cod4_api_gsc.json carries an explicit "devOnly": false on every entry, and an
+// explicit false beats the fallback list in DevOnlyBuiltins. The BO3 library
+// marks two entries dev-only, so the BO3 lints file is where 5006 is pinned.
+//
+// Left here, uncommented and unexpected-free, so that the day BO1's data is
+// curated this sample fails and asks to be updated.
+// ---------------------------------------------------------------------------
+
+dev_only_calls()
+{
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+
+	/#
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+	#/
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/bo1/gscode_target.csc
+++ b/server/samples/bo1/gscode_target.csc
@@ -1,0 +1,19 @@
+// BO1 (Treyarch CSC) — the client-side second file.
+//
+// The two worlds are separate namespaces of files, not one tree with two extensions: an `#include`
+// in a .csc resolves to a .csc, and the same path from a .gsc resolves to the .gsc beside it. That
+// is why gscode_target.gsc has a twin here rather than being reached from both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: client_target_helper( <value> )"
+"Summary: The client-side counterpart of gscode_target.gsc's target_helper."
+"MandatoryArg: <value> : the number to add to"
+///ScriptDocEnd
+*/
+client_target_helper( value )
+{
+	return value + 1;
+}

--- a/server/samples/bo1/gscode_target.gsc
+++ b/server/samples/bo1/gscode_target.gsc
@@ -1,0 +1,42 @@
+// BO1 (Treyarch GSC) — the second file.
+//
+// The Infinity Ward dialects have no namespaces. `#include` MERGES a file's functions into the
+// including file's scope, so everything here is called by bare name from gscode.gsc — and two files
+// declaring `main` are two different functions only because nothing includes both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: target_helper( <value> )"
+"Summary: Adds one. Exists so another file has something to call."
+"MandatoryArg: <value> : the number to add to"
+"Example: result = target_helper( 1 );"
+///ScriptDocEnd
+*/
+target_helper( value )
+{
+	return value + 1;
+}
+
+/*
+///ScriptDocBegin
+"Name: target_never_included()"
+"Summary: Called by gscode_lints.gsc, which includes a different file. That is 5026."
+///ScriptDocEnd
+*/
+target_never_included()
+{
+	return "reached";
+}
+
+/*
+///ScriptDocBegin
+"Name: target_by_path()"
+"Summary: Reached as gscode_target::target_by_path(), which needs no #include at all."
+///ScriptDocEnd
+*/
+target_by_path()
+{
+	return "by path";
+}

--- a/server/samples/bo1/gscode_unresolved.gsc
+++ b/server/samples/bo1/gscode_unresolved.gsc
@@ -1,0 +1,23 @@
+// BO1 (Treyarch GSC) — the unresolvable include, alone in its own file.
+//
+// It has to be alone, and that is worth knowing rather than working around. The import lints share
+// one resolution pass, and the pass reports NOTHING when any `#include` in the file failed to
+// resolve: once an import is missing, every "unused include" and every "declared but not included"
+// answer would be drawn from a scope that is known to be incomplete, and the file would be covered
+// in errors pointing at calls instead of at the one line that is actually wrong.
+//
+// So 5009 suppresses 5012 and 5026, and a file demonstrating all three would demonstrate one. The
+// other two live in gscode_lints.gsc, which includes nothing broken.
+//
+// The .csc side has the same arrangement for the same reason; see gscode_lints.csc.
+
+// expect 5009 — no such script under the raw root
+#include gscode_does_not_exist;
+
+// What the import rules stand down on, the RESOLUTION rules would still answer — but not on this
+// game, whose builtin library is not trusted, so 5014 is gated off here too. CoD4's copy of this
+// file pins that half; see the gate note in gscode_lints.gsc.
+calls_into_the_missing_script()
+{
+	return does_not_exist_anywhere();
+}

--- a/server/samples/bo1/gscode_unused.csc
+++ b/server/samples/bo1/gscode_unused.csc
@@ -1,0 +1,13 @@
+// BO1 (Treyarch CSC) — a client file that exists only to be included and ignored.
+//
+// gscode_lints.csc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports. It has to be a real, resolvable CLIENT script: the .gsc of the same name is a
+// different file to a .csc, so a server-side twin would not satisfy the include and the report
+// would be 5009 instead.
+//
+// This file must produce ZERO diagnostics.
+
+client_unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/bo1/gscode_unused.gsc
+++ b/server/samples/bo1/gscode_unused.gsc
@@ -1,0 +1,11 @@
+// BO1 (Treyarch GSC) — a file that exists only to be included and ignored.
+//
+// gscode_lints.gsc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports — the `#include` twin of BO3's 5001.
+//
+// This file must produce ZERO diagnostics.
+
+unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/bo3/gscode.csc
+++ b/server/samples/bo3/gscode.csc
@@ -1,0 +1,100 @@
+// BO3 (Treyarch CSC) — the client-side showcase.
+//
+// Same grammar as the .gsc showcase, so this file does not repeat it. What it demonstrates is
+// everything the extension does DIFFERENTLY once the world is the client:
+//
+//   * a different engine library. Completion, hover and signature help are answered from the
+//     client API, and a server-only engine function is not offered here and does not resolve;
+//   * a different set of Radiant keys. The client-side keys are offered in a .csc and hidden in a
+//     .gsc, which is the whole reason the key data records a side at all;
+//   * client-only #precache asset types, which are an error in a .gsc and correct here;
+//   * separate import resolution. `#using gscode_target` finds gscode_target.csc
+//     from this file and gscode_target.gsc from the .gsc — two files, one path;
+//   * a SHARED header. gscode.gsh is inserted by both worlds, so a macro declared once has
+//     references on both sides and rename has to move all of them.
+//
+// This file must produce ZERO diagnostics.
+
+#using gscode_target;
+
+#insert gscode.gsh;
+
+#namespace gscode_client;
+
+// Correct here, and 4006 in a .gsc.
+#precache( "client_fx", "impacts/generic_impact" );
+#precache( "client_model", "tag_origin" );
+
+class client_thing
+{
+	var m_count;
+
+	constructor()
+	{
+		m_count = 0;
+	}
+
+	destructor()
+	{
+	}
+
+	function bump( amount )
+	{
+		m_count += amount;
+		return m_count;
+	}
+}
+
+/@
+"Name: init()"
+"Summary: The client-side entry point."
+"Module: GSCode"
+"CallOn: level"
+@/
+function autoexec init()
+{
+	level thread main();
+}
+
+function main()
+{
+	level endon( "game_ended" );
+
+	client_state();
+	shared_macros();
+	imports();
+}
+
+// The engine library answering this file is the CLIENT one. Every name below is a client engine
+// function; a server-only name in its place would be 5014 here even though it is correct in a .gsc.
+function private client_state()
+{
+	thing = new client_thing();
+	[[ thing ]]->bump( 1 );
+
+	origin = ( 0, 0, 0 );
+	scaled = vectorscale( origin, 64 );
+
+	return scaled;
+}
+
+// The same macros as the .gsc side, out of the same header. Find-references on GSCODE_SQUARE
+// returns uses in both worlds.
+function private shared_macros()
+{
+	squared = GSCODE_SQUARE( 3 );
+	clamped = GSCODE_CLAMPED( squared, GSCODE_MAX_COUNT );
+
+	if ( GSCODE_IS_TRUE( clamped ) )
+	{
+		return clamped;
+	}
+
+	return 0;
+}
+
+// Resolves to gscode_target.csc, not to the .gsc of the same path.
+function private imports()
+{
+	return gscode_target::client_target_helper( 1 );
+}

--- a/server/samples/bo3/gscode.gsc
+++ b/server/samples/bo3/gscode.gsc
@@ -1,0 +1,460 @@
+// BO3 (Treyarch GSC) — the showcase.
+//
+// Every construct the BO3 dialect has, written the way the formatter would leave it, and correct:
+// this file must produce ZERO diagnostics. That is what makes it the file to open when the question
+// is "does hover still work", "is this token coloured right", "does completion offer the class's
+// inherited methods" — anything underlined here is a false positive, not a mistake in the script.
+//
+// Its opposite numbers are gscode_lints.gsc (one deliberate finding per rule) and gscode_broken.gsc
+// (the lexer, preprocessor and parser errors).
+
+#using gscode_target;
+
+#insert gscode.gsh;
+
+#namespace gscode;
+
+#precache( "fx", "impacts/generic_impact" );
+#precache( "model", "tag_origin" );
+
+#define LOCAL_BUILD 1
+
+// The two branches below are excluded from the build, and the editor greys them out to say so.
+// That is a Hint rather than a complaint — the only diagnostic a correct file is expected to carry,
+// which is why the showcase declares it here instead of pretending the file is silent.
+//
+// Written as `expect-anywhere` because an anchored expectation would have to sit INSIDE the
+// inactive branch, and the region the hint covers starts wherever the first line of that branch is.
+// expect-anywhere 2013 — the #elif body
+// expect-anywhere 2013 — the #else body
+#if LOCAL_BUILD
+#define BUILD_MODE "full"
+#elif 0
+#define BUILD_MODE "partial"
+#else
+#define BUILD_MODE "none"
+#endif
+
+// ---------------------------------------------------------------------------
+// Classes — BO3 alone. `class`, `var`, `new`, `constructor`, `destructor` and
+// the `->` method call all arrive together with the class system.
+// ---------------------------------------------------------------------------
+
+class base_thing
+{
+	var m_name;
+
+	constructor()
+	{
+		m_name = "base";
+	}
+
+	destructor()
+	{
+	}
+
+	function get_name()
+	{
+		return m_name;
+	}
+}
+
+// Inheritance. Completion on a `derived_thing` offers `get_name` as well as `bump`, and
+// go-to-definition on the inherited one lands in `base_thing` above.
+class derived_thing : base_thing
+{
+	var m_count;
+
+	constructor()
+	{
+		m_count = 0;
+	}
+
+	destructor()
+	{
+	}
+
+	function bump( amount )
+	{
+		m_count += amount;
+		return m_count;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Functions — declaration modifiers, default parameters, by-reference
+// parameters, and the vararg pack.
+// ---------------------------------------------------------------------------
+
+/@
+"Name: init()"
+"Summary: The autoexec entry point. Runs without anything calling it."
+"Module: GSCode"
+"CallOn: level"
+"SPMP: both"
+@/
+function autoexec init()
+{
+	level.things = [];
+	level thread main();
+}
+
+/@
+"Name: main()"
+"Summary: Calls every demonstration below, so nothing here is unreachable."
+"Module: GSCode"
+@/
+function main()
+{
+	level endon( "game_ended" );
+
+	literals();
+	operators();
+	control_flow();
+	calls_and_pointers();
+	classes();
+	events();
+	imports();
+	macros();
+	variadic( 1, 2, 3 );
+
+	/#
+	dev_only();
+	#/
+}
+
+/@
+"Name: helper( <first>, [second], <out_ref> )"
+"Summary: A private function with a default parameter and a by-reference parameter."
+"MandatoryArg: <first> : the left operand"
+"OptionalArg: [second] : the right operand, 2 when omitted"
+"MandatoryArg: <out_ref> : written through, not read"
+"Example: helper( 1, 2, result );"
+@/
+function private helper( first, second = 2, &out_ref )
+{
+	out_ref = first + second;
+	return out_ref;
+}
+
+// `...` is the parameter pack; the values arrive as `vararg`, which is a keyword on BO3 but reads
+// as an ordinary value.
+function variadic( ... )
+{
+	total = 0;
+	foreach ( argument in vararg )
+	{
+		total += argument;
+	}
+
+	return total + vararg.size;
+}
+
+// ---------------------------------------------------------------------------
+// Literals — one of every kind the lexer knows, all read back at the end so
+// none of them is an unused local.
+// ---------------------------------------------------------------------------
+
+function private literals()
+{
+	const LOCAL_CONST = 10;
+
+	integer = 42;
+	real = 3.14;
+	hex = 0xFF;
+	text = "plain string";
+	localized = &"MENU_QUIT";
+	hashed = #"hashed_string";
+
+	yes = true;
+	no = false;
+	nothing = undefined;
+
+	vector = ( 0, 0, 1 );
+
+	array = [];
+	array[ 0 ] = "by index";
+	array[ "key" ] = "by key";
+
+	structure = spawnstruct();
+	structure.field = LOCAL_CONST;
+	structure.nested = BUILD_MODE;
+
+	bundle = [];
+	bundle[ 0 ] = integer;
+	bundle[ 1 ] = real;
+	bundle[ 2 ] = hex;
+	bundle[ 3 ] = text;
+	bundle[ 4 ] = localized;
+	bundle[ 5 ] = hashed;
+	bundle[ 6 ] = yes;
+	bundle[ 7 ] = no;
+	bundle[ 8 ] = nothing;
+	bundle[ 9 ] = vector;
+	bundle[ 10 ] = array;
+	bundle[ 11 ] = structure;
+
+	return bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Operators — every one, including the identity comparisons `===` / `!==`
+// that only Treyarch's line has.
+// ---------------------------------------------------------------------------
+
+function private operators()
+{
+	left = 7;
+	right = 3;
+
+	added = left + right;
+	subtracted = left - right;
+	multiplied = left * right;
+	divided = left / right;
+	remainder = left % right;
+
+	bit_and = left & right;
+	bit_or = left | right;
+	bit_xor = left ^ right;
+	shifted_left = left << 1;
+	shifted_right = left >> 1;
+	bit_not = ~left;
+	negated = -left;
+
+	equal = left == right;
+	identical = left === right;
+	unequal = left != right;
+	not_identical = left !== right;
+	less = left < right;
+	less_or_equal = left <= right;
+	greater = left > right;
+	greater_or_equal = left >= right;
+
+	both = ( left > 0 ) && ( right > 0 );
+	either = ( left > 0 ) || ( right > 0 );
+	inverted = !equal;
+
+	left++;
+	left--;
+	left += 1;
+	left -= 1;
+	left *= 2;
+	left /= 2;
+	left %= 3;
+	left &= 1;
+	left |= 2;
+	left ^= 3;
+	left <<= 1;
+	left >>= 1;
+
+	chosen = ( left > right ) ? "bigger" : "smaller";
+	scaled = vectorscale( ( 0, 0, 1 ), 64 );
+
+	if ( identical && not_identical && less && less_or_equal && greater && greater_or_equal
+		&& both && either && inverted && unequal && isdefined( chosen ) && isdefined( scaled ) )
+	{
+		return added + subtracted + multiplied + divided + remainder
+			+ bit_and + bit_or + bit_xor + shifted_left + shifted_right + bit_not + negated;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Control flow — `do`/`while` and `foreach` are both BO3 additions on this
+// side of the family tree.
+// ---------------------------------------------------------------------------
+
+function private control_flow()
+{
+	count = 0;
+
+	if ( count == 0 )
+	{
+		count = 1;
+	}
+	else if ( count == 1 )
+	{
+		count = 2;
+	}
+	else
+	{
+		count = 3;
+	}
+
+	if ( count > 0 )
+		count--;
+
+	while ( count < GSCODE_MAX_COUNT )
+	{
+		count++;
+		if ( count == 2 )
+		{
+			continue;
+		}
+	}
+
+	do
+	{
+		count--;
+	}
+	while ( count > 0 );
+
+	for ( index = 0; index < GSCODE_MAX_COUNT; index++ )
+	{
+		if ( index == 3 )
+		{
+			break;
+		}
+	}
+
+	for ( ;; )
+	{
+		break;
+	}
+
+	items = [];
+	items[ "first" ] = "a";
+	items[ "second" ] = "b";
+
+	foreach ( item in items )
+	{
+		count += item.size;
+	}
+
+	foreach ( key, value in items )
+	{
+		count += key.size + value.size;
+	}
+
+	switch ( count )
+	{
+		case 0:
+		case 1:
+			count = 10;
+			break;
+		case "string_case":
+			count = 20;
+			break;
+		default:
+			count = 30;
+			break;
+	}
+
+	wait 0.05;
+	waitrealtime 0.05;
+	waittillframeend;
+
+	assert( count > 0 );
+
+	profilestart( "control_flow" );
+	profilestop();
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// Calls, threads and function pointers — `&` is BO3's pointer spelling, and a
+// bare `ns::name` is always a call here.
+// ---------------------------------------------------------------------------
+
+function private calls_and_pointers()
+{
+	plain = helper( 1, 2, undefined );
+	qualified = gscode::helper( 1, 2, undefined );
+
+	pointer = &helper;
+	qualified_pointer = &gscode::helper;
+
+	through_pointer = [[ pointer ]]( 1, 2, undefined );
+	through_qualified = [[ qualified_pointer ]]( 1, 2, undefined );
+
+	entity = spawnstruct();
+	entity method_style();
+	entity thread method_style();
+	entity thread [[ pointer ]]( 1, 2, undefined );
+	thread method_style();
+
+	return plain + qualified + through_pointer + through_qualified;
+}
+
+function private method_style()
+{
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Classes in use.
+// ---------------------------------------------------------------------------
+
+function private classes()
+{
+	base = new base_thing();
+	derived = new derived_thing();
+
+	[[ derived ]]->bump( 1 );
+
+	return [[ base ]]->get_name() + [[ derived ]]->get_name();
+}
+
+// ---------------------------------------------------------------------------
+// Notify, waittill and endon. `waittill`'s trailing names are the only place
+// those variables come into existence — they are bound, not read.
+// ---------------------------------------------------------------------------
+
+function private events()
+{
+	level endon( "game_ended" );
+
+	thread waiter();
+
+	level waittill( "custom_event", first, second );
+	level waittillmatch( "custom_event", 1 );
+
+	return first + second;
+}
+
+function private waiter()
+{
+	wait 0.1;
+	level notify( "custom_event", 1, 2 );
+}
+
+// ---------------------------------------------------------------------------
+// The other file. Go-to-definition on either name below leaves this document.
+// ---------------------------------------------------------------------------
+
+function private imports()
+{
+	return gscode_target::target_helper( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Macros from the inserted header. Hover shows the expansion; go-to-definition
+// lands in gscode.gsh.
+// ---------------------------------------------------------------------------
+
+function private macros()
+{
+	squared = GSCODE_SQUARE( 3 );
+	clamped = GSCODE_CLAMPED( squared, GSCODE_MAX_COUNT );
+
+	if ( GSCODE_IS_TRUE( clamped ) )
+	{
+		return clamped;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Dev blocks. `/# … #/` is compiled out of a release build, so a function
+// declared inside one may only be called from inside one.
+// ---------------------------------------------------------------------------
+
+/#
+function dev_only()
+{
+	println( "dev build" );
+}
+#/

--- a/server/samples/bo3/gscode.gsh
+++ b/server/samples/bo3/gscode.gsh
@@ -1,0 +1,19 @@
+// BO3 (Treyarch GSH) — a preprocessor header.
+//
+// A .gsh is inserted textually by #insert, so it belongs to whichever world included it and is the
+// one place a macro can be declared. Everything the extension does for macros is reachable from
+// here: hover shows the expansion, go-to-definition from a use lands on the #define below,
+// find-references crosses into both the .gsc and the .csc that insert this file, and rename moves
+// every one of them together.
+//
+// This file must produce ZERO diagnostics.
+
+#define GSCODE_MAX_COUNT 4
+
+#define GSCODE_SQUARE( x ) ( ( x ) * ( x ) )
+
+#define GSCODE_IS_TRUE( value ) ( isdefined( value ) && value )
+
+// A macro whose body is a call. Hovering the USE in gscode.gsc shows this text; go-to-definition
+// on the name inside it resolves as though it were written at the call site.
+#define GSCODE_CLAMPED( value, high ) ( ( value ) > ( high ) ? ( high ) : ( value ) )

--- a/server/samples/bo3/gscode_broken.gsc
+++ b/server/samples/bo3/gscode_broken.gsc
@@ -1,0 +1,85 @@
+// BO3 (Treyarch GSC) — the lexer, preprocessor and parser errors.
+//
+// Kept away from gscode_lints.gsc because these three ranges are not like the rest: a syntax error
+// puts the parser into recovery, and every construct below it is analysed against a tree that is
+// missing pieces. Several lints stand down entirely on a file the parser could not read. Mixed
+// together, most of the 5000 range would still look "tested" and would be proving nothing.
+//
+// So this file is deliberately unsalvageable, and the only thing asserted about it is which
+// diagnostics it produces. Nothing imports it and nothing calls into it.
+
+// ---------------------------------------------------------------------------
+// 2000 range — the preprocessor.
+// ---------------------------------------------------------------------------
+
+// expect 2006 — #insert resolves like a path, and this one does not exist
+#insert gscode_no_such_header.gsh;
+
+// expect 2014 — #insert takes a header; this is a script
+#insert gscode_target.gsc;
+
+// expect 2003 — nothing to insert
+#insert;
+
+// Defined twice. The LATER definition is the one reported, because it is the one that silently
+// replaces the other — the first definition is the one the author probably meant to keep.
+#define GSCODE_TWICE 1
+// expect 2017 — already defined above
+#define GSCODE_TWICE 2
+
+// expect 2018 — the same macro parameter name twice
+#define GSCODE_DUPLICATE_PARAM( value, value ) ( value )
+
+// expect 2010 — an #endif with no #if above it
+#endif
+
+// ---------------------------------------------------------------------------
+// 3000 range — the parser.
+// ---------------------------------------------------------------------------
+
+function missing_semicolon()
+{
+	// expect 3014 — a statement ends with a semicolon
+	value = 1
+
+	return value;
+}
+
+function bad_assignment_target()
+{
+	// expect 3012 — a literal is not somewhere a value can be stored
+	1 = 2;
+
+	// expect 3013 — an assignment in a condition is almost always a typo for ==
+	if ( value = 1 )
+	{
+		return value;
+	}
+}
+
+function missing_expression()
+{
+	// expect 3002 — nothing to the right of the operator
+	return 1 +;
+}
+
+// ---------------------------------------------------------------------------
+// 1000 range — the lexer, and the unterminated blocks. Last on purpose: there
+// is no recovering from a construct that never closes, so nothing after this
+// point would be read as anything.
+// ---------------------------------------------------------------------------
+
+function unterminated_string()
+{
+	// A string that runs to the end of its line is two findings, not one: the string itself, and
+	// the statement that consequently never reaches its semicolon.
+	// expect 1000 — no closing quote before the end of the line
+	// expect 3014 — so the statement never ends either
+	return "this string never ends;
+}
+
+function unterminated_block()
+// expect 3007 — this brace is never closed, and neither is the file
+{
+	// expect 5008 — the one lint that still has something to say down here
+	value = 1;

--- a/server/samples/bo3/gscode_broken.gsh
+++ b/server/samples/bo3/gscode_broken.gsh
@@ -1,0 +1,61 @@
+// BO3 (Treyarch GSH) — the header that is deliberately not a script.
+//
+// This is the one file in the samples whose point is mostly what is NOT reported.
+//
+// A .gsh is analysed leniently, and `ParseResult.Analyze` is where that happens: `lenient` is set
+// for the header world alone, and it drops the WHOLE 3000 range along with the 4000-range
+// extraction diagnostics. The reason is that a header is a fragment. It is inserted into the middle
+// of whichever file includes it, so its text does not have to parse as a standalone script and
+// usually does not — a header ending mid-expression is normal, not broken.
+//
+// The lexer and the preprocessor are NOT lenient, and that is the line worth pinning. A header is
+// exactly where macros are declared, so the preprocessor's complaints about them are the ones a
+// user most needs, and dropping those with the rest would silence the only world that has them.
+//
+// The .csc world has no file like this and does not need one: `Lexer.Lex` and `Parser.Parse` take
+// the profile and never the language, so a client script's 1000/2000/3000 output is byte-identical
+// to a server script's. GSH is the only world the parse forks on.
+
+// ---------------------------------------------------------------------------
+// Still reported — the preprocessor.
+// ---------------------------------------------------------------------------
+
+#define GSCODE_BROKEN_TWICE 1
+// expect 2017 — already defined above
+#define GSCODE_BROKEN_TWICE 2
+
+// expect 2018 — the same macro parameter name twice
+#define GSCODE_BROKEN_DUPLICATE( value, value ) ( value )
+
+// expect 2006 — #insert resolves like a path, and this one does not exist
+#insert gscode_no_such_header.gsh;
+
+// expect 2010 — an #endif with no #if above it
+#endif
+
+// ---------------------------------------------------------------------------
+// NOT reported — the parser.
+//
+// Every line below is a 3000-range error in a .gsc and silent here, and none
+// of them carries an `expect`. That absence IS the assertion: the test fails
+// on any diagnostic a sample did not declare, so if leniency ever stopped
+// applying to headers, this file is what says so.
+//
+// The absence was checked rather than assumed. The same text under the .gsc
+// extension reports 3001 at the first line below and 3007 at the last — so
+// this file is silent because of the world it is in, not because the text
+// happens to be harmless.
+// ---------------------------------------------------------------------------
+
+// A dangling operator and a bare statement, where a declaration is due. Both
+// collapse into one 3001 in a script, since recovery resynchronises at the next
+// declaration and there is not one.
+1 +
+
+value = 1;
+
+// A block that never closes — which is exactly what a header carrying the top
+// half of something looks like, and the shape leniency exists for. 3007 in a
+// script.
+function fragment()
+{

--- a/server/samples/bo3/gscode_lints.csc
+++ b/server/samples/bo3/gscode_lints.csc
@@ -1,0 +1,27 @@
+// BO3 (Treyarch CSC) — the client-side findings.
+//
+// Deliberately NOT a copy of gscode_lints.gsc. The grammar and the flow rules are the same code
+// running over the same tree, so repeating them here would double the maintenance and prove
+// nothing. What is here is what only goes wrong in a .csc: the rules whose answer depends on which
+// world the file belongs to.
+//
+// The lexer, preprocessor and parser errors have no client-side variant at all — the parser does
+// not know what a client script is — so there is no gscode_broken.csc.
+
+#insert gscode.gsh;
+
+#namespace gscode_lints;
+
+// Server-only asset types, from a client script. The mirror of 4006 in the .gsc: neither world may
+// precache the other's assets, and the message names the side it belongs to.
+// expect 4000 — "not_a_real_asset_type" is not a type in either world
+#precache( "not_a_real_asset_type", "some/asset" );
+
+function client_only_resolution()
+{
+	// Resolved against the CLIENT engine library. A name that exists only on the server side is as
+	// unknown here as a name that does not exist at all — which is the point of keeping two
+	// libraries rather than one union of both.
+	// expect 5014 — no client engine function by this name
+	NoSuchClientFunction();
+}

--- a/server/samples/bo3/gscode_lints.gsc
+++ b/server/samples/bo3/gscode_lints.gsc
@@ -1,0 +1,281 @@
+// BO3 (Treyarch GSC) — the deliberate findings.
+//
+// One mistake at a time, each declared by the `// expect <code>` comment above it. The file still
+// PARSES cleanly on purpose: a syntax error puts the parser into recovery, several rules stand down
+// on a file the parser could not read, and everything below the error would be judged against a
+// damaged tree. The lexer, preprocessor and parser errors live in gscode_broken.gsc for that reason.
+//
+// Read this as the catalogue of what the extension will tell you about your code, and of what each
+// message actually means.
+
+// Used below, so this import is live.
+#using gscode;
+
+// The same script imported twice. The SECOND one is the one reported.
+// expect 5018 — already imported above
+#using gscode;
+
+// Imported and never used. A different complaint from 5018: this import is not a duplicate, it is
+// simply dead.
+// expect 5001 — nothing in this file uses anything it declares
+#using gscode_unused;
+
+// Note what is not HERE: 5009, the unresolvable import. It lives in gscode_unresolved.gsc, because
+// a file with one missing import gets no answer from the other import rules at all — see that file
+// for why. Putting it here would silently delete the 5001 case above.
+
+#insert gscode.gsh;
+
+#namespace gscode_lints;
+
+// ---------------------------------------------------------------------------
+// 4000 range — declarations and directives, decided from this file alone.
+// ---------------------------------------------------------------------------
+
+// expect 4000 — not one of BO3's precache asset types
+#precache( "not_a_real_asset_type", "some/asset" );
+
+// expect 4001 — #precache takes a type AND an asset
+#precache( "fx" );
+
+// Some asset types belong to the client. A .gsc cannot precache one, and a .gsh can precache
+// anything, because a header does not know which world will insert it.
+// expect 4006 — client_fx is a client-side type
+#precache( "client_fx", "impacts/generic_impact" );
+
+// Both ends of a cycle are reported, not just the one that closes it: neither class can be
+// constructed, and which of the two is "the mistake" is not something the rule can know.
+// expect 5021 — cycle_a inherits cycle_b, which inherits cycle_a
+class cycle_a : cycle_b
+{
+	constructor()
+	{
+	}
+
+	destructor()
+	{
+	}
+}
+
+// expect 5021 — and the same cycle seen from the other end
+class cycle_b : cycle_a
+{
+	constructor()
+	{
+	}
+
+	destructor()
+	{
+	}
+}
+
+class bad_members
+{
+	// A constructor runs from `new` and a destructor runs from the engine. Neither is ever handed
+	// anything, so a parameter list on either is a misunderstanding rather than a style choice.
+	// expect 4002 — a constructor cannot take parameters
+	// expect 5020 — and the parameter is unread, which is the second thing wrong with it
+	constructor( unwanted )
+	{
+	}
+
+	// expect 4003 — a destructor cannot take parameters
+	// expect 5020
+	destructor( unwanted )
+	{
+	}
+}
+
+// expect 4007 — the same parameter name twice
+function duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4008 — the parameter pack has to be last
+function vararg_not_last( ..., trailing )
+{
+	return trailing;
+}
+
+// expect 4005 — this name is already declared, above
+function duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// 5000 range — flow and the workspace.
+// ---------------------------------------------------------------------------
+
+function locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// Two findings on one line, and they are separate claims: nothing can reach the statement, and
+	// the variable it assigns is never read. Each is written on its own line above.
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+function switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+function constants()
+{
+	const FIXED = 1;
+
+	// expect 5030 — a const is assigned once, where it is declared
+	FIXED = 2;
+
+	// expect 5029 — a const initialiser is evaluated at compile time, so it cannot call anything
+	const COMPUTED = SpawnStruct();
+
+	return FIXED + COMPUTED;
+}
+
+function calls_that_do_not_resolve()
+{
+	// The two "not found" rules are a deliberate split. An UNQUALIFIED name could be either kind,
+	// so it is judged against the engine library; a name qualified with a namespace can only be a
+	// script function, and is judged against the workspace.
+	// expect 5014 — matches no script function and no known engine function
+	NoSuchEngineFunction();
+
+	// expect 5013 — gscode declares no such function
+	gscode::no_such_script_function();
+
+	// Nothing here imports a file declaring the gscode_unresolved namespace, so the name means
+	// nothing in this file even though the script exists and the function is right there in it.
+	//
+	// This is BO3's ONLY answer for an unreachable call to a real function. The Infinity Ward
+	// dialects have a second one, 5026, for a name that is merged into scope by #include rather
+	// than qualified — which cannot happen here, so that rule lives in the pre-BO3 samples.
+	// expect 5000 — the namespace itself is not imported
+	gscode_unresolved::calls_into_the_missing_script();
+
+	// expect 5003 — gscode::helper is private, so only its own file may call it
+	gscode::helper( 1, 2, undefined );
+
+	// expect 5022 — gscode::main takes none
+	gscode::main( 1 );
+
+	// expect 5023 — the engine's Abs takes exactly one
+	Abs();
+}
+
+function reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// A BARE global object name. Writing THROUGH one — level.things = [] — is how every script uses
+	// them and is not reported; it is the assignment to the name itself that cannot mean anything.
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	// expect 5019 — AddDebugCommand returns nothing, so this assigns undefined
+	nothing = AddDebugCommand( "cmd" );
+
+	// expect 5002 — AllowAttack's parameter is declared bool; say so
+	self AllowAttack( 1 );
+
+	return nothing;
+}
+
+function bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	// expect 5024 — `vararg` only exists inside a function declared with `...`
+	count = vararg.size;
+
+	return result + count;
+}
+
+function waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only builtins. `/# … #/` is compiled out of a release build, and so are
+// the engine functions that only exist in one — so calling one from release
+// code is a call to something that will not be there.
+// ---------------------------------------------------------------------------
+
+function dev_only_calls()
+{
+	// expect 5006 — Print3d only exists in a development build
+	Print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+
+	// The same call inside a dev block is correct, and is not reported.
+	/#
+	Print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+	#/
+}
+
+// ---------------------------------------------------------------------------
+// Suppression. Every rule can be switched off, and both spellings are shown so
+// that neither one quietly stops working. A suppressed diagnostic is not
+// reported, so neither suppressed line below carries an `expect` comment.
+//
+// The pragma lives INSIDE a comment on purpose: GSC has no `#pragma` of its
+// own, so a bare one would be a syntax error in the game's compiler. Anything
+// the extension adds to the language has to be invisible to it.
+// ---------------------------------------------------------------------------
+
+function suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// The pragma is a REGION and was restored above, so this one is reported again.
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/bo3/gscode_target.csc
+++ b/server/samples/bo3/gscode_target.csc
@@ -1,0 +1,19 @@
+// BO3 (Treyarch CSC) — the client-side second file.
+//
+// The two worlds are separate namespaces of files, not one tree with two extensions: a `#using` in
+// a .csc resolves to a .csc, and the same path from a .gsc resolves to the .gsc beside it. That is
+// why gscode_target.gsc has a twin here rather than being reached from both.
+//
+// This file must produce ZERO diagnostics.
+
+#namespace gscode_target;
+
+/@
+"Name: client_target_helper( <value> )"
+"Summary: The client-side counterpart of gscode_target.gsc's target_helper."
+"MandatoryArg: <value> : the number to add to"
+@/
+function client_target_helper( value )
+{
+	return value + 1;
+}

--- a/server/samples/bo3/gscode_target.gsc
+++ b/server/samples/bo3/gscode_target.gsc
@@ -1,0 +1,40 @@
+// BO3 (Treyarch GSC) — the second file.
+//
+// Half the language server only has an opinion once a workspace has more than one script:
+// #using resolution, cross-file go-to-definition and find-references, the unused-import rules, and
+// the "declared but not imported" error. This file is what gscode.gsc reaches for, and what
+// gscode_lints.gsc deliberately fails to import.
+//
+// This file must produce ZERO diagnostics.
+
+#namespace gscode_target;
+
+/@
+"Name: target_helper( <value> )"
+"Summary: Adds one. Exists so another file has something to call."
+"MandatoryArg: <value> : the number to add to"
+"Example: gscode_target::target_helper( 1 );"
+@/
+function target_helper( value )
+{
+	return value + 1;
+}
+
+/@
+"Name: target_never_imported()"
+"Summary: Called by gscode_lints.gsc WITHOUT a #using, which is what raises 5026 there."
+@/
+function target_never_imported()
+{
+	return "reached";
+}
+
+/@
+"Name: target_unused()"
+"Summary: Nothing calls this. There is deliberately no 'unused function' rule — a script function
+is the game's entry point far too often for absence of callers to mean anything."
+@/
+function target_unused()
+{
+	return 0;
+}

--- a/server/samples/bo3/gscode_unresolved.gsc
+++ b/server/samples/bo3/gscode_unresolved.gsc
@@ -1,0 +1,24 @@
+// BO3 (Treyarch GSC) — the unresolvable import, alone in its own file.
+//
+// It has to be alone, and that is worth knowing rather than working around. The import lints share
+// one resolution pass, and the pass reports NOTHING when any `#using` in the file failed to resolve:
+// once an import is missing, every "unused import" and every "declared but not imported" answer
+// would be drawn from a scope that is known to be incomplete, and the file would be covered in
+// errors pointing at calls instead of at the one line that is actually wrong.
+//
+// So 5009 suppresses 5001 and 5026, and a file demonstrating all three would demonstrate one. The
+// other two live in gscode_lints.gsc, which imports nothing broken.
+
+// expect 5009 — no such script under the raw root
+#using gscode_does_not_exist;
+
+#namespace gscode_unresolved;
+
+// What the import rules stand down on, the RESOLUTION rules still answer: the call below is
+// qualified, so it names a script location and no engine function could have matched it. The two
+// import rules go quiet; this one does not.
+function calls_into_the_missing_script()
+{
+	// expect 5013 — nothing in the workspace declares it
+	return gscode_does_not_exist::whatever();
+}

--- a/server/samples/bo3/gscode_unused.gsc
+++ b/server/samples/bo3/gscode_unused.gsc
@@ -1,0 +1,14 @@
+// BO3 (Treyarch GSC) — a file that exists only to be imported and ignored.
+//
+// gscode_lints.gsc has a `#using` for this and never calls anything in it, which is the whole of
+// what 5001 reports. It has to be a real, resolvable script: an import that does not resolve is
+// 5009 instead, and one file serving both rules would let either cover for the other.
+//
+// This file must produce ZERO diagnostics.
+
+#namespace gscode_unused;
+
+function unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/cod4/gscode.gsc
+++ b/server/samples/cod4/gscode.gsc
@@ -1,0 +1,304 @@
+// CoD4 (Infinity Ward GSC) — the showcase.
+//
+// Every construct the CoD4 dialect has, and correct: this file must produce ZERO diagnostics.
+//
+// Read it beside server/samples/bo3/gscode.gsc to see what the dialect actually
+// costs. This is the true base of the language, and most of what people think of as GSC arrived
+// later:
+//
+//   * no `function` keyword — a declaration is a name, a parameter list and a brace;
+//   * no `#using`, no `#namespace`, no `#insert`, no `#precache`, no `#define` and no `#if`. The
+//     preprocessor does not exist in this dialect, and a `#define` here is reported as such;
+//   * no classes, no `new`, no `->`;
+//   * no `foreach` — that is Infinity Ward's MW2 addition, and Treyarch's line does not get it
+//     until BO3. Iteration goes through GetArrayKeys;
+//   * no `do`/`while`, no `const`, no `autoexec`/`private`, no `vararg`;
+//   * `::` is the function pointer, and a bare qualified name IS the pointer — parentheses would
+//     call it. BO3 spells the same thing `&foo`;
+//   * a path may be written inline at a call: gscode_target::target_by_path(), which
+//     reaches a file this one never included;
+//   * ScriptDoc is `///ScriptDocBegin` inside an ordinary block comment, not BO3's `/@ … @/`.
+
+#include gscode_target;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: Calls every demonstration below, so nothing here is unreachable."
+"CallOn: level"
+"SPMP: MP"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	literals();
+	operators();
+	control_flow();
+	calls_and_pointers();
+	events();
+	includes();
+
+	/#
+	dev_only();
+	#/
+}
+
+/*
+///ScriptDocBegin
+"Name: helper( <first>, <second> )"
+"Summary: Adds two numbers. There are no default parameters in this dialect."
+"MandatoryArg: <first> : the left operand"
+"MandatoryArg: <second> : the right operand"
+///ScriptDocEnd
+*/
+helper( first, second )
+{
+	return first + second;
+}
+
+// ---------------------------------------------------------------------------
+// Literals. No hash strings — `#"…"` is a Treyarch feature and arrives with
+// BO1 — and no `const`.
+// ---------------------------------------------------------------------------
+
+literals()
+{
+	integer = 42;
+	real = 3.14;
+	hex = 0xFF;
+	text = "plain string";
+	localized = &"MENU_QUIT";
+
+	yes = true;
+	no = false;
+	nothing = undefined;
+
+	vector = ( 0, 0, 1 );
+
+	array = [];
+	array[ 0 ] = "by index";
+	array[ "key" ] = "by key";
+
+	structure = spawnstruct();
+	structure.field = 10;
+
+	bundle = [];
+	bundle[ 0 ] = integer;
+	bundle[ 1 ] = real;
+	bundle[ 2 ] = hex;
+	bundle[ 3 ] = text;
+	bundle[ 4 ] = localized;
+	bundle[ 5 ] = yes;
+	bundle[ 6 ] = no;
+	bundle[ 7 ] = nothing;
+	bundle[ 8 ] = vector;
+	bundle[ 9 ] = array;
+	bundle[ 10 ] = structure;
+
+	return bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Operators. No `===` / `!==`: identity comparison is Treyarch's.
+// ---------------------------------------------------------------------------
+
+operators()
+{
+	left = 7;
+	right = 3;
+
+	added = left + right;
+	subtracted = left - right;
+	multiplied = left * right;
+	divided = left / right;
+	remainder = left % right;
+
+	bit_and = left & right;
+	bit_or = left | right;
+	bit_xor = left ^ right;
+	shifted_left = left << 1;
+	shifted_right = left >> 1;
+	bit_not = ~left;
+	negated = -left;
+
+	equal = left == right;
+	unequal = left != right;
+	less = left < right;
+	less_or_equal = left <= right;
+	greater = left > right;
+	greater_or_equal = left >= right;
+
+	both = ( left > 0 ) && ( right > 0 );
+	either = ( left > 0 ) || ( right > 0 );
+	inverted = !equal;
+
+	left++;
+	left--;
+	left += 1;
+	left -= 1;
+	left *= 2;
+	left /= 2;
+
+	if ( unequal && less && less_or_equal && greater && greater_or_equal && both && either
+		&& inverted && isdefined( left ) )
+	{
+		return added + subtracted + multiplied + divided + remainder
+			+ bit_and + bit_or + bit_xor + shifted_left + shifted_right + bit_not + negated;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Control flow. No `foreach` and no `do`/`while`; an array is walked through
+// its keys.
+// ---------------------------------------------------------------------------
+
+control_flow()
+{
+	count = 0;
+
+	if ( count == 0 )
+	{
+		count = 1;
+	}
+	else if ( count == 1 )
+	{
+		count = 2;
+	}
+	else
+	{
+		count = 3;
+	}
+
+	if ( count > 0 )
+		count--;
+
+	while ( count < 4 )
+	{
+		count++;
+		if ( count == 2 )
+		{
+			continue;
+		}
+	}
+
+	for ( index = 0; index < 4; index++ )
+	{
+		if ( index == 3 )
+		{
+			break;
+		}
+	}
+
+	for ( ;; )
+	{
+		break;
+	}
+
+	items = [];
+	items[ "first" ] = "a";
+	items[ "second" ] = "b";
+
+	keys = getarraykeys( items );
+	for ( index = 0; index < keys.size; index++ )
+	{
+		count += items[ keys[ index ] ].size;
+	}
+
+	switch ( count )
+	{
+		case 0:
+		case 1:
+			count = 10;
+			break;
+		case "string_case":
+			count = 20;
+			break;
+		default:
+			count = 30;
+			break;
+	}
+
+	wait 0.05;
+	waittillframeend;
+
+	assert( count > 0 );
+
+	prof_begin( "control_flow" );
+	prof_end( "control_flow" );
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// Calls, threads and pointers. `::` without parentheses IS the pointer.
+// ---------------------------------------------------------------------------
+
+calls_and_pointers()
+{
+	plain = helper( 1, 2 );
+
+	pointer = gscode_target::target_helper;
+	through_pointer = [[ pointer ]]( 1 );
+
+	by_path = gscode_target::target_by_path();
+
+	entity = spawnstruct();
+	entity method_style();
+	entity thread method_style();
+	entity thread [[ pointer ]]( 1 );
+	thread method_style();
+
+	return plain + through_pointer + by_path.size;
+}
+
+method_style()
+{
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Notify, waittill and endon — unchanged since the first game.
+// ---------------------------------------------------------------------------
+
+events()
+{
+	level endon( "game_ended" );
+
+	thread waiter();
+
+	level waittill( "custom_event", first, second );
+	level waittillmatch( "custom_event", 1 );
+
+	return first + second;
+}
+
+waiter()
+{
+	wait 0.1;
+	level notify( "custom_event", 1, 2 );
+}
+
+// ---------------------------------------------------------------------------
+// The included file. `target_helper` is called by BARE name: #include merges
+// it into this file's scope rather than qualifying it.
+// ---------------------------------------------------------------------------
+
+includes()
+{
+	return target_helper( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Dev blocks — present from the first game.
+// ---------------------------------------------------------------------------
+
+/#
+dev_only()
+{
+	println( "dev build" );
+}
+#/

--- a/server/samples/cod4/gscode_broken.gsc
+++ b/server/samples/cod4/gscode_broken.gsc
@@ -1,0 +1,89 @@
+// CoD4 (Infinity Ward GSC) — the lexer and parser errors.
+//
+// Kept away from gscode_lints.gsc for the reason that file explains: a syntax error puts the parser
+// into recovery, several lints stand down entirely on a file the parser could not read, and
+// everything below the error is judged against a tree that is missing pieces.
+//
+// This dialect has no preprocessor, so there is no 2000 range here beyond the one diagnostic that
+// says exactly that — and that one lives in gscode_lints.gsc, because it does not break the parse.
+
+// ---------------------------------------------------------------------------
+// A keyword from a later dialect, in a position the parser has no production
+// for. This is the other half of 5025: where `vectorscale( … )` in
+// gscode_lints.gsc is a call the parser accepts and the rule simply explains, a
+// `foreach` header is not something the CoD4 grammar can read at all.
+//
+// 5025 still names it — the rule works from the WORD, not from a well-formed
+// call — but it arrives buried in a cascade of syntax errors, and that is the
+// difference worth seeing. It is also what a user porting a BO3 script actually
+// gets, and the reason the two cases live in two different files: this cascade
+// would take the rest of gscode_lints.gsc down with it.
+// ---------------------------------------------------------------------------
+
+keyword_from_a_later_dialect()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 3000 — expected ')' but found 'in'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3003 — and then no statement at all
+	// expect 5025 — the one diagnostic in the pile that says what is actually wrong
+	// expect 5016 — `item` and `in` both read as variables nothing assigns
+	// expect 5016
+	foreach ( item in items )
+	{
+		items[ 1 ] = item;
+	}
+	// expect 3001 — recovery never gets back in step, so the closing brace has nothing to close
+}
+
+// ---------------------------------------------------------------------------
+// 3000 range proper.
+// ---------------------------------------------------------------------------
+
+missing_semicolon()
+{
+	// expect 3014 — a statement ends with a semicolon
+	value = 1
+
+	return value;
+}
+
+bad_assignment_target()
+{
+	// expect 3012 — a literal is not somewhere a value can be stored
+	1 = 2;
+
+	// expect 3013 — an assignment in a condition is almost always a typo for ==
+	if ( value = 1 )
+	{
+		return value;
+	}
+}
+
+missing_expression()
+{
+	// expect 3002 — nothing to the right of the operator
+	return 1 +;
+}
+
+// ---------------------------------------------------------------------------
+// 1000 range — the lexer, and the block that never closes. Last, because
+// nothing after it is read as anything.
+// ---------------------------------------------------------------------------
+
+unterminated_string()
+{
+	// expect 1000 — no closing quote before the end of the line
+	// expect 3014 — so the statement never ends either
+	return "this string never ends;
+}
+
+unterminated_block()
+// expect 3007 — this brace is never closed, and neither is the file
+{
+	// expect 5008 — the one lint that still has something to say down here
+	value = 1;

--- a/server/samples/cod4/gscode_lints.gsc
+++ b/server/samples/cod4/gscode_lints.gsc
@@ -1,0 +1,218 @@
+// CoD4 (Infinity Ward GSC) — the deliberate findings.
+//
+// The same arrangement as the BO3 lints file: one mistake at a time, each declared by the
+// `// expect <code>` comment above it, and the file still parses cleanly so every rule is judged
+// against a complete tree.
+//
+// What is different is which rules can fire at all. Two whole families are missing here because the
+// dialect has nothing for them to be about — no #precache, so no 4000/4001/4006; no classes, so no
+// 5021 and no 4002/4003 — and two exist ONLY here, because they are about the include model that
+// BO3 replaced. Those two are 5012 and 5026, and they are the reason this file is not a translation
+// of the BO3 one.
+
+// Included and never used. The `#include` twin of BO3's 5001.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// Note what is NOT included: gscode_target. That is what 5026 below rests on.
+
+// ---------------------------------------------------------------------------
+// The dialect boundary. These are not mistakes in another game.
+// ---------------------------------------------------------------------------
+
+// The preprocessor arrives with BO3. Reported once for the file rather than once per directive, and
+// the macro still EXPANDS — telling the author the directive does not exist while silently dropping
+// its effect would produce a second, invented error at every use.
+// expect 2016 — #define is not in this dialect
+#define NOT_IN_THIS_DIALECT 1
+
+main()
+{
+	// `vectorscale` is one of BO3's intrinsics. Here it is an ordinary identifier, so this line
+	// reads as a call to a function that does not exist.
+	//
+	// Before this rule it was reported as a missing ENGINE function, which sent people looking for
+	// a builtin that never existed in any game. Naming the real problem — a word that is a keyword
+	// in a LATER dialect — is the whole of what 5025 adds.
+	// expect 5025 — `vectorscale` is not in this dialect
+	scaled = vectorscale( ( 0, 0, 1 ), 64 );
+
+	// A word that is a keyword in a later dialect is not always a call. `foreach` is Infinity Ward's
+	// MW2 addition, and writing one here is a SYNTAX error rather than a diagnostic about the
+	// dialect — the parser has no production for it, so there is nothing left to name. That case
+	// lives in gscode_broken.gsc, where a cascade cannot take the rest of this file with it.
+
+	return scaled;
+}
+
+// ---------------------------------------------------------------------------
+// The include model.
+// ---------------------------------------------------------------------------
+
+calls_that_do_not_resolve()
+{
+	// Declared in gscode_target.gsc, which this file does not include. The analyser can
+	// find it — hover and go-to-definition both work on this line — but the game's compiler will
+	// not link the call, so the script does not load. That gap is what the rule exists for.
+	// expect 5026 — declared in a file this one does not include
+	target_never_included();
+
+	// Nothing anywhere declares this, which is a different story and a different code.
+	// expect 5014 — matches no script function and no known engine function
+	NoSuchEngineFunction();
+
+	// A path call names its file outright, so it needs no #include.
+	//
+	// What it is reported AS depends on how many segments the path has, and the samples sit at the
+	// boundary. A multi-segment path — maps\mp\gscode_no_such_file::whatever() — is unambiguously
+	// a path, so a missing one is reported against the PATH, once for the file rather than once per
+	// call. A single segment is not: with the samples rooted flat, `gscode_no_such_file` could be a
+	// file or a namespace, and the call is judged as a function that no script location declares.
+	//
+	// Both answers are defensible and only one of them names the actual problem, so this line is
+	// worth keeping an eye on.
+	// expect 5013 — no script location declares it
+	gscode_no_such_file::whatever();
+
+	// expect 5023 — the engine's Abs takes exactly one
+	abs();
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals — the same rules as every other dialect.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	// expect 5019 — ClearAllCorpses returns nothing, so this assigns undefined
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only builtins — 5006 — cannot be shown on this game, and the reason is
+// our data rather than the dialect.
+//
+// The rule reports an engine function that only exists in a development build
+// being called from release code, and the call below is exactly that: Print3d
+// is dev-only in every game that has it. It is not reported here because
+// cod4_api_gsc.json carries an explicit "devOnly": false on every entry, and an
+// explicit false beats the fallback list in DevOnlyBuiltins. The BO3 library
+// marks two entries dev-only, so the BO3 lints file is where 5006 is pinned.
+//
+// Left here, uncommented and unexpected-free, so that the day CoD4's data is
+// curated this sample fails and asks to be updated.
+// ---------------------------------------------------------------------------
+
+dev_only_calls()
+{
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+
+	/#
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+	#/
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/cod4/gscode_target.gsc
+++ b/server/samples/cod4/gscode_target.gsc
@@ -1,0 +1,42 @@
+// CoD4 (Infinity Ward GSC) — the second file.
+//
+// The Infinity Ward dialects have no namespaces. `#include` MERGES a file's functions into the
+// including file's scope, so everything here is called by bare name from gscode.gsc — and two files
+// declaring `main` are two different functions only because nothing includes both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: target_helper( <value> )"
+"Summary: Adds one. Exists so another file has something to call."
+"MandatoryArg: <value> : the number to add to"
+"Example: result = target_helper( 1 );"
+///ScriptDocEnd
+*/
+target_helper( value )
+{
+	return value + 1;
+}
+
+/*
+///ScriptDocBegin
+"Name: target_never_included()"
+"Summary: Called by gscode_lints.gsc, which includes a different file. That is 5026."
+///ScriptDocEnd
+*/
+target_never_included()
+{
+	return "reached";
+}
+
+/*
+///ScriptDocBegin
+"Name: target_by_path()"
+"Summary: Reached as gscode_target::target_by_path(), which needs no #include at all."
+///ScriptDocEnd
+*/
+target_by_path()
+{
+	return "by path";
+}

--- a/server/samples/cod4/gscode_unresolved.gsc
+++ b/server/samples/cod4/gscode_unresolved.gsc
@@ -1,0 +1,24 @@
+// CoD4 (Infinity Ward GSC) — the unresolvable include, alone in its own file.
+//
+// It has to be alone, and that is worth knowing rather than working around. The import lints share
+// one resolution pass, and the pass reports NOTHING when any `#include` in the file failed to
+// resolve: once an import is missing, every "unused include" and every "declared but not included"
+// answer would be drawn from a scope that is known to be incomplete, and the file would be covered
+// in errors pointing at calls instead of at the one line that is actually wrong.
+//
+// So 5009 suppresses 5012 and 5026, and a file demonstrating all three would demonstrate one. The
+// other two live in gscode_lints.gsc, which includes nothing broken.
+//
+// The .csc side has the same arrangement for the same reason; see gscode_lints.csc.
+
+// expect 5009 — no such script under the raw root
+#include gscode_does_not_exist;
+
+// What the import rules stand down on, the RESOLUTION rules still answer. The two are gated
+// separately and on different evidence, so a file with a broken include is not a file the editor
+// goes silent about.
+calls_into_the_missing_script()
+{
+	// expect 5014 — matches no script function and no known engine function
+	return does_not_exist_anywhere();
+}

--- a/server/samples/cod4/gscode_unused.gsc
+++ b/server/samples/cod4/gscode_unused.gsc
@@ -1,0 +1,11 @@
+// CoD4 (Infinity Ward GSC) — a file that exists only to be included and ignored.
+//
+// gscode_lints.gsc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports — the `#include` twin of BO3's 5001.
+//
+// This file must produce ZERO diagnostics.
+
+unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/mw2/gscode.gsc
+++ b/server/samples/mw2/gscode.gsc
@@ -1,0 +1,326 @@
+// MW2 (Infinity Ward GSC) — the showcase.
+//
+// Every construct the MW2 dialect has, and correct: this file must produce ZERO diagnostics.
+//
+// Read it beside server/samples/bo3/gscode.gsc to see what the dialect actually
+// costs. This is the true base of the language, and most of what people think of as GSC arrived
+// later:
+//
+//   * no `function` keyword — a declaration is a name, a parameter list and a brace;
+//   * no `#using`, no `#namespace`, no `#insert`, no `#precache`, no `#define` and no `#if`. The
+//     preprocessor does not exist in this dialect, and a `#define` here is reported as such;
+//   * no classes, no `new`, no `->`;
+//   * `foreach` IS here — MW2 is the game that added it on the Infinity Ward line, and Treyarch's
+//     line does not get it until BO3. So MW2 is newer than nothing and older than BO3 and has it,
+//     while BO1 is newer than MW2 and does not: the feature is a family fork, not a timeline;
+//   * no `do`/`while`, no `const`, no `autoexec`/`private`, no `vararg`;
+//   * `childthread` and `call` are MW2's own, and are their own token kinds rather than spellings
+//     of `thread`: `childthread foo()` is a threaded call whose thread dies with its parent, and
+//     `call [[ ptr ]]( … )` is a SYNCHRONOUS call through a pointer;
+//   * `thisthread` is the running thread as a VALUE, which is a third shape again — not a call
+//     modifier, so it reads as an ordinary expression;
+//   * file-scope constants: a bare `NAME = value;` outside any function;
+//   * `::` is the function pointer, and a bare qualified name IS the pointer — parentheses would
+//     call it. BO3 spells the same thing `&foo`;
+//   * a path may be written inline at a call: gscode_target::target_by_path(), which
+//     reaches a file this one never included;
+//   * ScriptDoc is `///ScriptDocBegin` inside an ordinary block comment, not BO3's `/@ … @/`.
+
+#include gscode_target;
+
+// A file-scope constant: a bare assignment outside any function. Only the Infinity Ward line from
+// MW2 has these, and they are not `const` — the name is file-scoped and is not a local of anything,
+// which is why the per-function rules about locals must refuse to speak about it.
+MAX_COUNT = 4;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: Calls every demonstration below, so nothing here is unreachable."
+"CallOn: level"
+"SPMP: MP"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	literals();
+	operators();
+	control_flow();
+	calls_and_pointers();
+	events();
+	includes();
+
+	/#
+	dev_only();
+	#/
+}
+
+/*
+///ScriptDocBegin
+"Name: helper( <first>, <second> )"
+"Summary: Adds two numbers. There are no default parameters in this dialect."
+"MandatoryArg: <first> : the left operand"
+"MandatoryArg: <second> : the right operand"
+///ScriptDocEnd
+*/
+helper( first, second )
+{
+	return first + second;
+}
+
+// ---------------------------------------------------------------------------
+// Literals. No hash strings — `#"…"` is a Treyarch feature and arrives with
+// BO1 — and no `const`.
+// ---------------------------------------------------------------------------
+
+literals()
+{
+	integer = 42;
+	real = 3.14;
+	hex = 0xFF;
+	text = "plain string";
+	localized = &"MENU_QUIT";
+
+	yes = true;
+	no = false;
+	nothing = undefined;
+
+	vector = ( 0, 0, 1 );
+
+	array = [];
+	array[ 0 ] = "by index";
+	array[ "key" ] = "by key";
+
+	structure = spawnstruct();
+	structure.field = 10;
+
+	bundle = [];
+	bundle[ 0 ] = integer;
+	bundle[ 1 ] = real;
+	bundle[ 2 ] = hex;
+	bundle[ 3 ] = text;
+	bundle[ 4 ] = localized;
+	bundle[ 5 ] = yes;
+	bundle[ 6 ] = no;
+	bundle[ 7 ] = nothing;
+	bundle[ 8 ] = vector;
+	bundle[ 9 ] = array;
+	bundle[ 10 ] = structure;
+
+	return bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Operators. No `===` / `!==`: identity comparison is Treyarch's.
+// ---------------------------------------------------------------------------
+
+operators()
+{
+	left = 7;
+	right = 3;
+
+	added = left + right;
+	subtracted = left - right;
+	multiplied = left * right;
+	divided = left / right;
+	remainder = left % right;
+
+	bit_and = left & right;
+	bit_or = left | right;
+	bit_xor = left ^ right;
+	shifted_left = left << 1;
+	shifted_right = left >> 1;
+	bit_not = ~left;
+	negated = -left;
+
+	equal = left == right;
+	unequal = left != right;
+	less = left < right;
+	less_or_equal = left <= right;
+	greater = left > right;
+	greater_or_equal = left >= right;
+
+	both = ( left > 0 ) && ( right > 0 );
+	either = ( left > 0 ) || ( right > 0 );
+	inverted = !equal;
+
+	left++;
+	left--;
+	left += 1;
+	left -= 1;
+	left *= 2;
+	left /= 2;
+
+	if ( unequal && less && less_or_equal && greater && greater_or_equal && both && either
+		&& inverted && isdefined( left ) )
+	{
+		return added + subtracted + multiplied + divided + remainder
+			+ bit_and + bit_or + bit_xor + shifted_left + shifted_right + bit_not + negated;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Control flow. `foreach` in both its forms; still no `do`/`while`.
+// ---------------------------------------------------------------------------
+
+control_flow()
+{
+	count = 0;
+
+	if ( count == 0 )
+	{
+		count = 1;
+	}
+	else if ( count == 1 )
+	{
+		count = 2;
+	}
+	else
+	{
+		count = 3;
+	}
+
+	if ( count > 0 )
+		count--;
+
+	while ( count < MAX_COUNT )
+	{
+		count++;
+		if ( count == 2 )
+		{
+			continue;
+		}
+	}
+
+	for ( index = 0; index < 4; index++ )
+	{
+		if ( index == 3 )
+		{
+			break;
+		}
+	}
+
+	for ( ;; )
+	{
+		break;
+	}
+
+	items = [];
+	items[ "first" ] = "a";
+	items[ "second" ] = "b";
+
+	foreach ( item in items )
+	{
+		count += item.size;
+	}
+
+	foreach ( key, value in items )
+	{
+		count += key.size + value.size;
+	}
+
+	switch ( count )
+	{
+		case 0:
+		case 1:
+			count = 10;
+			break;
+		case "string_case":
+			count = 20;
+			break;
+		default:
+			count = 30;
+			break;
+	}
+
+	wait 0.05;
+	waittillframeend;
+
+	assert( count > 0 );
+
+	prof_begin( "control_flow" );
+	prof_end( "control_flow" );
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// Calls, threads and pointers. `::` without parentheses IS the pointer.
+// ---------------------------------------------------------------------------
+
+calls_and_pointers()
+{
+	plain = helper( 1, 2 );
+
+	pointer = gscode_target::target_helper;
+	through_pointer = [[ pointer ]]( 1 );
+
+	by_path = gscode_target::target_by_path();
+
+	entity = spawnstruct();
+	entity method_style();
+	entity thread method_style();
+	entity thread [[ pointer ]]( 1 );
+	thread method_style();
+
+	// MW2's own three. `childthread` threads a call whose thread ends with this one; `call`
+	// invokes a pointer synchronously, where `[[ ptr ]]( … )` alone would also do; and
+	// `thisthread` is the running thread as a value, so it is read rather than called.
+	childthread method_style();
+	called = call [[ pointer ]]( 1 );
+	running = thisthread;
+
+	return plain + through_pointer + by_path.size + called + running.size;
+}
+
+method_style()
+{
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Notify, waittill and endon — unchanged since the first game.
+// ---------------------------------------------------------------------------
+
+events()
+{
+	level endon( "game_ended" );
+
+	thread waiter();
+
+	level waittill( "custom_event", first, second );
+	level waittillmatch( "custom_event", 1 );
+
+	return first + second;
+}
+
+waiter()
+{
+	wait 0.1;
+	level notify( "custom_event", 1, 2 );
+}
+
+// ---------------------------------------------------------------------------
+// The included file. `target_helper` is called by BARE name: #include merges
+// it into this file's scope rather than qualifying it.
+// ---------------------------------------------------------------------------
+
+includes()
+{
+	return target_helper( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Dev blocks — present from the first game.
+// ---------------------------------------------------------------------------
+
+/#
+dev_only()
+{
+	println( "dev build" );
+}
+#/

--- a/server/samples/mw2/gscode_broken.gsc
+++ b/server/samples/mw2/gscode_broken.gsc
@@ -1,0 +1,91 @@
+// MW2 (Infinity Ward GSC) — the lexer and parser errors.
+//
+// Kept away from gscode_lints.gsc for the reason that file explains: a syntax error puts the parser
+// into recovery, several lints stand down entirely on a file the parser could not read, and
+// everything below the error is judged against a tree that is missing pieces.
+//
+// This dialect has no preprocessor, so there is no 2000 range here beyond the one diagnostic that
+// says exactly that — and that one lives in gscode_lints.gsc, because it does not break the parse.
+
+// ---------------------------------------------------------------------------
+// A keyword from a later dialect, in a position the parser has no production
+// for.
+//
+// The CoD4 sample uses `foreach` here. MW2 is the game that ADDED `foreach`, so
+// that example is correct code in this dialect — which is the point of keeping
+// one sample per game rather than one per family. `do`/`while` is MW2's version
+// of the same situation: it is BO3's addition on the Treyarch line and has no
+// production here, so the loop below is read as a call to a function named `do`
+// followed by wreckage.
+//
+// This is what a user porting a BO3 script actually gets, and the reason the
+// case lives here rather than in gscode_lints.gsc: the cascade would take the
+// rest of that file down with it.
+// ---------------------------------------------------------------------------
+
+keyword_from_a_later_dialect()
+{
+	count = 4;
+
+	// Fewer errors than the CoD4 case, and that is worse rather than better: `do` reads as an
+	// ordinary identifier, so the line parses as a bare expression that is missing its semicolon,
+	// the block below it becomes an unrelated block, and the `while` becomes a loop with an empty
+	// body. The script compiles to something, and it is not the loop that was written.
+	// expect 3014 — `do` is a name here, so the statement wants a semicolon
+	// expect 5016 — and it reads as a variable nothing ever assigned
+	do
+	{
+		count--;
+	}
+	while ( count > 0 );
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// 3000 range proper.
+// ---------------------------------------------------------------------------
+
+missing_semicolon()
+{
+	// expect 3014 — a statement ends with a semicolon
+	value = 1
+
+	return value;
+}
+
+bad_assignment_target()
+{
+	// expect 3012 — a literal is not somewhere a value can be stored
+	1 = 2;
+
+	// expect 3013 — an assignment in a condition is almost always a typo for ==
+	if ( value = 1 )
+	{
+		return value;
+	}
+}
+
+missing_expression()
+{
+	// expect 3002 — nothing to the right of the operator
+	return 1 +;
+}
+
+// ---------------------------------------------------------------------------
+// 1000 range — the lexer, and the block that never closes. Last, because
+// nothing after it is read as anything.
+// ---------------------------------------------------------------------------
+
+unterminated_string()
+{
+	// expect 1000 — no closing quote before the end of the line
+	// expect 3014 — so the statement never ends either
+	return "this string never ends;
+}
+
+unterminated_block()
+// expect 3007 — this brace is never closed, and neither is the file
+{
+	// expect 5008 — the one lint that still has something to say down here
+	value = 1;

--- a/server/samples/mw2/gscode_lints.gsc
+++ b/server/samples/mw2/gscode_lints.gsc
@@ -1,0 +1,234 @@
+// MW2 (Infinity Ward GSC) — the deliberate findings.
+//
+// The same arrangement as the BO3 lints file: one mistake at a time, each declared by the
+// `// expect <code>` comment above it, and the file still parses cleanly so every rule is judged
+// against a complete tree.
+//
+// What is different is which rules can fire at all. Two whole families are missing here because the
+// dialect has nothing for them to be about — no #precache, so no 4000/4001/4006; no classes, so no
+// 5021 and no 4002/4003 — and two exist ONLY here, because they are about the include model that
+// BO3 replaced. Those two are 5012 and 5026, and they are the reason this file is not a translation
+// of the BO3 one.
+
+// Included and never used. The `#include` twin of BO3's 5001.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// Note what is NOT included: gscode_target. That is what 5026 below rests on.
+
+// ---------------------------------------------------------------------------
+// The dialect boundary. These are not mistakes in another game.
+// ---------------------------------------------------------------------------
+
+// The preprocessor arrives with BO3. Reported once for the file rather than once per directive, and
+// the macro still EXPANDS — telling the author the directive does not exist while silently dropping
+// its effect would produce a second, invented error at every use.
+// expect 2016 — #define is not in this dialect
+#define NOT_IN_THIS_DIALECT 1
+
+main()
+{
+	// `vectorscale` is one of BO3's intrinsics. Here it is an ordinary identifier, so this line
+	// reads as a call to a function that does not exist.
+	//
+	// Before this rule it was reported as a missing ENGINE function, which sent people looking for
+	// a builtin that never existed in any game. Naming the real problem — a word that is a keyword
+	// in a LATER dialect — is the whole of what 5025 adds.
+	scaled = vectorscale( ( 0, 0, 1 ), 64 );
+
+	// A word that is a keyword in a later dialect is not always a call. `foreach` is Infinity Ward's
+	// MW2 addition, and writing one here is a SYNTAX error rather than a diagnostic about the
+	// dialect — the parser has no production for it, so there is nothing left to name. That case
+	// lives in gscode_broken.gsc, where a cascade cannot take the rest of this file with it.
+
+	return scaled;
+}
+
+// ---------------------------------------------------------------------------
+// What is NOT reported here, and why it is our data rather than the dialect.
+//
+// Modern Warfare 2 is a Supported game whose bundled engine library is not marked complete
+// or signature-reliable — the wordfile it was built from lists names without
+// arity, and the list itself is known to be short. Every rule that reasons
+// about ENGINE functions therefore stands down on this game, so that the editor
+// never blames a user for a hole in our data:
+//
+//   * 5025 — a word that is a keyword only in a later dialect. It reaches the
+//     user through the same resolution path, so it is gated with the rest.
+//   * 5014 — a call matching no script function and no known engine function.
+//   * 5023 — an engine call's argument count, which needs signatures to check.
+//
+// The calls below are left in place, uncommented and carrying no `expect`, so
+// that the day Modern Warfare 2's library is curated this sample fails and asks to be
+// brought up to date. That is the only reminder a gate like this ever gets.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// The include model.
+// ---------------------------------------------------------------------------
+
+calls_that_do_not_resolve()
+{
+	// Declared in gscode_target.gsc, which this file does not include. The analyser can
+	// find it — hover and go-to-definition both work on this line — but the game's compiler will
+	// not link the call, so the script does not load. That gap is what the rule exists for.
+	// expect 5026 — declared in a file this one does not include
+	target_never_included();
+
+	// Nothing anywhere declares this, which is a different story and a different code.
+	NoSuchEngineFunction();
+
+	// A path call names its file outright, so it needs no #include.
+	//
+	// What it is reported AS depends on how many segments the path has, and the samples sit at the
+	// boundary. A multi-segment path — maps\mp\gscode_no_such_file::whatever() — is unambiguously
+	// a path, so a missing one is reported against the PATH, once for the file rather than once per
+	// call. A single segment is not: with the samples rooted flat, `gscode_no_such_file` could be a
+	// file or a namespace, and the call is judged as a function that no script location declares.
+	//
+	// Both answers are defensible and only one of them names the actual problem, so this line is
+	// worth keeping an eye on.
+	// expect 5013 — no script location declares it
+	gscode_no_such_file::whatever();
+
+	abs();
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals — the same rules as every other dialect.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	// expect 5019 — ClearAllCorpses returns nothing, so this assigns undefined
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only builtins — 5006 — cannot be shown on this game, and the reason is
+// our data rather than the dialect.
+//
+// The rule reports an engine function that only exists in a development build
+// being called from release code, and the call below is exactly that: Print3d
+// is dev-only in every game that has it. It is not reported here because
+// cod4_api_gsc.json carries an explicit "devOnly": false on every entry, and an
+// explicit false beats the fallback list in DevOnlyBuiltins. The BO3 library
+// marks two entries dev-only, so the BO3 lints file is where 5006 is pinned.
+//
+// Left here, uncommented and unexpected-free, so that the day MW2's data is
+// curated this sample fails and asks to be updated.
+// ---------------------------------------------------------------------------
+
+dev_only_calls()
+{
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+
+	/#
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+	#/
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/mw2/gscode_target.gsc
+++ b/server/samples/mw2/gscode_target.gsc
@@ -1,0 +1,42 @@
+// MW2 (Infinity Ward GSC) — the second file.
+//
+// The Infinity Ward dialects have no namespaces. `#include` MERGES a file's functions into the
+// including file's scope, so everything here is called by bare name from gscode.gsc — and two files
+// declaring `main` are two different functions only because nothing includes both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: target_helper( <value> )"
+"Summary: Adds one. Exists so another file has something to call."
+"MandatoryArg: <value> : the number to add to"
+"Example: result = target_helper( 1 );"
+///ScriptDocEnd
+*/
+target_helper( value )
+{
+	return value + 1;
+}
+
+/*
+///ScriptDocBegin
+"Name: target_never_included()"
+"Summary: Called by gscode_lints.gsc, which includes a different file. That is 5026."
+///ScriptDocEnd
+*/
+target_never_included()
+{
+	return "reached";
+}
+
+/*
+///ScriptDocBegin
+"Name: target_by_path()"
+"Summary: Reached as gscode_target::target_by_path(), which needs no #include at all."
+///ScriptDocEnd
+*/
+target_by_path()
+{
+	return "by path";
+}

--- a/server/samples/mw2/gscode_unresolved.gsc
+++ b/server/samples/mw2/gscode_unresolved.gsc
@@ -1,0 +1,23 @@
+// MW2 (Infinity Ward GSC) — the unresolvable include, alone in its own file.
+//
+// It has to be alone, and that is worth knowing rather than working around. The import lints share
+// one resolution pass, and the pass reports NOTHING when any `#include` in the file failed to
+// resolve: once an import is missing, every "unused include" and every "declared but not included"
+// answer would be drawn from a scope that is known to be incomplete, and the file would be covered
+// in errors pointing at calls instead of at the one line that is actually wrong.
+//
+// So 5009 suppresses 5012 and 5026, and a file demonstrating all three would demonstrate one. The
+// other two live in gscode_lints.gsc, which includes nothing broken.
+//
+// The .csc side has the same arrangement for the same reason; see gscode_lints.csc.
+
+// expect 5009 — no such script under the raw root
+#include gscode_does_not_exist;
+
+// What the import rules stand down on, the RESOLUTION rules would still answer — but not on this
+// game, whose builtin library is not trusted, so 5014 is gated off here too. CoD4's copy of this
+// file pins that half; see the gate note in gscode_lints.gsc.
+calls_into_the_missing_script()
+{
+	return does_not_exist_anywhere();
+}

--- a/server/samples/mw2/gscode_unused.gsc
+++ b/server/samples/mw2/gscode_unused.gsc
@@ -1,0 +1,11 @@
+// MW2 (Infinity Ward GSC) — a file that exists only to be included and ignored.
+//
+// gscode_lints.gsc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports — the `#include` twin of BO3's 5001.
+//
+// This file must produce ZERO diagnostics.
+
+unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/waw/gscode.csc
+++ b/server/samples/waw/gscode.csc
@@ -1,0 +1,51 @@
+// WaW (Treyarch CSC) — the client-side showcase.
+//
+// Same grammar as this game's .gsc showcase, so this file does not repeat it. What it demonstrates
+// is everything the extension does DIFFERENTLY once the world is the client:
+//
+//   * a different engine library. Completion, hover and signature help are answered from the
+//     client API, and a server-only engine function does not resolve here;
+//   * a different set of Radiant keys. Treyarch's pre-BO3 games keep the client-side keys in a
+//     SECOND file, clientkeys.txt, where BO3 marks them with a `client` prefix in one file — two
+//     spellings of the same fact, and the reason the key data records a side at all;
+//   * separate import resolution. `#include gscode_target` finds gscode_target.csc from
+//     this file and gscode_target.gsc from the .gsc — two files, one path.
+//
+// There is no gscode_lints.csc for this game. The client-side rules all reason about engine
+// functions, and World at War's client library is not marked complete or signature-reliable, so every one
+// of them stands down here — see the gate note in gscode_lints.gsc. A lints file would assert that
+// nothing is reported, which is not a fact about the client world.
+//
+// This file must produce ZERO diagnostics.
+
+#include gscode_target;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: The client-side entry point."
+"CallOn: level"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	client_state();
+	includes();
+}
+
+client_state()
+{
+	origin = ( 0, 0, 0 );
+	structure = spawnstruct();
+	structure.origin = origin;
+
+	return structure;
+}
+
+// Resolves to gscode_target.csc, not to the .gsc of the same path.
+includes()
+{
+	return client_target_helper( 1 );
+}

--- a/server/samples/waw/gscode.gsc
+++ b/server/samples/waw/gscode.gsc
@@ -1,0 +1,304 @@
+// WaW (Treyarch GSC) — the showcase.
+//
+// Every construct the WaW dialect has, and correct: this file must produce ZERO diagnostics.
+//
+// Read it beside server/samples/bo3/gscode.gsc to see what the dialect actually
+// costs. This is the true base of the language, and most of what people think of as GSC arrived
+// later:
+//
+//   * no `function` keyword — a declaration is a name, a parameter list and a brace;
+//   * no `#using`, no `#namespace`, no `#insert`, no `#precache`, no `#define` and no `#if`. The
+//     preprocessor does not exist in this dialect, and a `#define` here is reported as such;
+//   * no classes, no `new`, no `->`;
+//   * no `foreach` — that is Infinity Ward's MW2 addition, and Treyarch's line does not get it
+//     until BO3. Iteration goes through GetArrayKeys;
+//   * no `do`/`while`, no `const`, no `autoexec`/`private`, no `vararg`;
+//   * `::` is the function pointer, and a bare qualified name IS the pointer — parentheses would
+//     call it. BO3 spells the same thing `&foo`;
+//   * a path may be written inline at a call: gscode_target::target_by_path(), which
+//     reaches a file this one never included;
+//   * ScriptDoc is `///ScriptDocBegin` inside an ordinary block comment, not BO3's `/@ … @/`.
+
+#include gscode_target;
+
+/*
+///ScriptDocBegin
+"Name: main()"
+"Summary: Calls every demonstration below, so nothing here is unreachable."
+"CallOn: level"
+"SPMP: MP"
+///ScriptDocEnd
+*/
+main()
+{
+	level endon( "game_ended" );
+
+	literals();
+	operators();
+	control_flow();
+	calls_and_pointers();
+	events();
+	includes();
+
+	/#
+	dev_only();
+	#/
+}
+
+/*
+///ScriptDocBegin
+"Name: helper( <first>, <second> )"
+"Summary: Adds two numbers. There are no default parameters in this dialect."
+"MandatoryArg: <first> : the left operand"
+"MandatoryArg: <second> : the right operand"
+///ScriptDocEnd
+*/
+helper( first, second )
+{
+	return first + second;
+}
+
+// ---------------------------------------------------------------------------
+// Literals. No hash strings — `#"…"` is a Treyarch feature and arrives with
+// BO1 — and no `const`.
+// ---------------------------------------------------------------------------
+
+literals()
+{
+	integer = 42;
+	real = 3.14;
+	hex = 0xFF;
+	text = "plain string";
+	localized = &"MENU_QUIT";
+
+	yes = true;
+	no = false;
+	nothing = undefined;
+
+	vector = ( 0, 0, 1 );
+
+	array = [];
+	array[ 0 ] = "by index";
+	array[ "key" ] = "by key";
+
+	structure = spawnstruct();
+	structure.field = 10;
+
+	bundle = [];
+	bundle[ 0 ] = integer;
+	bundle[ 1 ] = real;
+	bundle[ 2 ] = hex;
+	bundle[ 3 ] = text;
+	bundle[ 4 ] = localized;
+	bundle[ 5 ] = yes;
+	bundle[ 6 ] = no;
+	bundle[ 7 ] = nothing;
+	bundle[ 8 ] = vector;
+	bundle[ 9 ] = array;
+	bundle[ 10 ] = structure;
+
+	return bundle;
+}
+
+// ---------------------------------------------------------------------------
+// Operators. No `===` / `!==`: identity comparison is Treyarch's.
+// ---------------------------------------------------------------------------
+
+operators()
+{
+	left = 7;
+	right = 3;
+
+	added = left + right;
+	subtracted = left - right;
+	multiplied = left * right;
+	divided = left / right;
+	remainder = left % right;
+
+	bit_and = left & right;
+	bit_or = left | right;
+	bit_xor = left ^ right;
+	shifted_left = left << 1;
+	shifted_right = left >> 1;
+	bit_not = ~left;
+	negated = -left;
+
+	equal = left == right;
+	unequal = left != right;
+	less = left < right;
+	less_or_equal = left <= right;
+	greater = left > right;
+	greater_or_equal = left >= right;
+
+	both = ( left > 0 ) && ( right > 0 );
+	either = ( left > 0 ) || ( right > 0 );
+	inverted = !equal;
+
+	left++;
+	left--;
+	left += 1;
+	left -= 1;
+	left *= 2;
+	left /= 2;
+
+	if ( unequal && less && less_or_equal && greater && greater_or_equal && both && either
+		&& inverted && isdefined( left ) )
+	{
+		return added + subtracted + multiplied + divided + remainder
+			+ bit_and + bit_or + bit_xor + shifted_left + shifted_right + bit_not + negated;
+	}
+
+	return 0;
+}
+
+// ---------------------------------------------------------------------------
+// Control flow. No `foreach` and no `do`/`while`; an array is walked through
+// its keys.
+// ---------------------------------------------------------------------------
+
+control_flow()
+{
+	count = 0;
+
+	if ( count == 0 )
+	{
+		count = 1;
+	}
+	else if ( count == 1 )
+	{
+		count = 2;
+	}
+	else
+	{
+		count = 3;
+	}
+
+	if ( count > 0 )
+		count--;
+
+	while ( count < 4 )
+	{
+		count++;
+		if ( count == 2 )
+		{
+			continue;
+		}
+	}
+
+	for ( index = 0; index < 4; index++ )
+	{
+		if ( index == 3 )
+		{
+			break;
+		}
+	}
+
+	for ( ;; )
+	{
+		break;
+	}
+
+	items = [];
+	items[ "first" ] = "a";
+	items[ "second" ] = "b";
+
+	keys = getarraykeys( items );
+	for ( index = 0; index < keys.size; index++ )
+	{
+		count += items[ keys[ index ] ].size;
+	}
+
+	switch ( count )
+	{
+		case 0:
+		case 1:
+			count = 10;
+			break;
+		case "string_case":
+			count = 20;
+			break;
+		default:
+			count = 30;
+			break;
+	}
+
+	wait 0.05;
+	waittillframeend;
+
+	assert( count > 0 );
+
+	prof_begin( "control_flow" );
+	prof_end( "control_flow" );
+
+	return count;
+}
+
+// ---------------------------------------------------------------------------
+// Calls, threads and pointers. `::` without parentheses IS the pointer.
+// ---------------------------------------------------------------------------
+
+calls_and_pointers()
+{
+	plain = helper( 1, 2 );
+
+	pointer = gscode_target::target_helper;
+	through_pointer = [[ pointer ]]( 1 );
+
+	by_path = gscode_target::target_by_path();
+
+	entity = spawnstruct();
+	entity method_style();
+	entity thread method_style();
+	entity thread [[ pointer ]]( 1 );
+	thread method_style();
+
+	return plain + through_pointer + by_path.size;
+}
+
+method_style()
+{
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Notify, waittill and endon — unchanged since the first game.
+// ---------------------------------------------------------------------------
+
+events()
+{
+	level endon( "game_ended" );
+
+	thread waiter();
+
+	level waittill( "custom_event", first, second );
+	level waittillmatch( "custom_event", 1 );
+
+	return first + second;
+}
+
+waiter()
+{
+	wait 0.1;
+	level notify( "custom_event", 1, 2 );
+}
+
+// ---------------------------------------------------------------------------
+// The included file. `target_helper` is called by BARE name: #include merges
+// it into this file's scope rather than qualifying it.
+// ---------------------------------------------------------------------------
+
+includes()
+{
+	return target_helper( 1 );
+}
+
+// ---------------------------------------------------------------------------
+// Dev blocks — present from the first game.
+// ---------------------------------------------------------------------------
+
+/#
+dev_only()
+{
+	println( "dev build" );
+}
+#/

--- a/server/samples/waw/gscode_broken.gsc
+++ b/server/samples/waw/gscode_broken.gsc
@@ -1,0 +1,88 @@
+// WaW (Treyarch GSC) — the lexer and parser errors.
+//
+// Kept away from gscode_lints.gsc for the reason that file explains: a syntax error puts the parser
+// into recovery, several lints stand down entirely on a file the parser could not read, and
+// everything below the error is judged against a tree that is missing pieces.
+//
+// This dialect has no preprocessor, so there is no 2000 range here beyond the one diagnostic that
+// says exactly that — and that one lives in gscode_lints.gsc, because it does not break the parse.
+
+// ---------------------------------------------------------------------------
+// A keyword from a later dialect, in a position the parser has no production
+// for. This is the other half of 5025: where `vectorscale( … )` in
+// gscode_lints.gsc is a call the parser accepts and the rule simply explains, a
+// `foreach` header is not something the WaW grammar can read at all.
+//
+// 5025 still names it — the rule works from the WORD, not from a well-formed
+// call — but it arrives buried in a cascade of syntax errors, and that is the
+// difference worth seeing. It is also what a user porting a BO3 script actually
+// gets, and the reason the two cases live in two different files: this cascade
+// would take the rest of gscode_lints.gsc down with it.
+// ---------------------------------------------------------------------------
+
+keyword_from_a_later_dialect()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 3000 — expected ')' but found 'in'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3000 — and ';'
+	// expect 3003 — and then no statement at all
+	// expect 5016 — `item` and `in` both read as variables nothing assigns
+	// expect 5016
+	foreach ( item in items )
+	{
+		items[ 1 ] = item;
+	}
+	// expect 3001 — recovery never gets back in step, so the closing brace has nothing to close
+}
+
+// ---------------------------------------------------------------------------
+// 3000 range proper.
+// ---------------------------------------------------------------------------
+
+missing_semicolon()
+{
+	// expect 3014 — a statement ends with a semicolon
+	value = 1
+
+	return value;
+}
+
+bad_assignment_target()
+{
+	// expect 3012 — a literal is not somewhere a value can be stored
+	1 = 2;
+
+	// expect 3013 — an assignment in a condition is almost always a typo for ==
+	if ( value = 1 )
+	{
+		return value;
+	}
+}
+
+missing_expression()
+{
+	// expect 3002 — nothing to the right of the operator
+	return 1 +;
+}
+
+// ---------------------------------------------------------------------------
+// 1000 range — the lexer, and the block that never closes. Last, because
+// nothing after it is read as anything.
+// ---------------------------------------------------------------------------
+
+unterminated_string()
+{
+	// expect 1000 — no closing quote before the end of the line
+	// expect 3014 — so the statement never ends either
+	return "this string never ends;
+}
+
+unterminated_block()
+// expect 3007 — this brace is never closed, and neither is the file
+{
+	// expect 5008 — the one lint that still has something to say down here
+	value = 1;

--- a/server/samples/waw/gscode_lints.csc
+++ b/server/samples/waw/gscode_lints.csc
@@ -1,0 +1,158 @@
+// WaW (Treyarch CSC) — the client-side findings.
+//
+// The client world is not a different language. The grammar is the same grammar, the flow rules are
+// the same code walking the same tree, and every diagnostic below would read identically in the
+// .gsc — which is exactly why this file is worth having: it is the proof that the world does not
+// quietly change the answer.
+//
+// What the world DOES change is which rules speak at all, and on this game the answer is blunt.
+// Every client-side rule reasons about engine functions, and World at War's client library is not marked
+// complete or signature-reliable, so all of them stand down:
+//
+//   * 5013 / 5014 — a call resolving to neither a client script function nor a client engine
+//     function. This is the rule the client world exists to make interesting, since a SERVER-only
+//     engine name should be as unknown here as a name nobody has. It cannot be shown until the
+//     client library is trusted.
+//   * 5023 — a client engine call's argument count, which needs signatures.
+//   * 5019 — assigning the result of a client engine function that returns nothing.
+//   * 5002 — a literal 0/1 passed where the client library declares a bool.
+//
+// The calls that would trip them are left below with no `expect`, so the day this game's client
+// library is curated, this sample fails and asks to be brought up to date.
+//
+// There is no gscode_broken.csc, here or anywhere. The lexer and the parser do not know what a
+// client script is — the world is decided from the extension, after the text is read — so a
+// client-side copy of those errors would run the same code over the same input and assert the same
+// thing twice.
+
+// Included and never used.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// ---------------------------------------------------------------------------
+// The rules that would need a trusted client library. No `expect` on any of
+// them, on purpose — see the note above.
+// ---------------------------------------------------------------------------
+
+untrusted_library()
+{
+	NoSuchClientFunction();
+
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals, which do not care which world they are in.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// `level` is the engine's on the client side too. The global object names come from the
+	// profile, not from the world, so both worlds of a game share them.
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	return items;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings. Neither is world-specific.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/waw/gscode_lints.gsc
+++ b/server/samples/waw/gscode_lints.gsc
@@ -1,0 +1,235 @@
+// WaW (Treyarch GSC) — the deliberate findings.
+//
+// The same arrangement as the BO3 lints file: one mistake at a time, each declared by the
+// `// expect <code>` comment above it, and the file still parses cleanly so every rule is judged
+// against a complete tree.
+//
+// What is different is which rules can fire at all. Two whole families are missing here because the
+// dialect has nothing for them to be about — no #precache, so no 4000/4001/4006; no classes, so no
+// 5021 and no 4002/4003 — and two exist ONLY here, because they are about the include model that
+// BO3 replaced. Those two are 5012 and 5026, and they are the reason this file is not a translation
+// of the BO3 one.
+
+// Included and never used. The `#include` twin of BO3's 5001.
+// expect 5012 — nothing in this file calls anything it declares
+#include gscode_unused;
+
+// Note what is NOT included: gscode_target. That is what 5026 below rests on.
+
+// ---------------------------------------------------------------------------
+// The dialect boundary. These are not mistakes in another game.
+// ---------------------------------------------------------------------------
+
+// The preprocessor arrives with BO3. Reported once for the file rather than once per directive, and
+// the macro still EXPANDS — telling the author the directive does not exist while silently dropping
+// its effect would produce a second, invented error at every use.
+// expect 2016 — #define is not in this dialect
+#define NOT_IN_THIS_DIALECT 1
+
+main()
+{
+	// `vectorscale` is one of BO3's intrinsics. Here it is an ordinary identifier, so this line
+	// reads as a call to a function that does not exist.
+	//
+	// Before this rule it was reported as a missing ENGINE function, which sent people looking for
+	// a builtin that never existed in any game. Naming the real problem — a word that is a keyword
+	// in a LATER dialect — is the whole of what 5025 adds.
+	scaled = vectorscale( ( 0, 0, 1 ), 64 );
+
+	// A word that is a keyword in a later dialect is not always a call. `foreach` is Infinity Ward's
+	// MW2 addition, and writing one here is a SYNTAX error rather than a diagnostic about the
+	// dialect — the parser has no production for it, so there is nothing left to name. That case
+	// lives in gscode_broken.gsc, where a cascade cannot take the rest of this file with it.
+
+	return scaled;
+}
+
+// ---------------------------------------------------------------------------
+// What is NOT reported here, and why it is our data rather than the dialect.
+//
+// World at War is a Supported game whose bundled engine library is not marked complete
+// or signature-reliable — the wordfile it was built from lists names without
+// arity, and the list itself is known to be short. Every rule that reasons
+// about ENGINE functions therefore stands down on this game, so that the editor
+// never blames a user for a hole in our data:
+//
+//   * 5025 — a word that is a keyword only in a later dialect. It reaches the
+//     user through the same resolution path, so it is gated with the rest.
+//   * 5026 — a name declared in a file this one does not include. A real engine
+//     function absent from our data would otherwise be reported as a missing include.
+//   * 5014 — a call matching no script function and no known engine function.
+//   * 5023 — an engine call's argument count, which needs signatures to check.
+//   * 5019 — assigning the result of an engine function that returns nothing.
+//
+// The calls below are left in place, uncommented and carrying no `expect`, so
+// that the day World at War's library is curated this sample fails and asks to be
+// brought up to date. That is the only reminder a gate like this ever gets.
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+// The include model.
+// ---------------------------------------------------------------------------
+
+calls_that_do_not_resolve()
+{
+	// Declared in gscode_target.gsc, which this file does not include. The analyser can
+	// find it — hover and go-to-definition both work on this line — but the game's compiler will
+	// not link the call, so the script does not load. That gap is what the rule exists for.
+	target_never_included();
+
+	// Nothing anywhere declares this, which is a different story and a different code.
+	NoSuchEngineFunction();
+
+	// A path call names its file outright, so it needs no #include.
+	//
+	// What it is reported AS depends on how many segments the path has, and the samples sit at the
+	// boundary. A multi-segment path — maps\mp\gscode_no_such_file::whatever() — is unambiguously
+	// a path, so a missing one is reported against the PATH, once for the file rather than once per
+	// call. A single segment is not: with the samples rooted flat, `gscode_no_such_file` could be a
+	// file or a namespace, and the call is judged as a function that no script location declares.
+	//
+	// Both answers are defensible and only one of them names the actual problem, so this line is
+	// worth keeping an eye on.
+	// expect 5013 — no script location declares it
+	gscode_no_such_file::whatever();
+
+	abs();
+}
+
+// ---------------------------------------------------------------------------
+// Flow and locals — the same rules as every other dialect.
+// ---------------------------------------------------------------------------
+
+locals_and_flow()
+{
+	// expect 5008 — assigned, then never read
+	unused_local = 4;
+
+	// expect 5016 — read before anything assigns it
+	total = never_assigned + 1;
+
+	// expect 5031 — a division by a constant zero
+	broken = total / 0;
+
+	return broken;
+
+	// expect 5015 — unreachable
+	// expect 5008 — and unread
+	unreachable = 1;
+}
+
+switch_labels( value )
+{
+	switch ( value )
+	{
+		case 1:
+			break;
+		// expect 5017 — the same label twice; the second can never be taken
+		case 1:
+			break;
+		// expect 5011 — a case label has to be constant at compile time
+		case value:
+			break;
+		default:
+			break;
+		// expect 5027 — a switch has one default
+		default:
+			break;
+	}
+
+	return value;
+}
+
+reads_and_writes()
+{
+	items = [];
+	items[ 0 ] = "a";
+
+	// expect 5005 — .size is computed by the engine
+	items.size = 9;
+
+	// expect 5035 — `level` is the engine's name
+	// expect 5008 — and, taken as a local, it is written and never read
+	level = items;
+
+	nothing = clearallcorpses();
+
+	return nothing;
+}
+
+bindings_and_results()
+{
+	// expect 5020 — bound by waittill and never read
+	level waittill( "custom_event", unused_binding );
+
+	// expect 5028 — a threaded call returns immediately; there is no result to take
+	result = thread waiting_function();
+
+	// expect 5032 — the value is computed and dropped, so the line does nothing
+	1 + 1;
+
+	return result;
+}
+
+waiting_function()
+{
+	wait 0.05;
+	return 1;
+}
+
+// ---------------------------------------------------------------------------
+// Dev-only builtins — 5006 — cannot be shown on this game, and the reason is
+// our data rather than the dialect.
+//
+// The rule reports an engine function that only exists in a development build
+// being called from release code, and the call below is exactly that: Print3d
+// is dev-only in every game that has it. It is not reported here because
+// cod4_api_gsc.json carries an explicit "devOnly": false on every entry, and an
+// explicit false beats the fallback list in DevOnlyBuiltins. The BO3 library
+// marks two entries dev-only, so the BO3 lints file is where 5006 is pinned.
+//
+// Left here, uncommented and unexpected-free, so that the day WaW's data is
+// curated this sample fails and asks to be updated.
+// ---------------------------------------------------------------------------
+
+dev_only_calls()
+{
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+
+	/#
+	print3d( ( 0, 0, 0 ), "text", ( 1, 1, 1 ), 1, 1 );
+	#/
+}
+
+// ---------------------------------------------------------------------------
+// Declarations.
+// ---------------------------------------------------------------------------
+
+// expect 4007 — the same parameter name twice
+duplicate_parameters( value, value )
+{
+	return value;
+}
+
+// expect 4005 — this name is already declared, above
+duplicate_parameters( other )
+{
+	return other;
+}
+
+// ---------------------------------------------------------------------------
+// Suppression, in both spellings.
+// ---------------------------------------------------------------------------
+
+suppression()
+{
+	// #pragma disable 5008
+	suppressed_by_pragma = 1;
+	// #pragma restore 5008
+
+	// gscode ignore
+	suppressed_by_comment = 2;
+
+	// expect 5008 — outside the disabled region
+	reported_again = 3;
+}

--- a/server/samples/waw/gscode_target.csc
+++ b/server/samples/waw/gscode_target.csc
@@ -1,0 +1,19 @@
+// WaW (Treyarch CSC) — the client-side second file.
+//
+// The two worlds are separate namespaces of files, not one tree with two extensions: an `#include`
+// in a .csc resolves to a .csc, and the same path from a .gsc resolves to the .gsc beside it. That
+// is why gscode_target.gsc has a twin here rather than being reached from both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: client_target_helper( <value> )"
+"Summary: The client-side counterpart of gscode_target.gsc's target_helper."
+"MandatoryArg: <value> : the number to add to"
+///ScriptDocEnd
+*/
+client_target_helper( value )
+{
+	return value + 1;
+}

--- a/server/samples/waw/gscode_target.gsc
+++ b/server/samples/waw/gscode_target.gsc
@@ -1,0 +1,42 @@
+// WaW (Treyarch GSC) — the second file.
+//
+// The Infinity Ward dialects have no namespaces. `#include` MERGES a file's functions into the
+// including file's scope, so everything here is called by bare name from gscode.gsc — and two files
+// declaring `main` are two different functions only because nothing includes both.
+//
+// This file must produce ZERO diagnostics.
+
+/*
+///ScriptDocBegin
+"Name: target_helper( <value> )"
+"Summary: Adds one. Exists so another file has something to call."
+"MandatoryArg: <value> : the number to add to"
+"Example: result = target_helper( 1 );"
+///ScriptDocEnd
+*/
+target_helper( value )
+{
+	return value + 1;
+}
+
+/*
+///ScriptDocBegin
+"Name: target_never_included()"
+"Summary: Called by gscode_lints.gsc, which includes a different file. That is 5026."
+///ScriptDocEnd
+*/
+target_never_included()
+{
+	return "reached";
+}
+
+/*
+///ScriptDocBegin
+"Name: target_by_path()"
+"Summary: Reached as gscode_target::target_by_path(), which needs no #include at all."
+///ScriptDocEnd
+*/
+target_by_path()
+{
+	return "by path";
+}

--- a/server/samples/waw/gscode_unresolved.gsc
+++ b/server/samples/waw/gscode_unresolved.gsc
@@ -1,0 +1,23 @@
+// WaW (Treyarch GSC) — the unresolvable include, alone in its own file.
+//
+// It has to be alone, and that is worth knowing rather than working around. The import lints share
+// one resolution pass, and the pass reports NOTHING when any `#include` in the file failed to
+// resolve: once an import is missing, every "unused include" and every "declared but not included"
+// answer would be drawn from a scope that is known to be incomplete, and the file would be covered
+// in errors pointing at calls instead of at the one line that is actually wrong.
+//
+// So 5009 suppresses 5012 and 5026, and a file demonstrating all three would demonstrate one. The
+// other two live in gscode_lints.gsc, which includes nothing broken.
+//
+// The .csc side has the same arrangement for the same reason; see gscode_lints.csc.
+
+// expect 5009 — no such script under the raw root
+#include gscode_does_not_exist;
+
+// What the import rules stand down on, the RESOLUTION rules would still answer — but not on this
+// game, whose builtin library is not trusted, so 5014 is gated off here too. CoD4's copy of this
+// file pins that half; see the gate note in gscode_lints.gsc.
+calls_into_the_missing_script()
+{
+	return does_not_exist_anywhere();
+}

--- a/server/samples/waw/gscode_unused.csc
+++ b/server/samples/waw/gscode_unused.csc
@@ -1,0 +1,13 @@
+// WaW (Treyarch CSC) — a client file that exists only to be included and ignored.
+//
+// gscode_lints.csc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports. It has to be a real, resolvable CLIENT script: the .gsc of the same name is a
+// different file to a .csc, so a server-side twin would not satisfy the include and the report
+// would be 5009 instead.
+//
+// This file must produce ZERO diagnostics.
+
+client_unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/samples/waw/gscode_unused.gsc
+++ b/server/samples/waw/gscode_unused.gsc
@@ -1,0 +1,11 @@
+// WaW (Treyarch GSC) — a file that exists only to be included and ignored.
+//
+// gscode_lints.gsc has an `#include` for this and calls nothing it declares, which is the whole of
+// what 5012 reports — the `#include` twin of BO3's 5001.
+//
+// This file must produce ZERO diagnostics.
+
+unused_from_elsewhere()
+{
+	return 1;
+}

--- a/server/src/GSCode.Core/GameProfile.cs
+++ b/server/src/GSCode.Core/GameProfile.cs
@@ -587,6 +587,23 @@ public sealed partial record GameProfile
         get { return [.. ScriptExtensions.Select(static extension => "*" + extension)]; }
     }
 
+    /// <summary>
+    /// Directory names the workspace walk never descends into, because the tools write them and no
+    /// source lives there.
+    ///
+    /// This exists because a workspace folder is often the GAME INSTALL, not a scripts folder: a
+    /// Black Ops III install is 295,640 files, of which 170,328 are under `share\assetconvert` —
+    /// one shader and mesh cache per asset — and 4,329 more under `texture_assets`. Finding 1,105
+    /// scripts meant walking all of it, which took longer than analysing every one of them.
+    ///
+    /// Kept deliberately SHORT and specific to tool output. `zone`, `sound` and `video` were
+    /// measured too and are not worth the risk: they cost nothing on top of these two, and each is
+    /// a name a mod could plausibly give a scripts folder. Skipping a directory a user keeps
+    /// scripts in is a file that silently never gets indexed, which is a worse failure than a slow
+    /// walk.
+    /// </summary>
+    public static ImmutableArray<string> ToolOutputDirectories { get; } = ["assetconvert", "texture_assets"];
+
     private static readonly Lazy<ImmutableArray<GameProfile>> s_lineage = new(BuildLineage);
 
     /// <summary>

--- a/server/src/GSCode.Parser/Extraction/SymbolExtractor.cs
+++ b/server/src/GSCode.Parser/Extraction/SymbolExtractor.cs
@@ -85,18 +85,31 @@ public sealed class SymbolExtractor
         extractor.ReportDuplicateFunctions();
         PerfTracker.End();
 
-        return new ExtractionResult(
+        // The six builders sealed into arrays. Its own scope because the five scopes around it did
+        // NOT add up to the phase on the #insert dialect - bo3 left about a fifth of extract
+        // unattributed where cod4 left under one percent - and a builder is sized by what the file
+        // REFERENCES, which is the quantity #insert inflates.
+        PerfTracker.Begin("extract.build");
+        ExtractionResult built = new ExtractionResult(
             extractor._namespaces.ToImmutable(),
             extractor._functions.ToImmutable(),
             extractor._classes.ToImmutable(),
             extractor._references.ToImmutable(),
             extractor._diagnostics.ToImmutable(),
             extractor._pathCalls.ToImmutable());
+        PerfTracker.End();
+
+        return built;
     }
 
     private void Run(ParseTree tree, PreprocessResult preprocessed)
     {
         // Collected BEFORE the walk, because default-parameter validation consults them.
+        //
+        // Scoped because the loop is over EVERY invocation the preprocessor saw, headers included,
+        // to keep the few that came from this file - so on a dialect with #insert its cost is set
+        // by what was inserted rather than by what the file contains.
+        PerfTracker.Begin("extract.invocations");
         foreach ( MacroInvocation invocation in preprocessed.MacroInvocations )
         {
             if ( invocation.SourceFile is null )
@@ -104,6 +117,8 @@ public sealed class SymbolExtractor
                 _macroInvocations.Add(invocation.Range);
             }
         }
+
+        PerfTracker.End();
 
         // The dominant scope, and the parent of extract.doc and extract.body: everything the walk
         // does is inside it, so the three read as a breakdown rather than as peers.

--- a/server/src/GSCode.Parser/FOLDER.md
+++ b/server/src/GSCode.Parser/FOLDER.md
@@ -68,6 +68,13 @@ LSP types anywhere.
 - `static AstSearch` — `ChainAt(root, position)` (containing-node chain, outermost →
   innermost; the basis of selection ranges) and `ChildrenOf(node)` (full structural
   child enumeration).
+- `ChildrenOf` returns `ChildEnumerable`, a STRUCT enumerable, and every caller is a `foreach` that
+  binds to it by shape, so the walk allocates nothing. It was a `yield return` iterator, which
+  allocated one state machine per node VISITED — and the tree is walked once per rule, by fifteen
+  lints plus the reference, hint and typing passes, over corpus trees of a million nodes. Measured
+  on bo3: a bare full-tree walk cost 128–145 ms through the iterator against 35–47 ms without it.
+  A variant short-circuiting leaves before the type switch measured the same as the plain one, so
+  the allocation was the cost and the thirty-case switch was not.
 
 ## Syntax/Ast/AstNode.cs
 

--- a/server/src/GSCode.Parser/Syntax/AstSearch.cs
+++ b/server/src/GSCode.Parser/Syntax/AstSearch.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using GSCode.Core.Text;
 using GSCode.Parser.Lexing;
 using GSCode.Parser.Syntax.Ast;
@@ -92,139 +93,281 @@ public static class AstSearch
             && identifier.Token.Kind is TokenKind.WaitTill or TokenKind.WaitTillMatch;
     }
 
-    /// <summary>Direct structural children of a node (expression operands included).</summary>
-    public static IEnumerable<AstNode> ChildrenOf(AstNode node)
+    /// <summary>
+    /// Direct structural children of a node (expression operands included).
+    ///
+    /// Returns a STRUCT enumerable rather than an <c>IEnumerable</c>, and every caller is a
+    /// <c>foreach</c> that binds to it by shape, so the walk allocates nothing. It used to be a
+    /// <c>yield return</c> iterator, which allocated one state machine per node VISITED — and this
+    /// is walked once per rule, by fifteen lints plus the reference, hint and typing passes, over
+    /// trees of a million nodes. Measured on bo3: a bare full-tree walk of every script cost
+    /// 128–145 ms through the iterator against 35–47 ms without it, three times over, and a variant
+    /// that short-circuits leaves before the type switch measured the same as the plain one — so the
+    /// allocation was the cost and the thirty-case switch was not.
+    /// </summary>
+    public static ChildEnumerable ChildrenOf(AstNode node)
     {
         switch ( node )
         {
             case ScriptNode script:
-                foreach ( AstNode element in script.Elements ) { yield return element; }
-                yield break;
+                return ChildEnumerable.Of(script.Elements);
             case FunctionNode function:
-                foreach ( ParameterNode parameter in function.Parameters ) { yield return parameter; }
-                yield return function.Body;
-                yield break;
+                return ChildEnumerable.Of(function.Parameters.CastArray<AstNode>(), function.Body);
             case ParameterNode parameter:
-                if ( parameter.DefaultValue is not null ) { yield return parameter.DefaultValue; }
-                yield break;
+                return ChildEnumerable.Of(parameter.DefaultValue);
             case ClassNode classNode:
-                foreach ( AstNode member in classNode.Members ) { yield return member; }
-                yield break;
+                return ChildEnumerable.Of(classNode.Members);
             case ConstructorNode constructor:
-                foreach ( ParameterNode parameter in constructor.Parameters ) { yield return parameter; }
-                yield return constructor.Body;
-                yield break;
+                return ChildEnumerable.Of(constructor.Parameters.CastArray<AstNode>(), constructor.Body);
             case DestructorNode destructor:
-                foreach ( ParameterNode parameter in destructor.Parameters ) { yield return parameter; }
-                yield return destructor.Body;
-                yield break;
+                return ChildEnumerable.Of(destructor.Parameters.CastArray<AstNode>(), destructor.Body);
             case DevBlockDeclNode devDecl:
-                foreach ( AstNode declaration in devDecl.Declarations ) { yield return declaration; }
-                yield break;
+                return ChildEnumerable.Of(devDecl.Declarations);
             case BlockNode block:
-                foreach ( AstNode statement in block.Statements ) { yield return statement; }
-                yield break;
+                return ChildEnumerable.Of(block.Statements);
             case IfNode ifNode:
-                yield return ifNode.Condition;
-                yield return ifNode.Then;
-                if ( ifNode.Else is not null ) { yield return ifNode.Else; }
-                yield break;
+                return ChildEnumerable.Of(ifNode.Condition, ifNode.Then, ifNode.Else);
             case WhileNode whileNode:
-                yield return whileNode.Condition;
-                yield return whileNode.Body;
-                yield break;
+                return ChildEnumerable.Of(whileNode.Condition, whileNode.Body);
             case DoWhileNode doWhile:
-                yield return doWhile.Body;
-                yield return doWhile.Condition;
-                yield break;
+                return ChildEnumerable.Of(doWhile.Body, doWhile.Condition);
             case ForNode forNode:
-                if ( forNode.Initializer is not null ) { yield return forNode.Initializer; }
-                if ( forNode.Condition is not null ) { yield return forNode.Condition; }
-                if ( forNode.Increment is not null ) { yield return forNode.Increment; }
-                yield return forNode.Body;
-                yield break;
+                return ChildEnumerable.Of(forNode.Initializer, forNode.Condition, forNode.Increment, forNode.Body);
             case ForeachNode foreachNode:
-                yield return foreachNode.Collection;
-                yield return foreachNode.Body;
-                yield break;
+                return ChildEnumerable.Of(foreachNode.Collection, foreachNode.Body);
             case SwitchNode switchNode:
-                yield return switchNode.Subject;
-                foreach ( CaseGroupNode caseGroup in switchNode.Cases ) { yield return caseGroup; }
-                yield break;
+                return ChildEnumerable.Of(switchNode.Subject, switchNode.Cases.CastArray<AstNode>());
             case CaseGroupNode caseGroup:
-                foreach ( CaseLabel label in caseGroup.Labels )
-                {
-                    if ( label.Value is not null ) { yield return label.Value; }
-                }
-
-                foreach ( AstNode statement in caseGroup.Statements ) { yield return statement; }
-                yield break;
+                return ChildEnumerable.OfCaseGroup(caseGroup.Labels, caseGroup.Statements);
             case ReturnNode returnNode:
-                if ( returnNode.Value is not null ) { yield return returnNode.Value; }
-                yield break;
+                return ChildEnumerable.Of(returnNode.Value);
             case WaitNode wait:
-                yield return wait.Duration;
-                yield break;
+                return ChildEnumerable.Of(wait.Duration);
             case ConstDeclNode constDecl:
-                yield return constDecl.Value;
-                yield break;
+                return ChildEnumerable.Of(constDecl.Value);
             case ExprStatementNode exprStatement:
-                yield return exprStatement.Expression;
-                yield break;
+                return ChildEnumerable.Of(exprStatement.Expression);
             case DevBlockStmtNode devStmt:
-                foreach ( AstNode statement in devStmt.Statements ) { yield return statement; }
-                yield break;
+                return ChildEnumerable.Of(devStmt.Statements);
             case AssignmentNode assignment:
-                yield return assignment.Target;
-                yield return assignment.Value;
-                yield break;
+                return ChildEnumerable.Of(assignment.Target, assignment.Value);
             case BinaryNode binary:
-                yield return binary.Left;
-                yield return binary.Right;
-                yield break;
+                return ChildEnumerable.Of(binary.Left, binary.Right);
             case TernaryNode ternary:
-                yield return ternary.Condition;
-                yield return ternary.WhenTrue;
-                yield return ternary.WhenFalse;
-                yield break;
+                return ChildEnumerable.Of(ternary.Condition, ternary.WhenTrue, ternary.WhenFalse);
             case PrefixNode prefix:
-                yield return prefix.Operand;
-                yield break;
+                return ChildEnumerable.Of(prefix.Operand);
             case PostfixNode postfix:
-                yield return postfix.Operand;
-                yield break;
+                return ChildEnumerable.Of(postfix.Operand);
             case ParenNode paren:
-                yield return paren.Inner;
-                yield break;
+                return ChildEnumerable.Of(paren.Inner);
             case VectorNode vector:
-                yield return vector.X;
-                yield return vector.Y;
-                yield return vector.Z;
-                yield break;
+                return ChildEnumerable.Of(vector.X, vector.Y, vector.Z);
             case MemberNode member:
-                yield return member.Object;
-                yield break;
+                return ChildEnumerable.Of(member.Object);
             case IndexNode index:
-                yield return index.Object;
-                yield return index.Index;
-                yield break;
+                return ChildEnumerable.Of(index.Object, index.Index);
             case PointerDerefNode pointer:
-                yield return pointer.Pointer;
-                yield break;
+                return ChildEnumerable.Of(pointer.Pointer);
             case CallNode call:
-                if ( call.Target is not null ) { yield return call.Target; }
-                yield return call.Callee;
-                foreach ( ExprNode argument in call.Arguments ) { yield return argument; }
-                yield break;
+                return ChildEnumerable.Of(call.Target, call.Callee, call.Arguments.CastArray<AstNode>());
             case ArrowCallNode arrow:
-                yield return arrow.Object;
-                foreach ( ExprNode argument in arrow.Arguments ) { yield return argument; }
-                yield break;
+                return ChildEnumerable.Of(arrow.Object, arrow.Arguments.CastArray<AstNode>());
             case NewNode newNode:
-                foreach ( ExprNode argument in newNode.Arguments ) { yield return argument; }
-                yield break;
+                return ChildEnumerable.Of(newNode.Arguments.CastArray<AstNode>());
             default:
-                yield break;
+                return ChildEnumerable.Empty;
+        }
+    }
+}
+
+/// <summary>
+/// One node's children, in the order the tree declares them, held without allocating.
+///
+/// Every shape in the AST is some of: a LEADING array (a block's statements, a function's
+/// parameters), up to four NAMED children (a ternary's three operands, a for-loop's four parts),
+/// a case group's LABELS — whose values are the children, and any of which may be absent — and a
+/// TRAILING array (a call's arguments, a switch's case groups). The enumerator yields those four
+/// groups in that order, skipping the absent ones, which reproduces the hand-written order the
+/// <c>yield return</c> version had for every node type.
+///
+/// The arrays arrive through <c>CastArray</c>, which reinterprets the existing array rather than
+/// copying it — <c>ImmutableArray&lt;T&gt;</c> is a struct, so an array of a derived node type is
+/// not an array of <c>AstNode</c> without it.
+/// </summary>
+public readonly struct ChildEnumerable
+{
+    private readonly ImmutableArray<AstNode> _leading;
+    private readonly AstNode? _first;
+    private readonly AstNode? _second;
+    private readonly AstNode? _third;
+    private readonly AstNode? _fourth;
+    private readonly ImmutableArray<CaseLabel> _labels;
+    private readonly ImmutableArray<AstNode> _trailing;
+
+    private ChildEnumerable(
+        ImmutableArray<AstNode> leading,
+        AstNode? first,
+        AstNode? second,
+        AstNode? third,
+        AstNode? fourth,
+        ImmutableArray<CaseLabel> labels,
+        ImmutableArray<AstNode> trailing)
+    {
+        _leading = leading;
+        _first = first;
+        _second = second;
+        _third = third;
+        _fourth = fourth;
+        _labels = labels;
+        _trailing = trailing;
+    }
+
+    /// <summary>A leaf: an identifier, a literal, a directive, a `break`.</summary>
+    public static ChildEnumerable Empty
+    {
+        get { return default; }
+    }
+
+    public static ChildEnumerable Of(ImmutableArray<AstNode> children)
+    {
+        return new ChildEnumerable(children, null, null, null, null, default, default);
+    }
+
+    public static ChildEnumerable Of(AstNode? first, AstNode? second = null, AstNode? third = null, AstNode? fourth = null)
+    {
+        return new ChildEnumerable(default, first, second, third, fourth, default, default);
+    }
+
+    /// <summary>A declaration's parameters or members, then its body.</summary>
+    public static ChildEnumerable Of(ImmutableArray<AstNode> leading, AstNode body)
+    {
+        return new ChildEnumerable(leading, body, null, null, null, default, default);
+    }
+
+    /// <summary>A subject or receiver, then a list: a switch's cases, an arrow call's arguments.</summary>
+    public static ChildEnumerable Of(AstNode subject, ImmutableArray<AstNode> trailing)
+    {
+        return new ChildEnumerable(default, subject, null, null, null, default, trailing);
+    }
+
+    /// <summary>A call: its optional target, its callee, then its arguments.</summary>
+    public static ChildEnumerable Of(AstNode? target, AstNode callee, ImmutableArray<AstNode> trailing)
+    {
+        return new ChildEnumerable(default, target, callee, null, null, default, trailing);
+    }
+
+    /// <summary>The labels' values, then the statements they guard.</summary>
+    public static ChildEnumerable OfCaseGroup(ImmutableArray<CaseLabel> labels, ImmutableArray<AstNode> statements)
+    {
+        return new ChildEnumerable(default, null, null, null, null, labels, statements);
+    }
+
+    public Enumerator GetEnumerator()
+    {
+        return new Enumerator(this);
+    }
+
+    /// <summary>
+    /// Walks the four groups in order. A struct, and never boxed, because <c>foreach</c> binds to
+    /// <c>GetEnumerator</c> by shape rather than through <c>IEnumerable</c> — which is the whole
+    /// point of this type.
+    /// </summary>
+    public struct Enumerator
+    {
+        private readonly ChildEnumerable _children;
+        private int _stage;
+        private int _index;
+        private AstNode? _current;
+
+        internal Enumerator(ChildEnumerable children)
+        {
+            _children = children;
+            _stage = 0;
+            _index = 0;
+            _current = null;
+        }
+
+        public AstNode Current
+        {
+            get { return _current!; }
+        }
+
+        public bool MoveNext()
+        {
+            while ( true )
+            {
+                switch ( _stage )
+                {
+                    case 0:
+                        if ( !_children._leading.IsDefaultOrEmpty && _index < _children._leading.Length )
+                        {
+                            _current = _children._leading[_index++];
+                            return true;
+                        }
+
+                        _stage = 1;
+                        _index = 0;
+                        continue;
+
+                    case 1:
+                        if ( _index >= 4 )
+                        {
+                            _stage = 2;
+                            _index = 0;
+                            continue;
+                        }
+
+                        // The named children, in declaration order, skipping the absent ones — an
+                        // `if` with no `else`, a `for` with no initializer, a bare `return`.
+                        AstNode? named = _index switch
+                        {
+                            0 => _children._first,
+                            1 => _children._second,
+                            2 => _children._third,
+                            _ => _children._fourth,
+                        };
+
+                        _index++;
+                        if ( named is not null )
+                        {
+                            _current = named;
+                            return true;
+                        }
+
+                        continue;
+
+                    case 2:
+                        if ( !_children._labels.IsDefaultOrEmpty && _index < _children._labels.Length )
+                        {
+                            ExprNode? value = _children._labels[_index++].Value;
+                            if ( value is not null )
+                            {
+                                _current = value;
+                                return true;
+                            }
+
+                            continue;
+                        }
+
+                        _stage = 3;
+                        _index = 0;
+                        continue;
+
+                    case 3:
+                        if ( !_children._trailing.IsDefaultOrEmpty && _index < _children._trailing.Length )
+                        {
+                            _current = _children._trailing[_index++];
+                            return true;
+                        }
+
+                        _stage = 4;
+                        continue;
+
+                    default:
+                        return false;
+                }
+            }
         }
     }
 }

--- a/server/src/GSCode.Parser/Syntax/Parser.Declarations.cs
+++ b/server/src/GSCode.Parser/Syntax/Parser.Declarations.cs
@@ -1,3 +1,4 @@
+using GSCode.Core.Instrumentation;
 using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Text;
@@ -295,6 +296,19 @@ public sealed partial class Parser
 
     private FunctionNode ParseFunction()
     {
+        PerfTracker.Begin("parse.function");
+        try
+        {
+            return ParseFunctionCore();
+        }
+        finally
+        {
+            PerfTracker.End();
+        }
+    }
+
+    private FunctionNode ParseFunctionCore()
+    {
         // The declaration begins at the `function` keyword where the dialect has one, otherwise at
         // the name itself. `private`/`autoexec` and the keyword are BO3 features, so a dialect
         // without the keyword has neither.
@@ -415,6 +429,19 @@ public sealed partial class Parser
     }
 
     private ClassNode ParseClass()
+    {
+        PerfTracker.Begin("parse.class");
+        try
+        {
+            return ParseClassCore();
+        }
+        finally
+        {
+            PerfTracker.End();
+        }
+    }
+
+    private ClassNode ParseClassCore()
     {
         PToken classKeyword = Advance();
         PToken nameToken = Expect(TokenKind.Identifier, "class name");

--- a/server/src/GSCode.Parser/Syntax/Parser.Expressions.cs
+++ b/server/src/GSCode.Parser/Syntax/Parser.Expressions.cs
@@ -1,5 +1,6 @@
 using GSCode.Core.Instrumentation;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Text;
 using GSCode.Parser.Lexing;
@@ -66,9 +67,93 @@ public sealed partial class Parser
             return AbandonNesting();
         }
 
+        // Most expressions in a script are one token. An argument, an array index, the right-hand
+        // side of a field assignment — `foo( a, 1, "x" )` is three expressions and not one of them
+        // has an operator in it. Reaching ParsePrimary for those costs ParseExpressionCore,
+        // ParseTernary, ParseTernaryCore, ParseBinary, ParseCallChain, ParseUnary, ParseUnaryCore
+        // and ParsePostfix — eight calls that each look at one token, decide it is not theirs, and
+        // descend — plus two more EnterNesting/ExitNesting pairs on the way down and a postfix loop,
+        // a method-callee test, a precedence lookup, a `?` test and an assignment test on the way
+        // back up.
+        //
+        // The nesting claim above is taken first and released either way, so the depth limit still
+        // behaves exactly as it did: this is a shortcut through the descent, not around the guard.
+        if ( TryParseLeafExpression(out ExprNode? leaf) )
+        {
+            ExitNesting();
+            return leaf;
+        }
+
         ExprNode expression = ParseExpressionCore();
         ExitNesting();
         return expression;
+    }
+
+    /// <summary>
+    /// Parses a one-token expression directly, when the token AFTER it proves that every level of
+    /// the descent would have been a pass-through.
+    ///
+    /// The follower set is the whole argument. Each of the four tokens below fails every test the
+    /// skipped levels apply, and they were checked one level at a time rather than assumed:
+    /// none is an assignment operator (<c>ParseExpressionCore</c>), none is <c>?</c>
+    /// (<c>ParseTernaryCore</c>), none has a binary precedence (<c>ParseBinary</c>), none begins a
+    /// method call — that needs <c>thread</c>, <c>childthread</c>, <c>call</c>, an identifier, or
+    /// <c>[[</c> (<c>ParseCallChain</c>) — and none is a postfix operator, so <c>.</c>, <c>[</c>,
+    /// <c>(</c>, <c>++</c>, <c>--</c> and <c>-&gt;</c> are all excluded
+    /// (<c>ParsePostfixChainCore</c>). The token itself is one <c>ParsePrimary</c> builds from a
+    /// single <c>Advance</c>, and the two lookahead forms it would otherwise check for —
+    /// <c>name::name</c> and an inline <c>path\name</c> — both need a token these four are not.
+    ///
+    /// <c>:</c> is deliberately NOT in the set. A ternary's arms and a <c>case</c> label are parsed
+    /// by <see cref="ParseTernary"/> rather than by this method, so admitting it would buy nothing
+    /// and would put the shortcut a lookahead away from the one place a colon is structural.
+    /// </summary>
+    private bool TryParseLeafExpression([NotNullWhen(true)] out ExprNode? leaf)
+    {
+        leaf = null;
+
+        switch ( Peek(1).Kind )
+        {
+            case TokenKind.Comma:
+            case TokenKind.CloseParen:
+            case TokenKind.CloseBracket:
+            case TokenKind.Semicolon:
+                break;
+            default:
+                return false;
+        }
+
+        // Exactly the single-Advance cases of ParsePrimary, split the way it splits them: the ones
+        // that become a literal, and the ones that become a name.
+        switch ( Kind )
+        {
+            case TokenKind.Integer:
+            case TokenKind.Float:
+            case TokenKind.Hex:
+            case TokenKind.String:
+            case TokenKind.LocalizedString:
+            case TokenKind.HashString:
+            case TokenKind.AnimReference:
+            case TokenKind.True:
+            case TokenKind.False:
+            case TokenKind.Undefined:
+            case TokenKind.AnimTreeDirective:
+            {
+                PToken token = Advance();
+                leaf = new LiteralNode(token.RootRange, token);
+                return true;
+            }
+            case TokenKind.Identifier:
+            case TokenKind.Vararg:
+            case TokenKind.ThisThread:
+            {
+                PToken token = Advance();
+                leaf = new IdentifierNode(token.RootRange, token);
+                return true;
+            }
+            default:
+                return false;
+        }
     }
 
     private ExprNode ParseExpressionCore()

--- a/server/src/GSCode.Parser/Syntax/Parser.Expressions.cs
+++ b/server/src/GSCode.Parser/Syntax/Parser.Expressions.cs
@@ -1,3 +1,4 @@
+using GSCode.Core.Instrumentation;
 using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Text;
@@ -19,6 +20,47 @@ public sealed partial class Parser
     /// </remarks>
     private ExprNode ParseExpression()
     {
+#if GSCODE_INSTRUMENTATION
+        // Only the OUTERMOST expression is timed. A scope at every level would nest inside itself —
+        // `a + b * c` is several calls deep — and the report sums nested scopes, so the figure would
+        // count the same microseconds once per level. One scope per expression entered from a
+        // statement gives a share that can be subtracted from `parse.function` to leave the
+        // statement and declaration structure behind.
+        //
+        // Guarded with #if rather than [Conditional] because a depth counter is not a call: the
+        // increment would survive into a normal build, and this is the parser's hottest method.
+        if ( _expressionDepth > 0 )
+        {
+            return ParseExpressionTracked();
+        }
+
+        PerfTracker.Begin("parse.expression");
+        try
+        {
+            return ParseExpressionTracked();
+        }
+        finally
+        {
+            PerfTracker.End();
+        }
+    }
+
+    private ExprNode ParseExpressionTracked()
+    {
+        _expressionDepth++;
+        try
+        {
+            return ParseExpressionInner();
+        }
+        finally
+        {
+            _expressionDepth--;
+        }
+    }
+
+    private ExprNode ParseExpressionInner()
+    {
+#endif
         if ( !EnterNesting() )
         {
             return AbandonNesting();

--- a/server/src/GSCode.Parser/Syntax/Parser.cs
+++ b/server/src/GSCode.Parser/Syntax/Parser.cs
@@ -61,6 +61,14 @@ public sealed partial class Parser
         return new ParseTree(root, parser._diagnostics.ToImmutable());
     }
 
+#if GSCODE_INSTRUMENTATION
+    /// <summary>
+    /// How deep the expression parser currently is, so only the outermost entry is timed. Present in
+    /// instrumented builds only — see the note in <c>ParseExpression</c>.
+    /// </summary>
+    private int _expressionDepth;
+#endif
+
     // --- Cursor ---
 
     private PToken Current

--- a/server/src/GSCode.Server/Configuration/ServerSettings.cs
+++ b/server/src/GSCode.Server/Configuration/ServerSettings.cs
@@ -20,6 +20,14 @@ public sealed class ServerSettings
     public bool CodeLensEnabled { get; set; } = true;
     public bool InlayParameterNames { get; set; } = true;
     public bool InlayInferredTypes { get; set; } = true;
+
+    /// <summary>
+    /// Whether a MACRO invocation's arguments get their parameter names —
+    /// <c>IS_TRUE( __a: level.ready )</c>. Off by default: macro parameters are named for the
+    /// macro's own body rather than for the caller, so the label often adds noise rather than
+    /// meaning, and macros are dense in this code.
+    /// </summary>
+    public bool InlayMacroParameterNames { get; set; } = false;
     public bool CompletionLiterals { get; set; } = true;
 
     /// <summary>"owner" (default) or "all" — how widely assignment-derived fields are offered.</summary>
@@ -84,6 +92,25 @@ public sealed class ServerSettings
         }
     }
 
+    /// <summary>
+    /// The three inlay families as one comparable value.
+    ///
+    /// A hint is computed per request and cached by the client, so toggling a family changes
+    /// nothing the user can see until something else invalidates the document — a keystroke, a
+    /// scroll, a reopen. Comparing this across a settings push is what tells the handler to ask
+    /// for a refresh, and comparing a STRING rather than three fields keeps the caller to one
+    /// line. Not part of <see cref="EffectiveSummary"/>: that line is for the log, and these
+    /// three are not what a "why is it doing that" turns on.
+    /// </summary>
+    public string InlayFamilies
+    {
+        get
+        {
+            return $"types={OnOff(InlayInferredTypes)}, parameters={OnOff(InlayParameterNames)}, "
+                + $"macroParameters={OnOff(InlayMacroParameterNames)}";
+        }
+    }
+
     private static string OnOff(bool value)
     {
         return value ? "on" : "off";
@@ -118,6 +145,9 @@ public sealed class ServerSettings
         InlayInferredTypes = section.Value<bool?>("inlayHints.inferredTypes")
             ?? section["inlayHints"]?.Value<bool?>("inferredTypes")
             ?? InlayInferredTypes;
+        InlayMacroParameterNames = section.Value<bool?>("inlayHints.macroParameterNames")
+            ?? section["inlayHints"]?.Value<bool?>("macroParameterNames")
+            ?? InlayMacroParameterNames;
         CompletionLiterals = section.Value<bool?>("completion.literals")
             ?? section["completion"]?.Value<bool?>("literals")
             ?? CompletionLiterals;

--- a/server/src/GSCode.Server/FOLDER.md
+++ b/server/src/GSCode.Server/FOLDER.md
@@ -19,7 +19,7 @@ completion, hover, signature help, code lens, rename, the hierarchies, inlay hin
   rather than a list that goes stale: the game and script roots (game, serverLogLevel, raw.enabled,
   rawPath/modsPath overrides, rawFileWarningMode), indexing (workspaceIndexingMode,
   enableWorkspaceCache, diagnostics.scope), the editor features (outline.showAssignments,
-  codeLens.enabled, the inlayHints.* and completion.* pairs) and the four format.* knobs.
+  codeLens.enabled, the three inlayHints.* and the completion.* keys) and the four format.* knobs.
   `Apply(JToken)` merges a settings payload (accepting both dotted and nested key forms); missing
   keys keep current values.
 
@@ -66,6 +66,12 @@ completion, hover, signature help, code lens, rename, the hierarchies, inlay hin
 ## Handlers/ConfigurationHandler.cs
 
 - didChangeConfiguration → ServerSettings.Apply + live Serilog level switch update.
+- Two things are re-requested on an ACTUAL change, because clients push their whole configuration
+  on any settings edit: a workspace diagnostics republish when diagnostics.scope moves, and
+  `workspace/inlayHint/refresh` when `ServerSettings.InlayFamilies` does. Hints are cached by the
+  client, so without the refresh a toggled family does nothing until the next keystroke or scroll,
+  and a family turned OFF leaves its hints on screen — both of which read as the setting being
+  ignored. Fire-and-forget, like the code-lens refresh.
 
 ## Handlers/IndexProgressNotifier.cs
 
@@ -218,12 +224,15 @@ completion, hover, signature help, code lens, rename, the hierarchies, inlay hin
 
 ## Handlers/InlayHintHandler.cs
 
-- Inlay hints, two independently-toggleable families over the visible range: inferred-type
+- Inlay hints, three independently-toggleable families over the visible range: inferred-type
   hints (`: int`, and `: derived_thing` for a class instance) at each FlowTyper
   `InferredAssignment` name-range end (gated by inlayHints.inferredTypes), and parameter-name
-  hints (`amount:`) before each call argument (gated by inlayHints.parameterNames).
-  The FlowTyper it builds is seeded with the shared ObjectFields for field-type inference.
-  ResolveProvider is false, so the resolve handler is a passthrough.
+  hints (`amount:`) before each call argument (gated by inlayHints.parameterNames), and macro
+  parameter-name hints (`__a:`) before the arguments of a `#define` invocation (gated by
+  inlayHints.macroParameterNames, which is OFF by default). The FlowTyper it builds is seeded
+  with the shared ObjectFields for field-type inference, and is built only when one of the first
+  two families is on — the macro pass reads the preprocessor's invocation list and needs no flow
+  analysis. ResolveProvider is false, so the resolve handler is a passthrough.
 
   Parameter names come from four callee forms. A bare name and a `ns::fn` are answered from the
   SYNTAX, through `UnqualifiedParameterNames` (script functions in the file's namespaces, else
@@ -234,6 +243,15 @@ completion, hover, signature help, code lens, rename, the hierarchies, inlay hin
   `InstanceClass`. Both showed nothing at all before, which on a BO3 script is most of the
   dispatch in some files. That is why the handler runs `FlowTyper.InferValues` once per request
   when parameter hints are on, rather than a position query per call site.
+
+  Macro hints are a separate pass rather than a relaxation of the call pass's macro guard. By the
+  time there is a tree the invocation is gone: the author's call was replaced by the body it
+  expands to, and every token of that body reports the invocation's own range, so hinting it
+  would stamp the whole expansion onto one call site. `PreprocessResult.MacroInvocations` is the
+  only record the call site existed, and its range covers the NAME alone — the arguments are
+  found by scanning the file text after it, through the same
+  `MacroExpansionPreview.ArgumentSpansFollowing` the macro hover reads, so a hint can never name
+  an argument the hover splits differently.
 
 ## Handlers/DocumentFormattingHandler.cs
 

--- a/server/src/GSCode.Server/GSCode.Server.csproj
+++ b/server/src/GSCode.Server/GSCode.Server.csproj
@@ -9,6 +9,29 @@
     <NoWarn>$(NoWarn);NU1903</NoWarn>
   </PropertyGroup>
 
+  <!-- Ahead-of-time compilation, but only for a publish that names a runtime.
+
+       What it buys, measured by driving the published server over stdio against BO3's 1,105
+       scripts and reading its own "Ready" line, five alternating runs each, warm cache:
+       1.3 s every time without it against 0.9-1.0 s with it. The index inside that is 0.5-0.6 s
+       on both sides, so the whole difference is startup - the JIT compiling the lex, parse and
+       extract pipeline on the way to its first file - and none of it is analysis getting faster.
+       Same result whether the host is the apphost or `dotnet GSCode.Server.dll`, which is what the
+       extension actually runs.
+
+       It also makes the bundle SMALLER, which is the opposite of what precompiled code suggests:
+       48 MB to 29 MB. A RID-less publish carries runtimes/ for all 22 platforms the SQLite package
+       supports; naming one keeps that platform's native library and drops the rest.
+
+       Gated on RuntimeIdentifier rather than turned on, because that is the whole cost of it: a
+       RID-specific bundle runs on one platform, and `npm run bundle-server` currently produces one
+       cross-platform folder for one .vsix. Turning this on by default means shipping a .vsix per
+       target platform. Until that happens, `bundle-server-win` opts in and the default does not. -->
+  <PropertyGroup Condition="'$(RuntimeIdentifier)' != ''">
+    <PublishReadyToRun>true</PublishReadyToRun>
+    <SelfContained>false</SelfContained>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="OmniSharp.Extensions.LanguageProtocol" Version="0.19.9" />

--- a/server/src/GSCode.Server/Handlers/ConfigurationHandler.cs
+++ b/server/src/GSCode.Server/Handlers/ConfigurationHandler.cs
@@ -3,6 +3,7 @@ using GSCode.Server.Logging;
 using MediatR;
 using Newtonsoft.Json.Linq;
 using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Server;
 using OmniSharp.Extensions.LanguageServer.Protocol.Workspace;
 using Serilog;
 using Serilog.Core;
@@ -15,15 +16,18 @@ public sealed class ConfigurationHandler : DidChangeConfigurationHandlerBase
     private readonly ServerSettings _settings;
     private readonly LoggingLevelSwitch _levelSwitch;
     private readonly WorkspaceDiagnosticsPublisher _workspaceDiagnostics;
+    private readonly ILanguageServerFacade _server;
 
     public ConfigurationHandler(
         ServerSettings settings,
         LoggingLevelSwitch levelSwitch,
-        WorkspaceDiagnosticsPublisher workspaceDiagnostics)
+        WorkspaceDiagnosticsPublisher workspaceDiagnostics,
+        ILanguageServerFacade server)
     {
         _settings = settings;
         _levelSwitch = levelSwitch;
         _workspaceDiagnostics = workspaceDiagnostics;
+        _server = server;
     }
 
     public override Task<Unit> Handle(DidChangeConfigurationParams request, CancellationToken cancellationToken)
@@ -35,6 +39,7 @@ public sealed class ConfigurationHandler : DidChangeConfigurationHandlerBase
 
         string previousScope = _settings.DiagnosticsScope;
         string previousSummary = _settings.EffectiveSummary;
+        string previousInlay = _settings.InlayFamilies;
 
         _settings.Apply(settingsRoot);
         _levelSwitch.MinimumLevel = ServerLogLevel.FromSetting(_settings.ServerLogLevel);
@@ -78,6 +83,29 @@ public sealed class ConfigurationHandler : DidChangeConfigurationHandlerBase
             _workspaceDiagnostics.Refresh();
         }
 
+        // Same reasoning, for the inlay families: turning one on or off is invisible until the
+        // client re-requests, so without this the setting appears not to work until the next
+        // keystroke or scroll — and turning one OFF leaves stale hints on screen, which reads as
+        // the setting being ignored entirely.
+        if ( !string.Equals(previousInlay, _settings.InlayFamilies, StringComparison.Ordinal) )
+        {
+            RequestInlayHintRefresh();
+        }
+
         return Unit.Task;
+    }
+
+    /// <summary>
+    /// Asks the client to re-request every inlay hint.
+    ///
+    /// A REQUEST per the spec, not a notification: the client answers with null. Fire-and-forget,
+    /// like the code-lens refresh — a client that does not support it just errors, and a failed
+    /// refresh costs nothing beyond the delay this exists to remove.
+    /// </summary>
+    private void RequestInlayHintRefresh()
+    {
+        _ = _server.SendRequest("workspace/inlayHint/refresh")
+            .ReturningVoid(CancellationToken.None)
+            .ContinueWith(static _ => { }, TaskScheduler.Default);
     }
 }

--- a/server/src/GSCode.Server/Handlers/InlayHintHandler.cs
+++ b/server/src/GSCode.Server/Handlers/InlayHintHandler.cs
@@ -1,6 +1,7 @@
 using System.Collections.Immutable;
 using GSCode.Core.Symbols;
 using GSCode.Core.Text;
+using GSCode.Parser.Preprocessing;
 using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 using GSCode.Workspace.Api;
@@ -19,9 +20,9 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 namespace GSCode.Server.Handlers;
 
 /// <summary>
-/// Inlay hints: inferred local types after assignments (FlowTyper) and parameter names
-/// before call arguments. Each family is independently toggleable and only shown when the
-/// underlying fact is certain.
+/// Inlay hints: inferred local types after assignments (FlowTyper), parameter names before
+/// call arguments, and macro parameter names before the arguments of a #define invocation.
+/// Each family is independently toggleable and only shown when the underlying fact is certain.
 /// </summary>
 public sealed class InlayHintHandler : InlayHintsHandlerBase
 {
@@ -62,27 +63,26 @@ public sealed class InlayHintHandler : InlayHintsHandlerBase
         TextRange window = request.Range.ToCore();
         List<InlayHint> hints = [];
 
-        if ( !_settings.InlayInferredTypes && !_settings.InlayParameterNames )
-        {
-            return Task.FromResult<InlayHintContainer?>(new InlayHintContainer(hints));
-        }
-
-        FlowTyper typer = new(_builtins.For(target.Language), _objectFields);
-
         // Per-expression values are needed only by the parameter-name pass, which has to ask what a
         // `[[ ptr ]]` holds to know whose parameters to name. The type-hint pass wants assignment
-        // sites alone, so it runs the cheaper walk that records nothing else.
+        // sites alone, so it runs the cheaper walk that records nothing else. The macro pass reads
+        // the preprocessor's invocation list and needs neither, so it pays for no flow analysis.
         ScriptTypes types = ScriptTypes.Empty;
-        ImmutableArray<InferredAssignment> assignments;
+        ImmutableArray<InferredAssignment> assignments = [];
 
-        if ( _settings.InlayParameterNames )
+        if ( _settings.InlayInferredTypes || _settings.InlayParameterNames )
         {
-            types = typer.InferValues(target.Result);
-            assignments = types.Assignments;
-        }
-        else
-        {
-            assignments = typer.InferAssignments(target.Result);
+            FlowTyper typer = new(_builtins.For(target.Language), _objectFields);
+
+            if ( _settings.InlayParameterNames )
+            {
+                types = typer.InferValues(target.Result);
+                assignments = types.Assignments;
+            }
+            else
+            {
+                assignments = typer.InferAssignments(target.Result);
+            }
         }
 
         if ( _settings.InlayInferredTypes )
@@ -109,7 +109,70 @@ public sealed class InlayHintHandler : InlayHintsHandlerBase
             AddParameterNameHints(target, types, window, hints);
         }
 
+        if ( _settings.InlayMacroParameterNames )
+        {
+            AddMacroParameterNameHints(target, window, hints);
+        }
+
         return Task.FromResult<InlayHintContainer?>(new InlayHintContainer(hints));
+    }
+
+    /// <summary>
+    /// Parameter names before the arguments of a MACRO invocation — <c>IS_TRUE( __a: value )</c>.
+    ///
+    /// A separate pass from <see cref="AddParameterNameHints"/> rather than a relaxation of its
+    /// macro guard, because by the time there is a tree the invocation is gone: the call the
+    /// author wrote was replaced by the body it expands to, and every token of that body reports
+    /// the invocation's own range. The preprocessor's invocation list is the only record that the
+    /// call site existed, and it names the macro that was expanded there.
+    ///
+    /// Off by default (<c>inlayHints.macroParameterNames</c>). A macro parameter is named for the
+    /// macro's implementation rather than for its caller — <c>__a</c>, <c>__b</c> — so unlike a
+    /// function's parameters the name is often worth less than the space it takes.
+    /// </summary>
+    private static void AddMacroParameterNameHints(NavigationTarget target, TextRange window, List<InlayHint> hints)
+    {
+        string text = target.Result.Text.Text;
+
+        foreach ( MacroInvocation invocation in target.Result.Preprocessed.MacroInvocations )
+        {
+            // Only invocations written in THIS file: one reached through an #insert has its range
+            // in the header's coordinates, which here would land on unrelated lines.
+            if ( invocation.SourceFile is not null || !window.Contains(invocation.Range.Start) )
+            {
+                continue;
+            }
+
+            // Object-like macros take no arguments, so there is nothing to label.
+            if ( invocation.Definition.Parameters is not { } parameters || parameters.IsEmpty )
+            {
+                continue;
+            }
+
+            // The range covers the NAME only — `IS_TRUE`, not `IS_TRUE( v )` — so the arguments
+            // are found by scanning the text that follows it.
+            int afterName = target.Result.Text.GetOffset(invocation.Range.End);
+            if ( afterName <= 0 || afterName > text.Length )
+            {
+                continue;
+            }
+
+            ImmutableArray<MacroArgumentSpan> spans = MacroExpansionPreview.ArgumentSpansFollowing(text, afterName);
+
+            // Whichever list is shorter: a half-written invocation should label what it has, and a
+            // wrong-arity one should not name arguments the macro never declared.
+            int count = Math.Min(parameters.Length, spans.Length);
+            for ( int index = 0; index < count; index++ )
+            {
+                hints.Add(new InlayHint
+                {
+                    Position = target.Result.Text.GetPosition(spans[index].Start).ToLsp(),
+                    Label = parameters[index] + ":",
+                    Kind = InlayHintKind.Parameter,
+                    PaddingRight = true,
+                });
+            }
+        }
     }
 
     /// <summary>True when the call's callee token was produced by expanding a macro body.</summary>

--- a/server/src/GSCode.Server/Handlers/SignatureHelpHandler.cs
+++ b/server/src/GSCode.Server/Handlers/SignatureHelpHandler.cs
@@ -6,7 +6,7 @@ using OmniSharp.Extensions.LanguageServer.Protocol.Models;
 
 namespace GSCode.Server.Handlers;
 
-/// <summary>Signature help for script functions, builtins, and call-shaped keywords.</summary>
+/// <summary>Signature help for script functions, builtins, function-like macros, and call-shaped keywords.</summary>
 public sealed class SignatureHelpHandler : SignatureHelpHandlerBase
 {
     private readonly NavigationSupport _support;

--- a/server/src/GSCode.Server/Handlers/SupportedGamesHandler.cs
+++ b/server/src/GSCode.Server/Handlers/SupportedGamesHandler.cs
@@ -1,0 +1,89 @@
+using GSCode.Core;
+using MediatR;
+using OmniSharp.Extensions.JsonRpc;
+
+namespace GSCode.Server.Handlers;
+
+/// <summary>One game the extension can be switched to, as offered in a picker.</summary>
+public sealed record SupportedGame(string Id, string Label);
+
+/// <summary>
+/// The games a picker may offer, in release order, and the one in force.
+///
+/// One list with two callers: <see cref="SupportedGamesHandler"/> answers the picker command, and
+/// <see cref="TextSyncHandler"/> carries the same roster on gscode/gameMismatch so the offer to
+/// switch needs no second round trip. Only the server knows which profiles are
+/// <see cref="GameProfile.Supported"/>, and the client's own copy of this list had drifted to nine
+/// games — four of them cores with no dialect filled in, so picking one wrote a value the
+/// gscode.game enum does not accept and the server then resolved it back to Black Ops III.
+/// </summary>
+public static class GameRoster
+{
+    /// <summary>
+    /// Exactly the supported profiles, which is also exactly what the gscode.game enum accepts —
+    /// the two lists are the same list, so a pick can no longer write a setting the schema rejects.
+    ///
+    /// Labelled with the release year, since the display names alone do not separate the two Modern
+    /// Warfare 2s or the two Modern Warfare 3s once the cores are ever promoted.
+    /// </summary>
+    public static List<SupportedGame> Supported()
+    {
+        List<SupportedGame> games = [];
+        foreach ( GameProfile profile in GameProfile.All )
+        {
+            if ( profile.Supported )
+            {
+                games.Add(new SupportedGame(profile.ShortName, profile.DisplayName + " (" + profile.ReleaseYear + ")"));
+            }
+        }
+
+        return games;
+    }
+}
+
+/// <summary>Request for gscode/supportedGames. No parameters: the server knows its own roster.</summary>
+[Method("gscode/supportedGames", Direction.ClientToServer)]
+public sealed class SupportedGamesParams : IRequest<SupportedGamesResponse>
+{
+}
+
+/// <summary>Response for gscode/supportedGames.</summary>
+public sealed class SupportedGamesResponse
+{
+    /// <summary>The profile actually in force, as a short name (<c>bo3</c>).</summary>
+    public string SelectedGame { get; set; } = "";
+
+    /// <summary>That profile's display name, for a picker that wants to say what is current.</summary>
+    public string SelectedDisplayName { get; set; } = "";
+
+    /// <summary>Every game that may be picked, in release order.</summary>
+    public IReadOnlyList<SupportedGame> Games { get; set; } = [];
+}
+
+/// <summary>
+/// Answers the game picker: which games exist, and which one is running.
+///
+/// The selected game is <see cref="GameProfile.Active"/> rather than an echo of the client's
+/// <c>gscode.game</c> setting, and the difference is the whole reason to ask the server at all. An
+/// unrecognised name falls back to Black Ops III, so the setting says what was ASKED FOR while this
+/// says what was SELECTED — and a picker that ticks a game which is not in use is worse than one
+/// that ticks nothing, because it rules out the very thing that is wrong.
+///
+/// This is a request rather than a notification because the picker is user-driven and can be opened
+/// at any time. gscode/gameMismatch pushes the same roster, but only when the server happens to
+/// notice a file that does not look like the selected game, and only once per session.
+/// </summary>
+public sealed class SupportedGamesHandler : IJsonRpcRequestHandler<SupportedGamesParams, SupportedGamesResponse>
+{
+    public Task<SupportedGamesResponse> Handle(SupportedGamesParams request, CancellationToken cancellationToken)
+    {
+        GameProfile active = GameProfile.Active;
+
+        return Task.FromResult(new SupportedGamesResponse
+        {
+            SelectedGame = active.ShortName,
+            SelectedDisplayName = active.DisplayName,
+            Games = GameRoster.Supported(),
+        });
+    }
+}

--- a/server/src/GSCode.Server/Handlers/TextSyncHandler.cs
+++ b/server/src/GSCode.Server/Handlers/TextSyncHandler.cs
@@ -24,16 +24,13 @@ namespace GSCode.Server.Handlers;
 /// <summary>Payload for gscode/rawFolderWriteWarning.</summary>
 public sealed record RawFolderWriteWarningParams(string Path, string RelativePath, bool IsStockScript);
 
-/// <summary>One game the extension can be switched to, as offered in the mismatch picker.</summary>
-public sealed record SupportedGame(string Id, string Label);
-
 /// <summary>
 /// Payload for gscode/gameMismatch: the selected game does not match what the file looks like.
 ///
-/// Carries the roster rather than letting the client keep its own. Only the server knows which
-/// profiles are <see cref="GameProfile.Supported"/>, and the client's hardcoded list had drifted to
-/// nine games — four of them cores with no dialect filled in, so picking one wrote a value the
-/// gscode.game enum does not accept and the server then resolved back to BO3.
+/// Carries the roster rather than letting the client keep its own, and carries it HERE rather than
+/// making the client ask: the offer to switch is one notification and should not need a round trip
+/// to be able to list anything. It is the same list <see cref="GameRoster"/> gives the picker
+/// command, so the two offers can never disagree about which games exist.
 /// </summary>
 public sealed record GameMismatchParams(
     string SelectedGame,
@@ -148,29 +145,7 @@ public sealed class TextSyncHandler : TextDocumentSyncHandlerBase
                 active.ShortName,
                 active.DisplayName,
                 shape == GameShape.BlackOps3,
-                SupportedGames()));
-    }
-
-    /// <summary>
-    /// The games the picker may offer, in release order. Exactly the supported profiles, which is
-    /// also exactly what the gscode.game enum accepts — the two lists are the same list now, so a
-    /// pick can no longer write a setting the schema rejects.
-    ///
-    /// Labelled with the release year, since the display names alone do not separate the two Modern
-    /// Warfare 2s or the two Modern Warfare 3s once the cores are ever promoted.
-    /// </summary>
-    private static List<SupportedGame> SupportedGames()
-    {
-        List<SupportedGame> games = [];
-        foreach ( GameProfile profile in GameProfile.All )
-        {
-            if ( profile.Supported )
-            {
-                games.Add(new SupportedGame(profile.ShortName, profile.DisplayName + " (" + profile.ReleaseYear + ")"));
-            }
-        }
-
-        return games;
+                GameRoster.Supported()));
     }
 
     public override Task<Unit> Handle(DidChangeTextDocumentParams request, CancellationToken cancellationToken)

--- a/server/src/GSCode.Server/Handlers/WorkspaceFoldersHandler.cs
+++ b/server/src/GSCode.Server/Handlers/WorkspaceFoldersHandler.cs
@@ -19,8 +19,13 @@ namespace GSCode.Server.Handlers;
 /// Three things have to happen in order: the resolver is swapped first, since every later
 /// query classifies paths through it; records under removed folders are dropped, because
 /// their files are no longer visible; and the added folders are indexed last. Re-indexing is
-/// a full pass — unchanged files restore from the in-memory cache snapshot, so the cost is a
-/// warm start rather than a cold one.
+/// a full pass — unchanged files restore from the cache snapshot, so the cost is a warm start
+/// rather than a cold one.
+///
+/// This is the only place that indexes twice in one session, and the snapshot is released when a
+/// pass finishes rather than kept for the run — a bo3 workspace's blobs are 21 MB and a bo1 one's
+/// 64, against a 400 MB steady-state budget. So it is re-read here, which is the 13–54 ms this
+/// path pays to keep the other case free.
 /// </summary>
 public sealed class WorkspaceFoldersHandler : DidChangeWorkspaceFoldersHandlerBase
 {
@@ -66,6 +71,8 @@ public sealed class WorkspaceFoldersHandler : DidChangeWorkspaceFoldersHandlerBa
         // Only worth re-indexing when a folder was added; a pure removal has nothing new.
         if ( request.Event.Added.Any() )
         {
+            _indexer.ReloadRestoreSnapshot();
+
             IndexOutcome outcome = await _indexer
                 .IndexAsync(IndexingModeFor(_settings), NullIndexProgressListener.Instance, cancellationToken)
                 .ConfigureAwait(false);

--- a/server/src/GSCode.Server/Program.cs
+++ b/server/src/GSCode.Server/Program.cs
@@ -435,7 +435,15 @@ LanguageServer server = await LanguageServer.From(options =>
 
                         // Compiles to nothing without -p:GscodeInstrumentation=true, so a normal
                         // build pays neither the timing scopes nor this dump.
-                        PerfTracker.Report(line => Log.Information("Perf  {Scope}", line));
+                        //
+                        // Debug, not Information: an instrumented build reports thirty-odd scopes
+                        // in one burst, and at Information they land in the same channel as the
+                        // handful of lines that say what the server is DOING. Debug is a level
+                        // ABOVE Verbose in Serilog's ordering, which is the point - the dump is
+                        // what an instrumented build was made for, so it should not need the level
+                        // that also turns on a line per file for a thousand files. Same reasoning
+                        // as the slow-file line.
+                        PerfTracker.Report(line => Log.Debug("Perf  {Scope}", line));
 
                         // Start sampling memory only now — during indexing it climbs steadily,
                         // and every sample would be a change. One sampler serves both the

--- a/server/src/GSCode.Server/Program.cs
+++ b/server/src/GSCode.Server/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using System.Diagnostics;
 using System.Runtime;
 using GSCode.Core;
 using GSCode.Core.Instrumentation;
@@ -330,11 +331,30 @@ LanguageServer server = await LanguageServer.From(options =>
                         System.Diagnostics.Stopwatch stopwatch = System.Diagnostics.Stopwatch.StartNew();
                         IndexOutcome outcome = await indexer.IndexAsync(mode, notifier, CancellationToken.None);
                         stopwatch.Stop();
+                        // Split, because "indexing took 2.8s" hid which half was slow and the two
+                        // have nothing to do with each other. Enumeration is serial and depends on
+                        // how big the WORKSPACE is; analysis is parallel and depends on how many
+                        // SCRIPTS there are. A workspace folder holding a whole game install is
+                        // 295,640 files to find 1,105 scripts, and it read as slow analysis.
+                        //
+                        // The parallelism figure is thread-time over analysis wall-clock. Well below
+                        // the core count means the workers are not running — contention, or a lock —
+                        // rather than each file being expensive.
                         Log.Information(
-                            "Workspace indexing complete: {Count} files in {Seconds:F1}s ({Restored:N0} from cache)",
+                            "Workspace indexing complete: {Count} files in {Seconds:F1}s "
+                            + "(find {Enumerate:F1}s, analyse {Analyse:F1}s at {Parallelism:F1}x, {Restored:N0} from cache)",
                             outcome.Total,
                             stopwatch.Elapsed.TotalSeconds,
+                            outcome.Enumerate.TotalSeconds,
+                            outcome.Analyse.TotalSeconds,
+                            outcome.Parallelism,
                             outcome.Restored);
+
+                        // What the user actually waited: the process has been up since before the
+                        // client connected, and indexing is only the last part of it.
+                        Log.Information(
+                            "Ready {Seconds:F1}s after start",
+                            (DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime()).TotalSeconds);
                         // A dropped cache write is not an error the user can act on, but it is the
                         // difference between the next start being warm and it silently re-analysing
                         // part of the workspace. It used to be invisible.

--- a/server/src/GSCode.Server/Program.cs
+++ b/server/src/GSCode.Server/Program.cs
@@ -1,4 +1,5 @@
 ﻿using CommandLine;
+using System.Runtime;
 using GSCode.Core;
 using GSCode.Core.Instrumentation;
 using GSCode.Core.Symbols;
@@ -33,6 +34,18 @@ Log.Logger = new LoggerConfiguration()
     .CreateLogger();
 
 Log.Information("GSCode {Version} language server starting", ServerVersion());
+
+// The GC configuration this process actually got, which is not the same question as what the
+// repository's runtimeconfig template says. The template is baked into runtimeconfig.json at
+// PUBLISH time, so an extension running a bundle from before a template change runs the old
+// settings however recently the server project itself was rebuilt — and the difference between
+// Workstation and four-heap Server GC is a cold index of 2.2 s against 0.8 on bo3. That took a
+// while to spot from timings alone; it is one line to state.
+Log.Information(
+    "GC: {Mode}, {Heaps} heap(s), {Processors} processors",
+    GCSettings.IsServerGC ? "server" : "workstation",
+    AppContext.GetData("System.GC.HeapCount") ?? "one per core",
+    Environment.ProcessorCount);
 
 TransportOptions transportOptions = new();
 CommandLine.Parser.Default.ParseArguments<TransportOptions>(args).WithParsed(parsed => transportOptions = parsed);

--- a/server/src/GSCode.Server/Program.cs
+++ b/server/src/GSCode.Server/Program.cs
@@ -164,6 +164,7 @@ LanguageServer server = await LanguageServer.From(options =>
         .AddHandler<WorkspaceFoldersHandler>()
         .AddHandler<PlanRenameHandler>()
         .AddHandler<ClearCacheHandler>()
+        .AddHandler<SupportedGamesHandler>()
         .AddHandler<BuiltinAtHandler>()
         .AddHandler<HoverHandler>()
         .AddHandler<DefinitionHandler>()

--- a/server/src/GSCode.Server/Program.cs
+++ b/server/src/GSCode.Server/Program.cs
@@ -286,9 +286,20 @@ LanguageServer server = await LanguageServer.From(options =>
                 WorkspaceIndexer indexer = languageServer.Services.GetRequiredService<WorkspaceIndexer>();
                 IndexProgressNotifier notifier = new(languageServer.Services.GetRequiredService<ILanguageServerFacade>());
 
-                // Open the persistent cache and prime the indexer with its restored records.
+                // Open the persistent cache and prime the indexer with its restored entries.
+                //
+                // Timed, because this is where a warm start used to disappear. `LoadAll` is an
+                // ARGUMENT to UseCache, so it ran to completion before the stopwatch below was even
+                // started, and every warm figure on record was the index alone. It was reading and
+                // deserializing every cached record on this one thread while the parallel index it
+                // was feeding sat idle behind it — 1,509 ms on BO3 in front of a cold index that
+                // does the whole job in 390. Now it reads blobs only and the deserialize happens on
+                // the indexing threads, but the number stays in the log either way: an untimed
+                // stage is one that can regress without anybody noticing.
+                TimeSpan restoreElapsed = TimeSpan.Zero;
                 if ( settings.EnableWorkspaceCache )
                 {
+                    System.Diagnostics.Stopwatch restoreWatch = System.Diagnostics.Stopwatch.StartNew();
                     try
                     {
                         SqliteCache.CleanUpLegacyCache();
@@ -315,6 +326,11 @@ LanguageServer server = await LanguageServer.From(options =>
                     {
                         Log.Error(exception, "Failed to open the workspace cache; continuing without it");
                     }
+
+                    // Outside the catch, so a cache that failed to open still reports what the
+                    // attempt cost rather than reporting zero.
+                    restoreWatch.Stop();
+                    restoreElapsed = restoreWatch.Elapsed;
                 }
 
                 _ = Task.Run(async () =>
@@ -342,9 +358,11 @@ LanguageServer server = await LanguageServer.From(options =>
                         // rather than each file being expensive.
                         Log.Information(
                             "Workspace indexing complete: {Count} files in {Seconds:F1}s "
-                            + "(find {Enumerate:F1}s, analyse {Analyse:F1}s at {Parallelism:F1}x, {Restored:N0} from cache)",
+                            + "(cache {Restore:F1}s, find {Enumerate:F1}s, analyse {Analyse:F1}s at {Parallelism:F1}x, "
+                            + "{Restored:N0} from cache)",
                             outcome.Total,
-                            stopwatch.Elapsed.TotalSeconds,
+                            restoreElapsed.TotalSeconds + stopwatch.Elapsed.TotalSeconds,
+                            restoreElapsed.TotalSeconds,
                             outcome.Enumerate.TotalSeconds,
                             outcome.Analyse.TotalSeconds,
                             outcome.Parallelism,

--- a/server/src/GSCode.Server/runtimeconfig.template.json
+++ b/server/src/GSCode.Server/runtimeconfig.template.json
@@ -1,5 +1,11 @@
 {
   "configProperties": {
-    "System.GC.ConserveMemory": 5
+    "System.GC.ConserveMemory": 5,
+
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,091-2,182 ms with Workstation and 601-702 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "System.GC.Server": true,
+
+    "_comment_HeapCount": "Eight, not one per core. Unbounded on a 24-thread machine is no faster (733-768 ms) and leaves 35 MB of large-object holes and a larger working set, because each heap keeps its own LOH; at eight, fragmentation measures 0.7 MB. Retained memory is identical either way - 51.0-51.1 MB live on bo3, the same as Workstation - so this trades working set for throughput and nothing else.",
+    "System.GC.HeapCount": 8
   }
 }

--- a/server/src/GSCode.Server/runtimeconfig.template.json
+++ b/server/src/GSCode.Server/runtimeconfig.template.json
@@ -2,10 +2,10 @@
   "configProperties": {
     "System.GC.ConserveMemory": 5,
 
-    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,177-2,182 ms with Workstation and 768 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap. Measured end to end on the real server, bo3, 1,085 files: 2.6-2.7 s with Workstation against 0.4-0.5 s with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms in the harness, so the contention is the heap count and not the collection frequency.",
     "System.GC.Server": true,
 
-    "_comment_HeapCount": "Four. This is a resident language server, so the number to protect is the memory it sits at between edits, and the heap count buys throughput with exactly that: measured on bo3, four heaps rest at 200 MB and eight at 281, against Workstation's 127. Four is 768 ms against eight's 564-638 and Workstation's 2,177, so it keeps most of the speedup for half the extra footprint. Retained memory and fragmentation are identical at every setting - 51.0-51.1 MB live, 0.6-0.7 MB fragmented - and so is the PEAK right after indexing, around 450 MB; only the resting set differs.",
-    "System.GC.HeapCount": 4
+    "_comment_HeapCount": "Eight. The heap count changes the PEAK while indexing and not the memory the server rests at, because Program.cs compacts the large-object heap once at the indexing to serving transition and that returns the pages: measured on the real server, four heaps rest at 125.4-125.9 MB, eight at 125.0-126.8 and one per core at 128.3-128.9, against Workstation's 127. Eight indexes in 0.4-0.5 s against four's 0.5-0.6 with a peak within a few MB of it; one per core is no faster and peaks at 392-453 MB. Retained memory is 55 MB at every setting.",
+    "System.GC.HeapCount": 8
   }
 }

--- a/server/src/GSCode.Server/runtimeconfig.template.json
+++ b/server/src/GSCode.Server/runtimeconfig.template.json
@@ -2,10 +2,10 @@
   "configProperties": {
     "System.GC.ConserveMemory": 5,
 
-    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,091-2,182 ms with Workstation and 601-702 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,177-2,182 ms with Workstation and 768 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
     "System.GC.Server": true,
 
-    "_comment_HeapCount": "Eight, not one per core. Unbounded on a 24-thread machine is no faster (733-768 ms) and leaves 35 MB of large-object holes and a larger working set, because each heap keeps its own LOH; at eight, fragmentation measures 0.7 MB. Retained memory is identical either way - 51.0-51.1 MB live on bo3, the same as Workstation - so this trades working set for throughput and nothing else.",
-    "System.GC.HeapCount": 8
+    "_comment_HeapCount": "Four. This is a resident language server, so the number to protect is the memory it sits at between edits, and the heap count buys throughput with exactly that: measured on bo3, four heaps rest at 200 MB and eight at 281, against Workstation's 127. Four is 768 ms against eight's 564-638 and Workstation's 2,177, so it keeps most of the speedup for half the extra footprint. Retained memory and fragmentation are identical at every setting - 51.0-51.1 MB live, 0.6-0.7 MB fragmented - and so is the PEAK right after indexing, around 450 MB; only the resting set differs.",
+    "System.GC.HeapCount": 4
   }
 }

--- a/server/src/GSCode.Workspace/Analysis/ArithmeticLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ArithmeticLint.cs
@@ -1,9 +1,7 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Globalization;
 using GSCode.Core.Diagnostics;
-using GSCode.Parser;
 using GSCode.Parser.Lexing;
-using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 
 namespace GSCode.Workspace.Analysis;
@@ -21,25 +19,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class ArithmeticLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        Walk(result.Tree.Root, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
-    private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
-    }
-
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so
     /// <see cref="NodeLintPass"/> can run it from the shared walk.

--- a/server/src/GSCode.Workspace/Analysis/ArithmeticLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ArithmeticLint.cs
@@ -32,6 +32,20 @@ public static class ArithmeticLint
 
     private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
+        InspectNode(node, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Walk(child, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
         switch ( node )
         {
             case BinaryNode { Operator: TokenKind.Slash or TokenKind.Percent } binary
@@ -44,11 +58,6 @@ public static class ArithmeticLint
                 when IsLiteralZero(assignment.Value):
                 Report(assignment.Value, diagnostics);
                 break;
-        }
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/CaseLabelLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/CaseLabelLint.cs
@@ -1,6 +1,5 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
-using GSCode.Parser;
 using GSCode.Parser.Lexing;
 using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
@@ -28,41 +27,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class CaseLabelLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        Walk(result.Tree.Root, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
-    /// <summary>
-    /// Finds every switch in the file. Only <see cref="SwitchNode"/> is interesting, so everything
-    /// else descends through <see cref="AstSearch.ChildrenOf"/> rather than being enumerated here —
-    /// a statement form added later is walked without this rule having to learn about it.
-    ///
-    /// The walk stops at an expression. A switch is a STATEMENT and cannot appear inside one, and
-    /// the labels are read from the node itself rather than reached by descent, so there is nothing
-    /// below an <see cref="ExprNode"/> for this rule to find. Descending anyway walked every operand
-    /// of every expression in the file, which expressions outnumber statements by enough to make it
-    /// most of the rule's cost.
-    /// </summary>
-    private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        if ( node is ExprNode )
-        {
-            return;
-        }
-
-        InspectNode(node, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
-    }
-
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so
     /// <see cref="NodeLintPass"/> can run it from the shared walk. Only ever called for a node that

--- a/server/src/GSCode.Workspace/Analysis/CaseLabelLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/CaseLabelLint.cs
@@ -55,14 +55,24 @@ public static class CaseLabelLint
             return;
         }
 
-        if ( node is SwitchNode switchNode )
-        {
-            InspectLabels(switchNode, diagnostics);
-        }
+        InspectNode(node, diagnostics);
 
         foreach ( AstNode child in AstSearch.ChildrenOf(node) )
         {
             Walk(child, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. Only ever called for a node that
+    /// is not an <c>ExprNode</c>, which is the same restriction the walk above applies.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        if ( node is SwitchNode switchNode )
+        {
+            InspectLabels(switchNode, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/ConstDeclarationLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ConstDeclarationLint.cs
@@ -35,11 +35,7 @@ public static class ConstDeclarationLint
         ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
 
         Walk(result.Tree.Root, diagnostics);
-
-        foreach ( AstNode element in result.Tree.Root.Elements )
-        {
-            InspectDeclaration(element, diagnostics);
-        }
+        InspectRest(result, diagnostics);
 
         return diagnostics.ToImmutable();
     }
@@ -47,6 +43,21 @@ public static class ConstDeclarationLint
     // --- 5029: the value has to be known at compile time ---
 
     private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        InspectNode(node, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Walk(child, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. The declaration-level and
+    /// body-level passes below are separate and are invoked by <see cref="InspectRest"/>.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
         if ( node is ConstDeclNode constDecl && !IsConstantExpression(constDecl.Value) )
         {
@@ -56,10 +67,14 @@ public static class ConstDeclarationLint
                 GscDiagnosticCode.ExpectedConstantExpression,
                 constDecl.NameToken.Text));
         }
+    }
 
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+    /// <summary>Everything this rule does that is not per-node: the declaration-level checks.</summary>
+    internal static void InspectRest(ParseResult result, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        foreach ( AstNode element in result.Tree.Root.Elements )
         {
-            Walk(child, diagnostics);
+            InspectDeclaration(element, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/ConstDeclarationLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ConstDeclarationLint.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Parser;
 using GSCode.Parser.Lexing;
@@ -30,27 +30,7 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class ConstDeclarationLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        Walk(result.Tree.Root, diagnostics);
-        InspectRest(result, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
     // --- 5029: the value has to be known at compile time ---
-
-    private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
-    }
 
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so

--- a/server/src/GSCode.Workspace/Analysis/ExpressionStatementLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ExpressionStatementLint.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Parser;
 using GSCode.Parser.Syntax;
@@ -20,34 +20,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class ExpressionStatementLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        // Stands down on a file the parser could not read, and the corpus is the entire argument for
-        // it. Before this gate the rule reported nine statements across the five games and not one
-        // was a statement with no effect — every single one was the wreckage of a parse the tree had
-        // recovered from:
-        //
-        // - bo3's two are the known `gib.gsc(58)` grammar gap, where an object-like macro is called
-        //   as `GET_GIB_BUNDLES()` and the postfix chain will not accept the '('.
-        // - bo1's four are `level.scr_anim[…] = % o_full_interstitial_01_camera;` — an anim
-        //   reference written with a space after '%', which splits into an assignment and a bare
-        //   identifier, and the identifier is what got reported.
-        //
-        // The rule's premise is that the statement is what the author wrote. After a parse error the
-        // tree is a recovery guess, so the premise does not hold and neither does the finding —
-        // which would also be a second diagnostic on a line that already has one.
-        if ( !Applies(result) )
-        {
-            return [];
-        }
-
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        Walk(result.Tree.Root, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
     private static bool HasParseError(ParseResult result)
     {
         foreach ( Diagnostic diagnostic in result.Tree.Diagnostics )
@@ -59,16 +31,6 @@ public static class ExpressionStatementLint
         }
 
         return false;
-    }
-
-    private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
     }
 
     /// <summary>
@@ -89,7 +51,29 @@ public static class ExpressionStatementLint
         }
     }
 
-    /// <summary>Whether this rule speaks about this file at all. See the gate in <c>Analyze</c>.</summary>
+    /// <summary>
+    /// Whether this rule speaks about this file at all. It stands down on a file the parser could
+    /// not read, and the corpus is the entire argument for that.
+    ///
+    /// Before this gate the rule reported nine statements across the five games and not one was a
+    /// statement with no effect — every single one was the wreckage of a parse the tree had
+    /// recovered from:
+    ///
+    /// <list type="bullet">
+    /// <item>bo3's two are the known `gib.gsc(58)` grammar gap, where an object-like macro is called
+    /// as <c>GET_GIB_BUNDLES()</c> and the postfix chain will not accept the '('.</item>
+    /// <item>bo1's four are <c>level.scr_anim[…] = % o_full_interstitial_01_camera;</c> — an anim
+    /// reference written with a space after '%', which splits into an assignment and a bare
+    /// identifier, and the identifier is what got reported.</item>
+    /// </list>
+    ///
+    /// The rule's premise is that the statement is what the author wrote. After a parse error the
+    /// tree is a recovery guess, so the premise does not hold and neither does the finding — which
+    /// would also be a second diagnostic on a line that already has one.
+    ///
+    /// Called by <see cref="NodeLintPass"/>, which asks once per file and then skips the rule for
+    /// every node rather than re-testing it at each one.
+    /// </summary>
     internal static bool Applies(ParseResult result)
     {
         return !HasParseError(result);

--- a/server/src/GSCode.Workspace/Analysis/ExpressionStatementLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ExpressionStatementLint.cs
@@ -36,7 +36,7 @@ public static class ExpressionStatementLint
         // The rule's premise is that the statement is what the author wrote. After a parse error the
         // tree is a recovery guess, so the premise does not hold and neither does the finding —
         // which would also be a second diagnostic on a line that already has one.
-        if ( HasParseError(result) )
+        if ( !Applies(result) )
         {
             return [];
         }
@@ -63,6 +63,21 @@ public static class ExpressionStatementLint
 
     private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
+        InspectNode(node, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Walk(child, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. The caller is responsible for
+    /// the parse-error gate — see <see cref="Applies"/>.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
         // A for-loop's initializer and increment are ExprStatementNodes too, and the same rule
         // applies to them: `for ( i = 0; i < 3; i )` increments nothing.
         if ( node is ExprStatementNode statement && !HasEffect(statement.Expression) )
@@ -72,11 +87,12 @@ public static class ExpressionStatementLint
                 DiagnosticSeverity.Warning,
                 GscDiagnosticCode.InvalidExpressionStatement));
         }
+    }
 
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
+    /// <summary>Whether this rule speaks about this file at all. See the gate in <c>Analyze</c>.</summary>
+    internal static bool Applies(ParseResult result)
+    {
+        return !HasParseError(result);
     }
 
     /// <summary>

--- a/server/src/GSCode.Workspace/Analysis/GlobalObjectWriteLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/GlobalObjectWriteLint.cs
@@ -1,8 +1,6 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
-using GSCode.Parser;
-using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 
 namespace GSCode.Workspace.Analysis;
@@ -44,27 +42,6 @@ public static class GlobalObjectWriteLint
         }
 
         return globals;
-    }
-
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        HashSet<string> globals = GlobalNames();
-
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-        Inspect(result.Tree.Root, globals, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
-    private static void Inspect(
-        AstNode node, HashSet<string> globals, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, globals, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Inspect(child, globals, diagnostics);
-        }
     }
 
     /// <summary>

--- a/server/src/GSCode.Workspace/Analysis/GlobalObjectWriteLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/GlobalObjectWriteLint.cs
@@ -26,7 +26,13 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class GlobalObjectWriteLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
+    /// <summary>
+    /// The dialect's global object names, minus `classes`.
+    ///
+    /// Built once per file and handed to the per-node check, since the set is a property of the
+    /// active profile rather than of the node being looked at.
+    /// </summary>
+    internal static HashSet<string> GlobalNames()
     {
         HashSet<string> globals = new(StringComparer.OrdinalIgnoreCase);
         foreach ( string name in GameProfile.Active.GlobalObjectNames )
@@ -37,6 +43,13 @@ public static class GlobalObjectWriteLint
             }
         }
 
+        return globals;
+    }
+
+    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
+    {
+        HashSet<string> globals = GlobalNames();
+
         ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
         Inspect(result.Tree.Root, globals, diagnostics);
 
@@ -44,6 +57,22 @@ public static class GlobalObjectWriteLint
     }
 
     private static void Inspect(
+        AstNode node, HashSet<string> globals, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        InspectNode(node, globals, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Inspect(child, globals, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. The name set comes from
+    /// <see cref="GlobalNames"/>, built once per file rather than per node.
+    /// </summary>
+    internal static void InspectNode(
         AstNode node, HashSet<string> globals, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
         switch ( node )
@@ -56,11 +85,6 @@ public static class GlobalObjectWriteLint
             case PostfixNode { Operand: IdentifierNode operand }:
                 Report(operand, globals, diagnostics);
                 break;
-        }
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Inspect(child, globals, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/NodeLintPass.cs
+++ b/server/src/GSCode.Workspace/Analysis/NodeLintPass.cs
@@ -1,0 +1,135 @@
+using System.Collections.Immutable;
+using GSCode.Core.Diagnostics;
+using GSCode.Parser;
+using GSCode.Parser.Syntax;
+using GSCode.Parser.Syntax.Ast;
+using GSCode.Workspace.Api;
+using GSCode.Workspace.Typing;
+
+namespace GSCode.Workspace.Analysis;
+
+/// <summary>
+/// One walk of the tree, shared by every rule whose judgement is about a single node.
+///
+/// Nine rules each descended the whole file on their own, and each descent visited the same
+/// million nodes: a bo3 script's tree is around a thousand nodes and the corpus is a million, so
+/// the traversal was being paid for nine times over to ask nine independent questions of each node.
+/// Measured on bo3, a bare walk that visits and does nothing else is about 85 ms of a 2.1 s lint
+/// pass, and `TypeMismatchLint` — one of the nine — cost 95 ms in total, so the walking was nearly
+/// all of what those rules cost and their own predicates were almost free.
+///
+/// A rule qualifies for this pass when its own walk was PURE PASS-THROUGH: look at the node, then
+/// recurse into every child unconditionally. Nine were. The ones left out are left out for a
+/// reason, not for lack of attention:
+///
+/// <list type="bullet">
+/// <item>`ThreadedResultLint` treats an expression differently depending on whether its value is
+/// consumed, so it threads a flag down the descent.</item>
+/// <item>`UnusedLocalLint`, `UnusedBindingLint` and `UnassignedVariableLint` each build per-function
+/// state, so their walk is scoped to a declaration rather than to the file.</item>
+/// <item>`ArgumentCountLint` and `DevBlockCallLint` carry a lookup cache and a namespace set down
+/// their walks, and the second reads reference entries rather than the tree.</item>
+/// </list>
+///
+/// Each rule keeps its own `Analyze`, which still walks on its own — that is what the rule's unit
+/// tests exercise, and what an offline caller with one file and no lint pass uses. This type calls
+/// the same per-node methods those walks call, so there is one copy of each judgement.
+///
+/// The diagnostics all land in one builder and `WorkspaceLints` sorts by position before returning,
+/// so merging the walks does not change what is published: the order is a property of the file, not
+/// of which rule ran when.
+/// </summary>
+internal static class NodeLintPass
+{
+    /// <summary>
+    /// Everything the per-node rules need that does not change from node to node. Passed by
+    /// <c>in</c> so the descent does not copy it at every step.
+    /// </summary>
+    private readonly struct Context
+    {
+        public Context(
+            BuiltinApi builtins,
+            ScriptTypes types,
+            HashSet<string> globals,
+            bool voidResults,
+            bool expressionStatements)
+        {
+            Builtins = builtins;
+            Types = types;
+            Globals = globals;
+            VoidResults = voidResults;
+            ExpressionStatements = expressionStatements;
+        }
+
+        public BuiltinApi Builtins { get; }
+
+        public ScriptTypes Types { get; }
+
+        public HashSet<string> Globals { get; }
+
+        /// <summary>False on a game with no bundled library, where the rule cannot speak.</summary>
+        public bool VoidResults { get; }
+
+        /// <summary>False on a file the parser could not read, where the rule's premise fails.</summary>
+        public bool ExpressionStatements { get; }
+    }
+
+    /// <summary>
+    /// Runs the nine per-node rules over the file in one descent, appending to
+    /// <paramref name="diagnostics"/>.
+    /// </summary>
+    /// <param name="types">
+    /// The flow typer's answer for this file, which `TypeMismatchLint` reads. It is memoised per
+    /// parse, so asking for it here costs nothing beyond the walk the field-write rules already
+    /// paid for.
+    /// </param>
+    internal static void Run(
+        ParseResult result,
+        BuiltinApi builtins,
+        ScriptTypes types,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        Context context = new(
+            builtins,
+            types,
+            GlobalObjectWriteLint.GlobalNames(),
+            VoidResultLint.Applies(builtins),
+            ExpressionStatementLint.Applies(result));
+
+        Visit(result.Tree.Root, in context, diagnostics);
+    }
+
+    private static void Visit(AstNode node, in Context context, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        ArithmeticLint.InspectNode(node, diagnostics);
+        ConstDeclarationLint.InspectNode(node, diagnostics);
+        GlobalObjectWriteLint.InspectNode(node, context.Globals, diagnostics);
+        PreferBooleanLiteralLint.InspectNode(node, context.Builtins, diagnostics);
+        TypeMismatchLint.InspectNode(node, context.Types, diagnostics);
+
+        if ( context.VoidResults )
+        {
+            VoidResultLint.InspectNode(node, context.Builtins, diagnostics);
+        }
+
+        if ( context.ExpressionStatements )
+        {
+            ExpressionStatementLint.InspectNode(node, diagnostics);
+        }
+
+        // Two rules look only at statements, and their own walks stop at the first expression rather
+        // than descending through every operand in the file. This pass has to descend anyway for the
+        // rules above, so the restriction is applied by not ASKING them about an expression — which
+        // is the same set of nodes their own walks would have reached.
+        if ( node is not ExprNode )
+        {
+            CaseLabelLint.InspectNode(node, diagnostics);
+            UnreachableCodeLint.InspectNode(node, diagnostics);
+        }
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Visit(child, in context, diagnostics);
+        }
+    }
+}

--- a/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
@@ -1,8 +1,7 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Parser;
 using GSCode.Parser.Lexing;
-using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 using GSCode.Core.Symbols;
 using GSCode.Workspace.Api;
@@ -30,16 +29,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class PreferBooleanLiteralLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(
-        ParseResult result, BuiltinApi builtins, ObjectFields objectFields, FlowTyper typer)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-        Inspect(result.Tree.Root, builtins, diagnostics);
-        InspectFieldWrites(result, objectFields, typer, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
     private static void InspectFieldWrites(
         ParseResult result,
         ObjectFields objectFields,
@@ -101,16 +90,6 @@ public static class PreferBooleanLiteralLint
         }
 
         return sawEntityKind;
-    }
-
-    private static void Inspect(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, builtins, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Inspect(child, builtins, diagnostics);
-        }
     }
 
     /// <summary>

--- a/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
@@ -105,15 +105,35 @@ public static class PreferBooleanLiteralLint
 
     private static void Inspect(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
-        if ( node is CallNode call )
-        {
-            InspectCall(call, builtins, diagnostics);
-        }
+        InspectNode(node, builtins, diagnostics);
 
         foreach ( AstNode child in AstSearch.ChildrenOf(node) )
         {
             Inspect(child, builtins, diagnostics);
         }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. The field-write half is a
+    /// separate pass over the flow typer's output — see <see cref="InspectRest"/>.
+    /// </summary>
+    internal static void InspectNode(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        if ( node is CallNode call )
+        {
+            InspectCall(call, builtins, diagnostics);
+        }
+    }
+
+    /// <summary>Everything this rule does that is not per-node: the field writes the typer found.</summary>
+    internal static void InspectRest(
+        ParseResult result,
+        ObjectFields objectFields,
+        FlowTyper typer,
+        ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        InspectFieldWrites(result, objectFields, typer, diagnostics);
     }
 
     private static void InspectCall(CallNode call, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)

--- a/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Parser;
 using GSCode.Parser.Lexing;

--- a/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/PreferBooleanLiteralLint.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Parser;
 using GSCode.Parser.Lexing;
@@ -46,7 +46,7 @@ public static class PreferBooleanLiteralLint
         FlowTyper typer,
         ImmutableArray<Diagnostic>.Builder diagnostics)
     {
-        typer.InferAssignments(result, out ImmutableArray<FieldWrite> writes);
+        ImmutableArray<FieldWrite> writes = typer.InferValues(result).FieldWrites;
 
         foreach ( FieldWrite write in writes )
         {

--- a/server/src/GSCode.Workspace/Analysis/ReadOnlyWriteLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ReadOnlyWriteLint.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
 using GSCode.Parser;
@@ -19,7 +19,9 @@ namespace GSCode.Workspace.Analysis;
 /// silence beats a false error on correct code.
 ///
 /// Owner types come from <see cref="FlowTyper"/>'s own walk rather than a second inference pass,
-/// so this can never disagree with the types shown in hovers and inlay hints.
+/// so this can never disagree with the types shown in hovers and inlay hints. The walk is asked
+/// for through <c>InferValues</c>, which memoises it per parse, so the three rules reading the
+/// typer share one pass over the file instead of taking one each.
 ///
 /// The two rules carry different severities because they carry different confidence. `.size`
 /// being read-only is a language-spec fact, so that is an error. A field's read-only flag comes
@@ -29,7 +31,7 @@ public static class ReadOnlyWriteLint
 {
     public static ImmutableArray<Diagnostic> Analyze(ParseResult result, ObjectFields objectFields, FlowTyper typer)
     {
-        typer.InferAssignments(result, out ImmutableArray<FieldWrite> writes);
+        ImmutableArray<FieldWrite> writes = typer.InferValues(result).FieldWrites;
         if ( writes.IsEmpty )
         {
             return [];

--- a/server/src/GSCode.Workspace/Analysis/ReadOnlyWriteLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/ReadOnlyWriteLint.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Immutable;
+using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
 using GSCode.Parser;

--- a/server/src/GSCode.Workspace/Analysis/TypeMismatchLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/TypeMismatchLint.cs
@@ -50,6 +50,20 @@ public static class TypeMismatchLint
 
     private static void Walk(AstNode node, ScriptTypes types, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
+        InspectNode(node, types, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Walk(child, types, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ScriptTypes types, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
         switch ( node )
         {
             case ForeachNode foreachNode:
@@ -59,11 +73,6 @@ public static class TypeMismatchLint
             case VectorNode vector:
                 InspectVectorComponents(vector, types, diagnostics);
                 break;
-        }
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, types, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/TypeMismatchLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/TypeMismatchLint.cs
@@ -1,9 +1,6 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
-using GSCode.Parser;
-using GSCode.Parser.Lexing;
-using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 using GSCode.Workspace.Typing;
 
@@ -38,26 +35,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class TypeMismatchLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result, FlowTyper typer)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        ScriptTypes types = typer.InferValues(result);
-        Walk(result.Tree.Root, types, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
-    private static void Walk(AstNode node, ScriptTypes types, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, types, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, types, diagnostics);
-        }
-    }
-
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so
     /// <see cref="NodeLintPass"/> can run it from the shared walk.

--- a/server/src/GSCode.Workspace/Analysis/UnreachableCodeLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/UnreachableCodeLint.cs
@@ -62,14 +62,24 @@ public static class UnreachableCodeLint
             return;
         }
 
-        if ( node is BlockNode block )
-        {
-            ReportAfterTerminator(block, diagnostics);
-        }
+        InspectNode(node, diagnostics);
 
         foreach ( AstNode child in AstSearch.ChildrenOf(node) )
         {
             Walk(child, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. Only ever called for a node that
+    /// is not an <c>ExprNode</c>, which is the same restriction the walk above applies.
+    /// </summary>
+    internal static void InspectNode(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        if ( node is BlockNode block )
+        {
+            ReportAfterTerminator(block, diagnostics);
         }
     }
 

--- a/server/src/GSCode.Workspace/Analysis/UnreachableCodeLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/UnreachableCodeLint.cs
@@ -1,7 +1,6 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Text;
-using GSCode.Parser;
 using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 
@@ -32,15 +31,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class UnreachableCodeLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result)
-    {
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        Walk(result.Tree.Root, diagnostics);
-
-        return diagnostics.ToImmutable();
-    }
-
     /// <summary>
     /// Finds every block in the file. Only <see cref="BlockNode"/> is interesting — the run of
     /// statements after a terminator lives there and nowhere else — so everything else just
@@ -52,24 +42,6 @@ public static class UnreachableCodeLint
     /// release build, so a debugging aid after a return is something the author put there knowingly
     /// rather than a leftover.
     /// </summary>
-    private static void Walk(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        // Nothing this rule looks for lives inside an expression: a block is a statement, and GSC
-        // has no construct that puts one inside an operand. Descending anyway walked every operand
-        // of every expression in the file for nothing, which was most of the rule's cost.
-        if ( node is ExprNode )
-        {
-            return;
-        }
-
-        InspectNode(node, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, diagnostics);
-        }
-    }
-
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so
     /// <see cref="NodeLintPass"/> can run it from the shared walk. Only ever called for a node that

--- a/server/src/GSCode.Workspace/Analysis/VoidResultLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/VoidResultLint.cs
@@ -26,7 +26,7 @@ public static class VoidResultLint
 {
     public static ImmutableArray<Diagnostic> Analyze(ParseResult result, BuiltinApi builtins)
     {
-        if ( builtins.Count == 0 )
+        if ( !Applies(builtins) )
         {
             return [];
         }
@@ -43,6 +43,21 @@ public static class VoidResultLint
 
     private static void Walk(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
     {
+        InspectNode(node, builtins, diagnostics);
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Walk(child, builtins, diagnostics);
+        }
+    }
+
+    /// <summary>
+    /// This rule's whole judgement about ONE node, with no descent of its own, so
+    /// <see cref="NodeLintPass"/> can run it from the shared walk. The caller is responsible for
+    /// the empty-library gate — see <see cref="Applies"/>.
+    /// </summary>
+    internal static void InspectNode(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
         // The only position that makes the mistake visible: the value is being kept.
         if ( node is AssignmentNode assignment
             && assignment.Operator == TokenKind.Assign
@@ -52,11 +67,15 @@ public static class VoidResultLint
             diagnostics.Add(Diagnostic.Create(
                 call.Range, DiagnosticSeverity.Warning, GscDiagnosticCode.VoidResultAssigned, name));
         }
+    }
 
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, builtins, diagnostics);
-        }
+    /// <summary>
+    /// Whether this rule speaks about this file at all: a game with no bundled library cannot say
+    /// which functions return nothing.
+    /// </summary>
+    internal static bool Applies(BuiltinApi builtins)
+    {
+        return builtins.Count > 0;
     }
 
     private static bool ReturnsNothing(CallNode call, BuiltinApi builtins, out string name)

--- a/server/src/GSCode.Workspace/Analysis/VoidResultLint.cs
+++ b/server/src/GSCode.Workspace/Analysis/VoidResultLint.cs
@@ -1,8 +1,6 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core.Diagnostics;
-using GSCode.Parser;
 using GSCode.Parser.Lexing;
-using GSCode.Parser.Syntax;
 using GSCode.Parser.Syntax.Ast;
 using GSCode.Workspace.Api;
 
@@ -24,33 +22,6 @@ namespace GSCode.Workspace.Analysis;
 /// </summary>
 public static class VoidResultLint
 {
-    public static ImmutableArray<Diagnostic> Analyze(ParseResult result, BuiltinApi builtins)
-    {
-        if ( !Applies(builtins) )
-        {
-            return [];
-        }
-
-        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
-
-        foreach ( AstNode element in result.Tree.Root.Elements )
-        {
-            Walk(element, builtins, diagnostics);
-        }
-
-        return diagnostics.ToImmutable();
-    }
-
-    private static void Walk(AstNode node, BuiltinApi builtins, ImmutableArray<Diagnostic>.Builder diagnostics)
-    {
-        InspectNode(node, builtins, diagnostics);
-
-        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
-        {
-            Walk(child, builtins, diagnostics);
-        }
-    }
-
     /// <summary>
     /// This rule's whole judgement about ONE node, with no descent of its own, so
     /// <see cref="NodeLintPass"/> can run it from the shared walk. The caller is responsible for

--- a/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
+++ b/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
@@ -165,8 +165,10 @@ public static class WorkspaceLints
         PerfTracker.Begin("lint.ArgumentCountLint");
         lints.AddRange(ArgumentCountLint.Analyze(result, store, contextId, path, languageBuiltins));
         PerfTracker.End();
-        // One typer for both field rules: each of them runs the assignment inference, and the
-        // walk is the expensive half.
+        // One typer for all three rules that read it, and — because InferValues memoises per parse
+        // — one inference walk between them. Each used to run its own: two InferAssignments and an
+        // InferValues over the same tree, which was 30% of BO3's lint pass and is now 20%.
+        // Whichever rule runs first pays for the walk; the other two read the same ScriptTypes.
         PerfTracker.Begin("lint.FlowTyper.ctor");
         FlowTyper typer = new(languageBuiltins, objectFields);
         PerfTracker.End();

--- a/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
+++ b/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
@@ -221,6 +221,41 @@ public static class WorkspaceLints
             result, store, contextId, path, DatabaseQueries.DeclaredNamespaces(result), languageBuiltins));
         PerfTracker.End();
 
+        return InReadingOrder(lints);
+    }
+
+    /// <summary>
+    /// The lints sorted by position, then by code.
+    ///
+    /// They came out in RULE order, which made the published order an accident of the order the
+    /// calls above happen to be written in — and made every corpus comparison sensitive to it. The
+    /// sweep that arbitrates a diagnostic change compares output text, so restructuring which rule
+    /// walks when would have shown up as a difference with no change in what was reported.
+    ///
+    /// Position then code, so the order is a property of the FILE rather than of this method: two
+    /// rules reporting the same position sort by their code, which is stable however they are
+    /// invoked. It also happens to be the order a reader wants, since a client that does not sort
+    /// shows them as given.
+    /// </summary>
+    private static ImmutableArray<Diagnostic> InReadingOrder(ImmutableArray<Diagnostic>.Builder lints)
+    {
+        lints.Sort(static (left, right) =>
+        {
+            int line = left.Range.Start.Line.CompareTo(right.Range.Start.Line);
+            if ( line != 0 )
+            {
+                return line;
+            }
+
+            int character = left.Range.Start.Character.CompareTo(right.Range.Start.Character);
+            if ( character != 0 )
+            {
+                return character;
+            }
+
+            return ((int)left.Code).CompareTo((int)right.Code);
+        });
+
         return lints.ToImmutable();
     }
 }

--- a/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
+++ b/server/src/GSCode.Workspace/Analysis/WorkspaceLints.cs
@@ -126,26 +126,8 @@ public static class WorkspaceLints
         PerfTracker.Begin("lint.UnusedLocalLint");
         lints.AddRange(UnusedLocalLint.Analyze(result));
         PerfTracker.End();
-        PerfTracker.Begin("lint.CaseLabelLint");
-        lints.AddRange(CaseLabelLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.UnreachableCodeLint");
-        lints.AddRange(UnreachableCodeLint.Analyze(result));
-        PerfTracker.End();
         PerfTracker.Begin("lint.ThreadedResultLint");
         lints.AddRange(ThreadedResultLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.ConstDeclarationLint");
-        lints.AddRange(ConstDeclarationLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.GlobalObjectWriteLint");
-        lints.AddRange(GlobalObjectWriteLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.ArithmeticLint");
-        lints.AddRange(ArithmeticLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.ExpressionStatementLint");
-        lints.AddRange(ExpressionStatementLint.Analyze(result));
         PerfTracker.End();
         PerfTracker.Begin("lint.UnassignedVariableLint");
         lints.AddRange(UnassignedVariableLint.Analyze(result));
@@ -155,9 +137,6 @@ public static class WorkspaceLints
         PerfTracker.End();
         PerfTracker.Begin("lint.UnusedBindingLint");
         lints.AddRange(UnusedBindingLint.Analyze(result));
-        PerfTracker.End();
-        PerfTracker.Begin("lint.VoidResultLint");
-        lints.AddRange(VoidResultLint.Analyze(result, languageBuiltins));
         PerfTracker.End();
         PerfTracker.Begin("lint.ClassCycleLint");
         lints.AddRange(ClassCycleLint.Analyze(result, store, contextId));
@@ -173,11 +152,20 @@ public static class WorkspaceLints
         FlowTyper typer = new(languageBuiltins, objectFields);
         PerfTracker.End();
 
-        PerfTracker.Begin("lint.PreferBooleanLiteralLint");
-        lints.AddRange(PreferBooleanLiteralLint.Analyze(result, languageBuiltins, objectFields, typer));
+        // The nine rules whose judgement is about one node, in ONE descent of the tree rather than
+        // nine. Run here because two of them read the flow typer, whose answer has to exist first;
+        // everything else in the pass is order-independent now that the result is sorted.
+        PerfTracker.Begin("lint.NodeLintPass");
+        NodeLintPass.Run(result, languageBuiltins, typer.InferValues(result), lints);
         PerfTracker.End();
-        PerfTracker.Begin("lint.TypeMismatchLint");
-        lints.AddRange(TypeMismatchLint.Analyze(result, typer));
+
+        // What those rules do that is NOT per-node, and so has no place in the shared walk: the
+        // field writes the typer collected, and the declaration-level constant checks.
+        PerfTracker.Begin("lint.PreferBooleanLiteralLint.FieldWrites");
+        PreferBooleanLiteralLint.InspectRest(result, objectFields, typer, lints);
+        PerfTracker.End();
+        PerfTracker.Begin("lint.ConstDeclarationLint.Declarations");
+        ConstDeclarationLint.InspectRest(result, lints);
         PerfTracker.End();
         PerfTracker.Begin("lint.PrivateAccessLint");
         lints.AddRange(PrivateAccessLint.Analyze(result, store, contextId, path, languageBuiltins));

--- a/server/src/GSCode.Workspace/Api/MacroExpansionPreview.cs
+++ b/server/src/GSCode.Workspace/Api/MacroExpansionPreview.cs
@@ -6,6 +6,14 @@ using GSCode.Parser.Preprocessing;
 namespace GSCode.Workspace.Api;
 
 /// <summary>
+/// One argument of a macro invocation, as offsets into the file's text: <c>[Start, End)</c>,
+/// already trimmed of the whitespace around it.
+/// </summary>
+/// <param name="Start">Offset of the argument's first character.</param>
+/// <param name="End">Offset one past its last.</param>
+public readonly record struct MacroArgumentSpan(int Start, int End);
+
+/// <summary>
 /// Renders a macro body back into readable GSC for hover.
 ///
 /// Reconstructed from the token stream rather than sliced out of the original source, because
@@ -92,6 +100,19 @@ public static class MacroExpansionPreview
     /// </summary>
     public static ImmutableArray<string> ArgumentsFollowing(string text, int afterName)
     {
+        return Texts(text, ArgumentSpansFollowing(text, afterName));
+    }
+
+    /// <summary>
+    /// Where each of those arguments IS, rather than what it says — the trimmed offsets of every
+    /// top-level argument following the name at <paramref name="afterName"/>.
+    ///
+    /// Inlay hints need the position and not the text: a <c>__a:</c> label goes immediately before
+    /// the argument it names. Sharing the scan with <see cref="ArgumentsFollowing"/> is what keeps
+    /// the hint on the same argument the hover claims it is.
+    /// </summary>
+    public static ImmutableArray<MacroArgumentSpan> ArgumentSpansFollowing(string text, int afterName)
+    {
         int scan = afterName;
         while ( scan < text.Length && char.IsWhiteSpace(text[scan]) )
         {
@@ -103,7 +124,7 @@ public static class MacroExpansionPreview
             return [];
         }
 
-        return ParseArguments(text[scan..]);
+        return SpansFrom(text, scan);
     }
 
     /// <summary>
@@ -121,48 +142,75 @@ public static class MacroExpansionPreview
             return [];
         }
 
-        ImmutableArray<string>.Builder arguments = ImmutableArray.CreateBuilder<string>();
-        StringBuilder current = new();
-        int depth = 0;
+        return Texts(invocationText, SpansFrom(invocationText, open));
+    }
 
-        for ( int index = open; index < invocationText.Length; index++ )
+    /// <summary>The text each span covers.</summary>
+    private static ImmutableArray<string> Texts(string text, ImmutableArray<MacroArgumentSpan> spans)
+    {
+        return [.. spans.Select(span => text[span.Start..span.End])];
+    }
+
+    /// <summary>
+    /// The top-level argument spans of the parenthesised list opening at <paramref name="open"/>,
+    /// each already trimmed of surrounding whitespace.
+    ///
+    /// Depth counts brackets as well as parentheses, so <c>things[0, 1]</c> stays one argument. An
+    /// unterminated list — the normal state while typing — yields what has been written so far.
+    /// </summary>
+    private static ImmutableArray<MacroArgumentSpan> SpansFrom(string text, int open)
+    {
+        ImmutableArray<MacroArgumentSpan>.Builder spans = ImmutableArray.CreateBuilder<MacroArgumentSpan>();
+        int depth = 0;
+        int start = open + 1;
+
+        for ( int index = open; index < text.Length; index++ )
         {
-            char c = invocationText[index];
+            char c = text[index];
 
             if ( c is '(' or '[' )
             {
                 depth++;
-                if ( depth == 1 )
-                {
-                    // The opening parenthesis is not part of the first argument.
-                    continue;
-                }
             }
             else if ( c is ')' or ']' )
             {
                 depth--;
                 if ( depth == 0 )
                 {
-                    break;
+                    // `FOO()` takes none; `FOO( a, )` really was written with a second, empty one.
+                    AddSpan(spans, text, start, index, keepEmpty: spans.Count > 0);
+                    return spans.ToImmutable();
                 }
             }
             else if ( c == ',' && depth == 1 )
             {
-                arguments.Add(current.ToString().Trim());
-                current.Clear();
-                continue;
+                AddSpan(spans, text, start, index, keepEmpty: true);
+                start = index + 1;
             }
-
-            current.Append(c);
         }
 
-        string last = current.ToString().Trim();
-        if ( last.Length > 0 || arguments.Count > 0 )
+        AddSpan(spans, text, start, text.Length, keepEmpty: spans.Count > 0);
+        return spans.ToImmutable();
+    }
+
+    /// <summary>Adds [start, end) with its surrounding whitespace trimmed off both ends.</summary>
+    private static void AddSpan(
+        ImmutableArray<MacroArgumentSpan>.Builder spans, string text, int start, int end, bool keepEmpty)
+    {
+        while ( start < end && char.IsWhiteSpace(text[start]) )
         {
-            arguments.Add(last);
+            start++;
         }
 
-        return arguments.ToImmutable();
+        while ( end > start && char.IsWhiteSpace(text[end - 1]) )
+        {
+            end--;
+        }
+
+        if ( start < end || keepEmpty )
+        {
+            spans.Add(new MacroArgumentSpan(start, end));
+        }
     }
 
     /// <summary>

--- a/server/src/GSCode.Workspace/Api/MacroExpansionPreview.cs
+++ b/server/src/GSCode.Workspace/Api/MacroExpansionPreview.cs
@@ -18,16 +18,22 @@ public readonly record struct MacroArgumentSpan(int Start, int End);
 ///
 /// Reconstructed from the token stream rather than sliced out of the original source, because
 /// a macro reached through <c>#insert</c> lives in a header whose text is not loaded at hover
-/// time. That costs the author's exact spacing, but it gains one thing that matters more: line
-/// continuations collapse, so a nine-statement macro reads as what it actually expands to
-/// instead of a wall of backslashes.
+/// time. That costs the author's exact spacing WITHIN a line, but the backslashes go with it, so
+/// a nine-statement macro reads as what it expands to instead of a wall of continuations.
+///
+/// The line STRUCTURE survives. Each body token still carries the line it was written on, so a
+/// break is a token whose line is past the last one's, and a macro that declares a function reads
+/// as a declaration rather than as one very long line.
 /// </summary>
 public static class MacroExpansionPreview
 {
     /// <summary>Long bodies are truncated: a hover is a glance, not a code listing.</summary>
     public const int MaxLength = 240;
 
-    /// <summary>The macro's body as a single readable line, or "" for a body-less define.</summary>
+    /// <summary>Spaces per indent level in the rendered body.</summary>
+    private const int IndentWidth = 4;
+
+    /// <summary>The macro's body on the lines it was written on, or "" for a body-less define.</summary>
     public static string Render(ImmutableArray<PToken> body)
     {
         return Render(body, [], []);
@@ -50,11 +56,32 @@ public static class MacroExpansionPreview
             return "";
         }
 
+        // Indentation is rendered as LEVELS, not as the author's own columns.
+        //
+        // A tab is ONE character in a token's range, so subtracting columns renders a tab-indented
+        // header at a one-space step — the structure is there and unreadable. Ranking the distinct
+        // columns the body's lines start at and giving each rank a fixed step reproduces the shape
+        // whatever the file was written with, which is what a preview wants.
+        //
+        // The body's own first line is the base, so the expansion sits flush against the code fence
+        // it is rendered into. A line further left than that — the body opened on the `#define`'s
+        // own line and continued underneath it — clamps to the base rather than going negative.
+        ImmutableArray<int> columns = LineStartColumns(body);
+        int baseLevel = columns.IndexOf(body[0].Range.Start.Character);
+        int line = body[0].Range.Start.Line;
+
         StringBuilder text = new();
         for ( int index = 0; index < body.Length; index++ )
         {
             PToken token = body[index];
-            if ( text.Length > 0 && NeedsSpaceBefore(token.Kind, body[index - 1].Kind) )
+
+            if ( token.Range.Start.Line > line )
+            {
+                int level = columns.IndexOf(token.Range.Start.Character) - baseLevel;
+                text.Append('\n').Append(' ', Math.Max(0, level) * IndentWidth);
+                line = token.Range.Start.Line;
+            }
+            else if ( text.Length > 0 && NeedsSpaceBefore(token.Kind, body[index - 1].Kind) )
             {
                 text.Append(' ');
             }
@@ -68,6 +95,28 @@ public static class MacroExpansionPreview
         }
 
         return text.ToString();
+    }
+
+    /// <summary>
+    /// The distinct columns the body's lines start at, ascending. A line's indent LEVEL is its
+    /// column's index here, which is what makes a tab-indented header and a space-indented one
+    /// render identically — and what keeps a body indented by some other width readable.
+    /// </summary>
+    private static ImmutableArray<int> LineStartColumns(ImmutableArray<PToken> body)
+    {
+        SortedSet<int> columns = [];
+        int line = -1;
+
+        foreach ( PToken token in body )
+        {
+            if ( token.Range.Start.Line != line )
+            {
+                columns.Add(token.Range.Start.Character);
+                line = token.Range.Start.Line;
+            }
+        }
+
+        return [.. columns];
     }
 
     /// <summary>The argument this token stands for, or the token's own text.</summary>

--- a/server/src/GSCode.Workspace/Api/MarkdownDocRenderer.cs
+++ b/server/src/GSCode.Workspace/Api/MarkdownDocRenderer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using System.Text;
 using GSCode.Core.Docs;
 using GSCode.Core.Symbols;
@@ -162,28 +161,12 @@ public static class MarkdownDocRenderer
     /// </summary>
     public static string RenderMacro(MacroRecord macro, string expansion = "")
     {
-        return RenderMacro(macro.Name, macro.IsFunctionLike, macro.Parameters, macro.Documentation, expansion);
-    }
-
-    /// <summary>
-    /// The same markdown from the parts rather than from an indexed record, for a caller holding a
-    /// live <see cref="GSCode.Parser.Preprocessing.MacroDefinition"/> instead. Signature help is one:
-    /// it reads the parse in hand, because help fires on an invocation being typed in a file whose
-    /// indexed record may predate the #insert that supplies the macro.
-    /// </summary>
-    public static string RenderMacro(
-        string name,
-        bool isFunctionLike,
-        ImmutableArray<string> parameters,
-        string documentation,
-        string expansion = "")
-    {
         StringBuilder markdown = new();
 
-        markdown.Append("```gsc\n#define ").Append(name);
-        if ( isFunctionLike )
+        markdown.Append("```gsc\n#define ").Append(macro.Name);
+        if ( macro.IsFunctionLike )
         {
-            markdown.Append('(').Append(string.Join(", ", parameters)).Append(')');
+            markdown.Append('(').Append(string.Join(", ", macro.Parameters)).Append(')');
         }
 
         // The expansion is what a caller actually wants to see, so it shares the code block
@@ -195,9 +178,42 @@ public static class MarkdownDocRenderer
 
         markdown.Append("\n```");
 
+        if ( macro.Documentation.Length > 0 )
+        {
+            markdown.Append("\n\n---\n\n").Append(CleanComment(macro.Documentation));
+        }
+
+        return markdown.ToString();
+    }
+
+    /// <summary>
+    /// Markdown for a macro whose DEFINE FORM is already on screen: the expansion and the
+    /// trailing-comment documentation, without the `#define` line.
+    ///
+    /// Signature help is the caller. Its label IS the define form — rendered by the client, above
+    /// the documentation and with the active argument highlighted — so repeating it here printed
+    /// the parameter list twice in a widget the reader is looking at mid-keystroke. Hover has no
+    /// label above it and keeps the full form.
+    /// </summary>
+    public static string RenderMacroExpansion(string expansion, string documentation)
+    {
+        StringBuilder markdown = new();
+
+        if ( expansion.Length > 0 )
+        {
+            markdown.Append("```gsc\n").Append(expansion).Append("\n```");
+        }
+
         if ( documentation.Length > 0 )
         {
-            markdown.Append("\n\n---\n\n").Append(CleanComment(documentation));
+            // The rule is separating two things that are both there. A body-less #define with a
+            // comment has only the comment, and a bare line above it reads as a missing expansion.
+            if ( markdown.Length > 0 )
+            {
+                markdown.Append("\n\n---\n\n");
+            }
+
+            markdown.Append(CleanComment(documentation));
         }
 
         return markdown.ToString();

--- a/server/src/GSCode.Workspace/Api/MarkdownDocRenderer.cs
+++ b/server/src/GSCode.Workspace/Api/MarkdownDocRenderer.cs
@@ -1,3 +1,4 @@
+using System.Collections.Immutable;
 using System.Text;
 using GSCode.Core.Docs;
 using GSCode.Core.Symbols;
@@ -161,12 +162,28 @@ public static class MarkdownDocRenderer
     /// </summary>
     public static string RenderMacro(MacroRecord macro, string expansion = "")
     {
+        return RenderMacro(macro.Name, macro.IsFunctionLike, macro.Parameters, macro.Documentation, expansion);
+    }
+
+    /// <summary>
+    /// The same markdown from the parts rather than from an indexed record, for a caller holding a
+    /// live <see cref="GSCode.Parser.Preprocessing.MacroDefinition"/> instead. Signature help is one:
+    /// it reads the parse in hand, because help fires on an invocation being typed in a file whose
+    /// indexed record may predate the #insert that supplies the macro.
+    /// </summary>
+    public static string RenderMacro(
+        string name,
+        bool isFunctionLike,
+        ImmutableArray<string> parameters,
+        string documentation,
+        string expansion = "")
+    {
         StringBuilder markdown = new();
 
-        markdown.Append("```gsc\n#define ").Append(macro.Name);
-        if ( macro.IsFunctionLike )
+        markdown.Append("```gsc\n#define ").Append(name);
+        if ( isFunctionLike )
         {
-            markdown.Append('(').Append(string.Join(", ", macro.Parameters)).Append(')');
+            markdown.Append('(').Append(string.Join(", ", parameters)).Append(')');
         }
 
         // The expansion is what a caller actually wants to see, so it shares the code block
@@ -178,9 +195,9 @@ public static class MarkdownDocRenderer
 
         markdown.Append("\n```");
 
-        if ( macro.Documentation.Length > 0 )
+        if ( documentation.Length > 0 )
         {
-            markdown.Append("\n\n---\n\n").Append(CleanComment(macro.Documentation));
+            markdown.Append("\n\n---\n\n").Append(CleanComment(documentation));
         }
 
         return markdown.ToString();

--- a/server/src/GSCode.Workspace/Cache/CachedEntry.cs
+++ b/server/src/GSCode.Workspace/Cache/CachedEntry.cs
@@ -1,0 +1,24 @@
+using GSCode.Workspace.Database;
+
+namespace GSCode.Workspace.Cache;
+
+/// <summary>
+/// A cached record still in the form it was stored in: the freshness key, and the compressed blob
+/// behind it. Turning the blob back into a <see cref="ScriptRecord"/> is deliberately NOT done when
+/// the cache is read.
+///
+/// The reason is that most of the cost of a warm start is that conversion, and a good deal of it is
+/// wasted. <see cref="SqliteCache.LoadAll"/> runs before the indexer knows which files are still
+/// current, so materialising every record there pays gzip inflation and a JSON parse for files that
+/// are about to be re-analysed anyway — and pays it on ONE thread, in front of an index that runs on
+/// all of them. Handing the indexer the blob instead moves both halves into its parallel per-file
+/// loop, behind the content-hash check that decides whether the record may be used at all.
+/// </summary>
+public sealed record CachedEntry(ulong ContentHash, byte[] Blob)
+{
+    /// <summary>Decompresses and parses the record, or null when the blob is unreadable.</summary>
+    public ScriptRecord? Materialize()
+    {
+        return RecordSerializer.Deserialize(Blob);
+    }
+}

--- a/server/src/GSCode.Workspace/Cache/SqliteCache.cs
+++ b/server/src/GSCode.Workspace/Cache/SqliteCache.cs
@@ -147,27 +147,49 @@ public sealed class SqliteCache : IAsyncDisposable
         return new SqliteCache(connection);
     }
 
-    /// <summary>Reads every cached record (cold-restore input), skipping any that fail to deserialize.</summary>
-    public IReadOnlyDictionary<string, ScriptRecord> LoadAll()
+    /// <summary>
+    /// Reads every cached entry (warm-restore input) WITHOUT deserializing any of them.
+    ///
+    /// This used to return finished records, which made it the whole cost of a warm start: one
+    /// thread inflating gzip and parsing JSON over every file's references and diagnostics, run to
+    /// completion before <c>IndexAsync</c> was called at all. Measured back to back in one process,
+    /// uninstrumented, that restore against a cold index of the same tree: bo3 1,509 ms against
+    /// 390 ms, cod4 720 against 236, bo1 2,747 against 718. The analysis the cache exists to avoid
+    /// runs at <c>ProcessorCount - 1</c>, so a serial restore made the cache four times slower than
+    /// the work it saved. Nothing had ever measured it, because the server calls this as an
+    /// ARGUMENT to <c>UseCache</c> — outside the stopwatch that times indexing.
+    ///
+    /// What is left here is the part that has to be serial: <see cref="SqliteDataReader"/> is not
+    /// thread-safe and a blob is only valid until the next <c>Read</c>. That part is cheap, because
+    /// the bytes are still compressed. The expensive part now happens inside the indexer's parallel
+    /// per-file loop and only for files whose content hash still matches — see
+    /// <see cref="CachedEntry"/>.
+    ///
+    /// The hash is stored beside the blob rather than inside it for exactly this reason: the
+    /// freshness check has to be answerable without paying for the record it guards.
+    /// </summary>
+    public IReadOnlyDictionary<string, CachedEntry> LoadAll()
     {
-        Dictionary<string, ScriptRecord> records = new(StringComparer.Ordinal);
+        Dictionary<string, CachedEntry> entries = new(StringComparer.Ordinal);
 
         using SqliteCommand command = _connection.CreateCommand();
-        command.CommandText = "SELECT path, record FROM files;";
+        command.CommandText = "SELECT path, content_hash, record FROM files;";
         using SqliteDataReader reader = command.ExecuteReader();
 
         while ( reader.Read() )
         {
-            string path = reader.GetString(0);
-            byte[] blob = (byte[])reader[1];
-            ScriptRecord? record = RecordSerializer.Deserialize(blob);
-            if ( record is not null )
+            // Written as text by the upsert, since SQLite's INTEGER is signed and a content hash is
+            // not. A row whose hash cannot be read is simply not offered for restore: it would fail
+            // the freshness check anyway, and re-analysing one file is the cheap outcome.
+            if ( !ulong.TryParse(reader.GetString(1), out ulong contentHash) )
             {
-                records[path] = record;
+                continue;
             }
+
+            entries[reader.GetString(0)] = new CachedEntry(contentHash, (byte[])reader[2]);
         }
 
-        return records;
+        return entries;
     }
 
     /// <summary>

--- a/server/src/GSCode.Workspace/Completion/CompletionEngine.Context.cs
+++ b/server/src/GSCode.Workspace/Completion/CompletionEngine.Context.cs
@@ -80,6 +80,43 @@ public sealed partial class CompletionEngine
     }
 
     /// <summary>
+    /// Whether the name being completed is the operand of a function-pointer <c>&amp;</c> — either
+    /// directly (<c>&amp;foo</c>) or through a namespace (<c>&amp;util::foo</c>), which is how 585 of
+    /// BO3's 4,564 pointers are written.
+    ///
+    /// Only the punctuation depends on this, not the list: what may be pointed at is what may be
+    /// called, so the same producers answer both. The caller gates it on the dialect's pointer
+    /// style, since a pre-BO3 <c>&amp;</c> is arithmetic and its pointers are bare qualified names.
+    /// </summary>
+    private static bool IsAddressOfPosition(ImmutableArray<Token> tokens, int triggerIndex)
+    {
+        if ( triggerIndex < 0 )
+        {
+            return false;
+        }
+
+        if ( tokens[triggerIndex].Kind == TokenKind.Ampersand )
+        {
+            return true;
+        }
+
+        // `&util::` — the trigger is the '::', so the '&' sits two significant tokens back.
+        if ( tokens[triggerIndex].Kind != TokenKind.ScopeResolution )
+        {
+            return false;
+        }
+
+        int namespaceIndex = PreviousSignificant(tokens, triggerIndex);
+        if ( namespaceIndex < 0 || tokens[namespaceIndex].Kind != TokenKind.Identifier )
+        {
+            return false;
+        }
+
+        int beforeNamespace = PreviousSignificant(tokens, namespaceIndex);
+        return beforeNamespace >= 0 && tokens[beforeNamespace].Kind == TokenKind.Ampersand;
+    }
+
+    /// <summary>
     /// Whether the lone colon at <paramref name="colonIndex"/> is the first half of a <c>::</c>
     /// being typed, rather than a ternary's divider.
     ///

--- a/server/src/GSCode.Workspace/Completion/CompletionEngine.Producers.cs
+++ b/server/src/GSCode.Workspace/Completion/CompletionEngine.Producers.cs
@@ -684,9 +684,23 @@ public sealed partial class CompletionEngine
         // Both scopes are filtered to what the active game actually has, so e.g. CoD4 is not
         // offered class/#using. The dialect's global objects are NOT folded in here — see the
         // separate loop below for why.
-        IEnumerable<string> words = insideFunction
-            ? GscKeywords.StatementKeywords
-            : GscKeywords.TopLevelKeywords;
+        //
+        // File scope takes BOTH lists, because it is not the declarations-only position it looks
+        // like. A top-level macro invocation is a CALL, so it opens an expression outside every
+        // function body: the shipped BO3 scripts pass `undefined` to REGISTER_SYSTEM 467 times, and
+        // `undefined` is a statement-scope word that file scope could not complete. Splitting the
+        // statement list into expression atoms and control flow would buy nothing but a rule to
+        // maintain — `if` offered at file scope is noise, not a wrong answer.
+        List<string> words = [];
+        if ( insideFunction )
+        {
+            words.AddRange(GscKeywords.StatementKeywords);
+        }
+        else
+        {
+            words.AddRange(GscKeywords.TopLevelKeywords);
+            words.AddRange(GscKeywords.StatementKeywords);
+        }
 
         if ( !insideFunction )
         {
@@ -783,11 +797,13 @@ public sealed partial class CompletionEngine
                 keyword, CompletionKind.Keyword, "", KeywordInsertText(keyword, callSuffix), documentation));
         }
 
-        if ( !insideFunction )
-        {
-            return entries.ToImmutable();
-        }
-
+        // Everything below used to be behind a `!insideFunction` return, so file scope was a static
+        // word list and no workspace data reached it at all: the macros a header supplies, the
+        // file's own functions, its classes. None of those is a per-CURSOR fact — the macro table
+        // is built per parse from this file plus the headers it #inserts, and a function is in
+        // scope for the file, not for a body — so the return was hiding categories that had no
+        // reason to be hidden, and the two scopes now differ only where a name is BOUND
+        // differently.
         LanguageStore store = _database.StoreFor(result.Language);
 
         // The class this cursor is inside, read from the live extraction's ranges rather than the
@@ -818,7 +834,13 @@ public sealed partial class CompletionEngine
             }
         }
 
-        CollectLocalScope(enclosingFunction!, position, boundNames, entries);
+        // Parameters and locals are the one category that genuinely IS per-cursor: outside a
+        // declaration nothing is bound, so there is nothing to collect rather than a list to
+        // suppress.
+        if ( enclosingFunction is not null )
+        {
+            CollectLocalScope(enclosingFunction, position, boundNames, entries);
+        }
 
         // Methods of the class this cursor is inside, own and inherited — a bare name written in a
         // class body means a method: all 525 such calls in the stock BO3 scripts do. They are added

--- a/server/src/GSCode.Workspace/Completion/CompletionEngine.Producers.cs
+++ b/server/src/GSCode.Workspace/Completion/CompletionEngine.Producers.cs
@@ -863,9 +863,18 @@ public sealed partial class CompletionEngine
         // which threw away the ones a header exists to supply: a script whose constants all live
         // in a shared .gsh got none of them, which is the normal arrangement rather than an
         // unusual one.
-        foreach ( GSCode.Parser.Preprocessing.MacroDefinition macro in result.Preprocessed.Macros.All )
+        //
+        // Gated on the dialect, like every other category here. The preprocessor records a #define
+        // whatever game is active, but only BO3 HAS one: in the IW line the single #define in the
+        // corpus is a commented-out block of C in _hud.gsc, and completing its name would offer an
+        // expansion the engine will never perform. This was already true in a body — the gate is
+        // not a consequence of file scope reaching the loop, only of the loop being read again.
+        if ( game.HasMacros )
         {
-            entries.Add(MacroEntry(macro, callSuffix, parameterHints));
+            foreach ( GSCode.Parser.Preprocessing.MacroDefinition macro in result.Preprocessed.Macros.All )
+            {
+                entries.Add(MacroEntry(macro, callSuffix, parameterHints));
+            }
         }
 
         // The declared set rather than the namespace spans, which carry a leading region named after

--- a/server/src/GSCode.Workspace/Completion/CompletionEngine.cs
+++ b/server/src/GSCode.Workspace/Completion/CompletionEngine.cs
@@ -216,13 +216,25 @@ public sealed partial class CompletionEngine
             return FieldCompletions(result, contextId, OwnerBefore(result, tokens, triggerIndex), fieldScope);
         }
 
+        // File scope holds no STATEMENTS, so nothing completed there takes a terminator.
+        // IsStatementPosition scans back from the caret, finds the previous function's '}' and
+        // answers true — right inside a body and meaningless outside one. The macro that stands
+        // alone at that position expands to a DECLARATION (REGISTER_SYSTEM writes `function
+        // autoexec ...() { }`), and all 447 of its uses in the shipped BO3 scripts are written
+        // without a semicolon.
+        CallPunctuation punctuation = callPunctuation;
+        if ( !insideFunction && punctuation == CallPunctuation.ParensAndSemicolon )
+        {
+            punctuation = CallPunctuation.Parens;
+        }
+
         return StatementScopeCompletions(
             result,
             contextId,
             offset,
             position,
             enclosingFunction,
-            CallSnippet(tokens, currentIndex, offset, callPunctuation),
+            CallSnippet(tokens, currentIndex, offset, punctuation),
             game,
             parameterHints);
     }

--- a/server/src/GSCode.Workspace/Completion/CompletionEngine.cs
+++ b/server/src/GSCode.Workspace/Completion/CompletionEngine.cs
@@ -89,6 +89,33 @@ public sealed partial class CompletionEngine
         FunctionSymbol? enclosingFunction = EnclosingFunction(result, position);
         bool insideFunction = enclosingFunction is not null;
 
+        // What punctuation a completed call carries, decided once for every arm below rather than
+        // per arm, because both corrections here are about the POSITION and not about which list
+        // is being produced.
+        //
+        // File scope holds no STATEMENTS, so nothing completed there takes a terminator.
+        // IsStatementPosition scans back from the caret, finds the previous function's '}' and
+        // answers true — right inside a body and meaningless outside one. The macro that stands
+        // alone at that position expands to a DECLARATION (REGISTER_SYSTEM writes `function
+        // autoexec ...() { }`), and all 447 of its uses in the shipped BO3 scripts carry none.
+        //
+        // A function POINTER takes no punctuation at all: `&foo` names the function where `&foo()`
+        // would call it and take the address of the result. BO3 writes 4,564 of these, 585 of them
+        // through a namespace, and both routes came through here — so completing one wrote
+        // parentheses that had to be deleted again. Gated on the dialect's pointer style, since in
+        // the IW line a pointer is a bare qualified name and an '&' is arithmetic.
+        CallPunctuation punctuation = callPunctuation;
+        if ( !insideFunction && punctuation == CallPunctuation.ParensAndSemicolon )
+        {
+            punctuation = CallPunctuation.Parens;
+        }
+
+        if ( game.FunctionPointerStyle == FunctionPointerStyle.Ampersand
+            && IsAddressOfPosition(tokens, triggerIndex) )
+        {
+            punctuation = CallPunctuation.Off;
+        }
+
         if ( !insideFunction )
         {
             // #precache( "type" ...) — offer asset types as the first argument.
@@ -194,7 +221,7 @@ public sealed partial class CompletionEngine
             {
                 string ns = tokens[nsIndex].GetText(result.Text).ToString().ToLowerInvariant();
                 return NamespaceFunctionCompletions(
-                    result, contextId, ns, CallSnippet(tokens, currentIndex, offset, callPunctuation), parameterHints);
+                    result, contextId, ns, CallSnippet(tokens, currentIndex, offset, punctuation), parameterHints);
             }
         }
 
@@ -206,7 +233,7 @@ public sealed partial class CompletionEngine
                 result,
                 contextId,
                 ArrowReceiverClass(result, tokens, triggerIndex, position),
-                CallSnippet(tokens, currentIndex, offset, callPunctuation),
+                CallSnippet(tokens, currentIndex, offset, punctuation),
                 parameterHints);
         }
 
@@ -214,18 +241,6 @@ public sealed partial class CompletionEngine
         if ( triggerIndex >= 0 && tokens[triggerIndex].Kind == TokenKind.Dot )
         {
             return FieldCompletions(result, contextId, OwnerBefore(result, tokens, triggerIndex), fieldScope);
-        }
-
-        // File scope holds no STATEMENTS, so nothing completed there takes a terminator.
-        // IsStatementPosition scans back from the caret, finds the previous function's '}' and
-        // answers true — right inside a body and meaningless outside one. The macro that stands
-        // alone at that position expands to a DECLARATION (REGISTER_SYSTEM writes `function
-        // autoexec ...() { }`), and all 447 of its uses in the shipped BO3 scripts are written
-        // without a semicolon.
-        CallPunctuation punctuation = callPunctuation;
-        if ( !insideFunction && punctuation == CallPunctuation.ParensAndSemicolon )
-        {
-            punctuation = CallPunctuation.Parens;
         }
 
         return StatementScopeCompletions(

--- a/server/src/GSCode.Workspace/Completion/SignatureEngine.cs
+++ b/server/src/GSCode.Workspace/Completion/SignatureEngine.cs
@@ -133,20 +133,19 @@ public sealed class SignatureEngine
             parameters.Add(new SignatureParameter(parameterName, ""));
         }
 
-        // The body is rendered with its own parameter names left in, where hover substitutes the
-        // call site's arguments. Here the parameter names ARE the subject — the client highlights
-        // one of them as the caret moves between arguments — so showing where that name lands in
-        // the expansion is what the panel is for.
+        // The EXPANSION alone below the label, without hover's `#define` line: the label above is
+        // the define form already, and the client draws it with the active argument highlighted.
+        //
+        // The body keeps its own parameter names, where hover substitutes the call site's arguments.
+        // Here the parameter names are the subject — they are what the label highlights as the caret
+        // moves between arguments — so showing where the highlighted one lands in the expansion is
+        // what this panel is for.
         return new SignatureResult(
             BuildLabel(macro.Name, parameters),
             parameters.ToImmutable(),
             ClampActive(activeParameter, parameters.Count),
-            MarkdownDocRenderer.RenderMacro(
-                macro.Name,
-                isFunctionLike: true,
-                macroParameters,
-                macro.Documentation ?? "",
-                MacroExpansionPreview.Render(macro.Body)));
+            MarkdownDocRenderer.RenderMacroExpansion(
+                MacroExpansionPreview.Render(macro.Body), macro.Documentation ?? ""));
     }
 
     private SignatureResult? TryScriptFunction(

--- a/server/src/GSCode.Workspace/Completion/SignatureEngine.cs
+++ b/server/src/GSCode.Workspace/Completion/SignatureEngine.cs
@@ -53,6 +53,29 @@ public sealed class SignatureEngine
 
         ArrowReceiver arrow = ClassifyArrow(tokens, result.Text, site.Value.CalleeIndex);
 
+        // A macro is asked BEFORE a function, because the preprocessor gets there first: where a
+        // #define and a function share a name, the invocation being typed is replaced before the
+        // parser ever sees it, so the function's parameters would describe code that never runs.
+        // They can only collide on exact case — a macro name is the language's one case-SENSITIVE
+        // kind. Neither an arrow call nor a qualified name can reach one: `[[o]]->NAME(` dispatches
+        // on an object and `util::NAME(` names a namespace member, and the preprocessor expands
+        // neither.
+        //
+        // Deliberately NOT gated on the dialect's HasMacros, unlike macro COMPLETION. Completion
+        // decides what to propose, and proposing an expansion a pre-BO3 engine will not perform is
+        // a wrong answer. This describes a name the user has already written, and the preprocessor
+        // expands a #define on every dialect by design — see Preprocessor.ReportIfNoPreprocessor,
+        // which reports the directive and then processes it anyway. Withholding help here would
+        // leave the expansion happening with nothing on screen to describe it.
+        if ( arrow == ArrowReceiver.None && namespaceName is null )
+        {
+            SignatureResult? macroSignature = TryMacro(result, calleeName, site.Value.ActiveParameter);
+            if ( macroSignature is not null )
+            {
+                return macroSignature;
+            }
+        }
+
         SignatureResult? scriptSignature = TryScriptFunction(
             result, contextId, namespaceName, calleeName, site.Value.ActiveParameter, position, arrow);
         if ( scriptSignature is not null )
@@ -77,6 +100,53 @@ public sealed class SignatureEngine
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Signature help for a function-like macro, read from the PARSE IN HAND rather than the store.
+    /// The macro table is rebuilt on every parse from this file plus the headers it #inserts, so it
+    /// is current for a header inserted a keystroke ago — which the indexed record is not, and help
+    /// fires while the invocation is still being typed.
+    /// </summary>
+    private static SignatureResult? TryMacro(ParseResult result, string calleeName, int activeParameter)
+    {
+        // Ordinal, which is the lookup MacroTable is keyed by: `IS_TRUE(` and `is_true(` are two
+        // different questions, unlike every other name in the language.
+        if ( !result.Preprocessed.Macros.TryGet(calleeName, out GSCode.Parser.Preprocessing.MacroDefinition macro) )
+        {
+            return null;
+        }
+
+        // An OBJECT-like macro is not a call. `MAX_PLAYERS( x )` expands to its body followed by a
+        // parenthesised expression, so it has no parameters to describe, and answering null hands
+        // the position back to the by-name lookups rather than showing an empty signature.
+        if ( macro.Parameters is not ImmutableArray<string> macroParameters )
+        {
+            return null;
+        }
+
+        ImmutableArray<SignatureParameter>.Builder parameters = ImmutableArray.CreateBuilder<SignatureParameter>();
+        foreach ( string parameterName in macroParameters )
+        {
+            // Nothing to document per parameter: a #define carries at most one trailing comment,
+            // and it describes the macro rather than any one of its arguments.
+            parameters.Add(new SignatureParameter(parameterName, ""));
+        }
+
+        // The body is rendered with its own parameter names left in, where hover substitutes the
+        // call site's arguments. Here the parameter names ARE the subject — the client highlights
+        // one of them as the caret moves between arguments — so showing where that name lands in
+        // the expansion is what the panel is for.
+        return new SignatureResult(
+            BuildLabel(macro.Name, parameters),
+            parameters.ToImmutable(),
+            ClampActive(activeParameter, parameters.Count),
+            MarkdownDocRenderer.RenderMacro(
+                macro.Name,
+                isFunctionLike: true,
+                macroParameters,
+                macro.Documentation ?? "",
+                MacroExpansionPreview.Render(macro.Body)));
     }
 
     private SignatureResult? TryScriptFunction(

--- a/server/src/GSCode.Workspace/Database/DatabaseQueries.cs
+++ b/server/src/GSCode.Workspace/Database/DatabaseQueries.cs
@@ -233,8 +233,17 @@ public static class DatabaseQueries
         // Same normalization contract as LookupFunctions: the same-file test gates privacy.
         string normalizedAskingPath = NormalizeAskingPath(askingPath);
 
-        foreach ( ScriptRecord record in store.AllRecords )
+        // The files that declare INTO this namespace, rather than every file in the store. The old
+        // walk read all ~30,000 BO3 symbols to keep the few dozen in one namespace, and it is asked
+        // once per namespace a file can see — so a namespace-dialect script paid for the whole store
+        // several times over on every keystroke.
+        foreach ( string declaringPath in store.FilesDeclaringInto(namespaceName) )
         {
+            if ( !store.TryGet(declaringPath, out ScriptRecord record) )
+            {
+                continue;
+            }
+
             if ( !ScriptDatabase.CanSee(askingContextId, record.ContextId) )
             {
                 continue;

--- a/server/src/GSCode.Workspace/Database/DeclarationIndex.cs
+++ b/server/src/GSCode.Workspace/Database/DeclarationIndex.cs
@@ -20,23 +20,13 @@ namespace GSCode.Workspace.Database;
 /// Paths rather than records, matching <see cref="ReferenceIndex"/>: a record is swapped wholesale
 /// on every edit, so holding one here would pin a stale version. The caller resolves the path
 /// through the record map it was going to read anyway.
+///
+/// The storage, the packing and the per-file diff live in <see cref="PackedInvertedIndex{TKey}"/>,
+/// shared with <see cref="ReferenceIndex"/>.
 /// </summary>
 public sealed class DeclarationIndex
 {
-    /// <summary>
-    /// name → the file that declares it, as a bare <c>string</c> when exactly one does and a
-    /// <c>HashSet&lt;string&gt;</c> only once a second appears.
-    ///
-    /// The overwhelming majority of function names are declared exactly once, and a HashSet holding
-    /// a single reference costs on the order of 150 bytes against the 8 of the reference itself.
-    /// Measured on BO1, the largest corpus at 2,963 files, this is the difference between the index
-    /// costing 5.1 MB and costing well under one.
-    ///
-    /// The union type is contained entirely within this class: nothing outside sees an
-    /// <c>object</c>, and both shapes are read through <see cref="FilesDeclaring"/>.
-    /// </summary>
-    private readonly Dictionary<string, object> _filesByName = new(StringComparer.Ordinal);
-    private readonly Lock _gate = new();
+    private readonly PackedInvertedIndex<string> _index = new(StringComparer.Ordinal);
 
     /// <summary>
     /// The distinct key names a function list declares. Built outside the caller's write gate for
@@ -56,69 +46,12 @@ public sealed class DeclarationIndex
     /// <summary>Replaces one file's contribution: removes names it no longer declares, adds the rest.</summary>
     public void Apply(string path, HashSet<string> oldNames, HashSet<string> newNames)
     {
-        lock ( _gate )
-        {
-            foreach ( string name in oldNames )
-            {
-                if ( newNames.Contains(name) || !_filesByName.TryGetValue(name, out object? existing) )
-                {
-                    continue;
-                }
-
-                if ( existing is HashSet<string> many )
-                {
-                    many.Remove(path);
-
-                    // Back down to one: keep the set rather than churning it back into a string. A
-                    // name that has had two declarers usually gets them back, and this path runs on
-                    // edits rather than on the cold index that the memory shape is tuned for.
-                    if ( many.Count == 0 )
-                    {
-                        _filesByName.Remove(name);
-                    }
-                }
-                else if ( string.Equals((string)existing, path, StringComparison.Ordinal) )
-                {
-                    _filesByName.Remove(name);
-                }
-            }
-
-            foreach ( string name in newNames )
-            {
-                if ( !_filesByName.TryGetValue(name, out object? existing) )
-                {
-                    _filesByName[name] = path;
-                    continue;
-                }
-
-                if ( existing is HashSet<string> many )
-                {
-                    many.Add(path);
-                    continue;
-                }
-
-                string only = (string)existing;
-                if ( string.Equals(only, path, StringComparison.Ordinal) )
-                {
-                    continue;
-                }
-
-                _filesByName[name] = new HashSet<string>(StringComparer.Ordinal) { only, path };
-            }
-        }
+        _index.Apply(path, oldNames, newNames);
     }
 
     /// <summary>Paths of the files declaring this key name (snapshot).</summary>
     public ImmutableArray<string> FilesDeclaring(string keyName)
     {
-        lock ( _gate )
-        {
-            if ( !_filesByName.TryGetValue(keyName, out object? existing) )
-            {
-                return [];
-            }
-
-            return existing is HashSet<string> many ? [.. many] : [(string)existing];
-        }
+        return _index.FilesFor(keyName);
     }
 }

--- a/server/src/GSCode.Workspace/Database/LanguageStore.cs
+++ b/server/src/GSCode.Workspace/Database/LanguageStore.cs
@@ -7,7 +7,8 @@ namespace GSCode.Workspace.Database;
 /// <summary>
 /// All knowledge for ONE language world (GSC or CSC): the path-keyed record map and its
 /// reference index. GSC/CSC isolation is structural — two instances, never a filter.
-/// Record swaps are atomic; the only lock guards the per-file reference-index diff.
+/// Record swaps are atomic; writes to one path are serialised against each other and against
+/// nothing else.
 /// </summary>
 public sealed class LanguageStore
 {
@@ -18,16 +19,55 @@ public sealed class LanguageStore
     private readonly ClassGraph _classGraph = new();
 
     /// <summary>
-    /// Serialises WRITES so a record swap and the two index diffs that describe it land together.
-    /// Indexing runs <c>Parallel.ForEachAsync</c>, so without this the read-previous and the swap
-    /// below were separate steps: two upserts of the same file could each read the same previous
-    /// record and diff against it, leaving the indexes describing a version neither of them wrote.
+    /// Serialises writes TO ONE PATH so a record swap and the index diffs that describe it land
+    /// together. Indexing runs <c>Parallel.ForEachAsync</c>, so without this the read-previous and
+    /// the swap below are separate steps: two upserts of the same file could each read the same
+    /// previous record and diff against it, leaving the indexes describing a version neither of them
+    /// wrote.
     ///
-    /// Reads do not take this — the record map is concurrent, and each index snapshots under its
-    /// own lock. That is also why the ordering is safe: this gate is only ever taken on the way IN
+    /// One gate for the whole store used to do that, and it was the wrong shape. The race it exists
+    /// to stop is between two writers of the SAME file; two writers of different files share
+    /// nothing here, because each index below serialises its own dictionary under its own lock. So a
+    /// process-wide gate serialised every index diff in the workspace against every other one, and
+    /// on CoD4 that made <c>commit.upsert</c> 28.6% of cold-index thread-time at 20x parallelism.
+    ///
+    /// Striped by path instead. Two upserts of one file still collide, which is the entire contract;
+    /// two upserts of different files collide only on a hash coincidence, at which point they are
+    /// still correct and merely serialised.
+    ///
+    /// Reads take none of these — the record map is concurrent and each index snapshots under its
+    /// own lock. That is also why the ordering is safe: a gate here is only ever taken on the way IN
     /// to an index, never from one.
     /// </summary>
-    private readonly Lock _writeGate = new();
+    private readonly Lock[] _writeGates = CreateGates();
+
+    /// <summary>
+    /// Enough stripes that a hash collision between two files being committed at once is rare at
+    /// any realistic core count, and small enough to stay a fixed cost. 64 locks is a few kilobytes.
+    /// </summary>
+    private const int WriteGateCount = 64;
+
+    private static Lock[] CreateGates()
+    {
+        Lock[] gates = new Lock[WriteGateCount];
+        for ( int index = 0; index < gates.Length; index++ )
+        {
+            gates[index] = new Lock();
+        }
+
+        return gates;
+    }
+
+    /// <summary>
+    /// The gate covering one path. Ordinal, because every path reaching this store has already been
+    /// normalised and the record map is keyed the same way — two spellings of one file would be two
+    /// records long before they were two gates.
+    /// </summary>
+    private Lock GateFor(string path)
+    {
+        int hash = StringComparer.Ordinal.GetHashCode(path);
+        return _writeGates[(hash & int.MaxValue) % WriteGateCount];
+    }
 
     /// <summary>Number of files currently held.</summary>
     public int Count
@@ -58,7 +98,7 @@ public sealed class LanguageStore
         HashSet<string> newNames = DeclarationIndex.NamesOf(record.Functions);
         HashSet<string> newNamespaces = NamespaceIndex.NamespacesOf(record.Functions);
 
-        lock ( _writeGate )
+        lock ( GateFor(record.Path) )
         {
             _records.TryGetValue(record.Path, out ScriptRecord? previous);
             _records[record.Path] = record;
@@ -76,7 +116,7 @@ public sealed class LanguageStore
     /// <summary>Removes a file entirely (deleted from disk).</summary>
     public void Remove(string normalizedPath)
     {
-        lock ( _writeGate )
+        lock ( GateFor(normalizedPath) )
         {
             if ( _records.TryRemove(normalizedPath, out ScriptRecord? previous) )
             {

--- a/server/src/GSCode.Workspace/Database/LanguageStore.cs
+++ b/server/src/GSCode.Workspace/Database/LanguageStore.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using GSCode.Core.Instrumentation;
 using GSCode.Core.Symbols;
 
 namespace GSCode.Workspace.Database;
@@ -106,10 +107,21 @@ public sealed class LanguageStore
             // The OLD sets still have to be built here: `previous` is only knowable under the gate,
             // and reading it outside would let two upserts of one file diff against the same
             // version. On a cold index it is always null and these are empty.
+            PerfTracker.Begin("upsert.reference");
             _referenceIndex.Apply(record.Path, ReferenceIndex.KeysOf(previous?.References ?? []), newKeys);
+            PerfTracker.End();
+
+            PerfTracker.Begin("upsert.declaration");
             _declarationIndex.Apply(record.Path, DeclarationIndex.NamesOf(previous?.Functions ?? []), newNames);
+            PerfTracker.End();
+
+            PerfTracker.Begin("upsert.namespace");
             _namespaceIndex.Apply(record.Path, NamespaceIndex.NamespacesOf(previous?.Functions ?? []), newNamespaces);
+            PerfTracker.End();
+
+            PerfTracker.Begin("upsert.class");
             _classGraph.Apply(record.Path, record.Classes);
+            PerfTracker.End();
         }
     }
 

--- a/server/src/GSCode.Workspace/Database/LanguageStore.cs
+++ b/server/src/GSCode.Workspace/Database/LanguageStore.cs
@@ -14,6 +14,7 @@ public sealed class LanguageStore
     private readonly ConcurrentDictionary<string, ScriptRecord> _records = new(StringComparer.Ordinal);
     private readonly ReferenceIndex _referenceIndex = new();
     private readonly DeclarationIndex _declarationIndex = new();
+    private readonly NamespaceIndex _namespaceIndex = new();
     private readonly ClassGraph _classGraph = new();
 
     /// <summary>
@@ -55,6 +56,7 @@ public sealed class LanguageStore
         // parallelism. The gate now covers only the swap and the dictionary mutations it orders.
         HashSet<SymbolKey> newKeys = ReferenceIndex.KeysOf(record.References);
         HashSet<string> newNames = DeclarationIndex.NamesOf(record.Functions);
+        HashSet<string> newNamespaces = NamespaceIndex.NamespacesOf(record.Functions);
 
         lock ( _writeGate )
         {
@@ -66,6 +68,7 @@ public sealed class LanguageStore
             // version. On a cold index it is always null and these are empty.
             _referenceIndex.Apply(record.Path, ReferenceIndex.KeysOf(previous?.References ?? []), newKeys);
             _declarationIndex.Apply(record.Path, DeclarationIndex.NamesOf(previous?.Functions ?? []), newNames);
+            _namespaceIndex.Apply(record.Path, NamespaceIndex.NamespacesOf(previous?.Functions ?? []), newNamespaces);
             _classGraph.Apply(record.Path, record.Classes);
         }
     }
@@ -79,6 +82,7 @@ public sealed class LanguageStore
             {
                 _referenceIndex.Apply(normalizedPath, ReferenceIndex.KeysOf(previous.References), []);
                 _declarationIndex.Apply(normalizedPath, DeclarationIndex.NamesOf(previous.Functions), []);
+                _namespaceIndex.Apply(normalizedPath, NamespaceIndex.NamespacesOf(previous.Functions), []);
                 _classGraph.Remove(normalizedPath);
             }
         }
@@ -88,6 +92,14 @@ public sealed class LanguageStore
     public ImmutableArray<string> FilesDeclaring(string keyName)
     {
         return _declarationIndex.FilesDeclaring(keyName);
+    }
+
+    /// <summary>
+    /// Paths of the files declaring a function INTO a namespace — see <see cref="NamespaceIndex"/>.
+    /// </summary>
+    public ImmutableArray<string> FilesDeclaringInto(string namespaceName)
+    {
+        return _namespaceIndex.FilesDeclaringInto(namespaceName);
     }
 
     /// <summary>Paths of every file that mentions the key (definition sites included).</summary>

--- a/server/src/GSCode.Workspace/Database/NamespaceIndex.cs
+++ b/server/src/GSCode.Workspace/Database/NamespaceIndex.cs
@@ -1,0 +1,90 @@
+using System.Collections.Immutable;
+using GSCode.Core.Symbols;
+
+namespace GSCode.Workspace.Database;
+
+/// <summary>
+/// Namespace → the files declaring a function in it, so a question about one namespace does not read
+/// the whole store.
+///
+/// `FunctionsInNamespace` walked every record and every function in each, filtering on the namespace
+/// — about 30,000 symbols on BO3 — and it is asked once per namespace a file can see. That is the
+/// same shape `DeclarationIndex` was built for, one question wider: a name identifies one or two
+/// files, and a namespace identifies a few dozen, which is still nothing against the store.
+///
+/// Namespaces are FEW — hundreds across a game, against thousands of function names — so this keeps
+/// a plain <c>HashSet</c> per key rather than the single-string-until-a-second-appears union
+/// <see cref="DeclarationIndex"/> needs. The saving that union exists for does not apply when the
+/// normal case is a key with many files.
+/// </summary>
+public sealed class NamespaceIndex
+{
+    private readonly Dictionary<string, HashSet<string>> _filesByNamespace = new(StringComparer.Ordinal);
+    private readonly Lock _gate = new();
+
+    /// <summary>
+    /// The distinct namespaces a function list declares into. Built outside the caller's write gate,
+    /// like <see cref="DeclarationIndex.NamesOf"/>.
+    /// </summary>
+    public static HashSet<string> NamespacesOf(ImmutableArray<FunctionSymbol> functions)
+    {
+        HashSet<string> namespaces = new(StringComparer.Ordinal);
+        foreach ( FunctionSymbol function in functions )
+        {
+            namespaces.Add(function.Namespace);
+        }
+
+        return namespaces;
+    }
+
+    /// <summary>Replaces one file's contribution: drops the namespaces it no longer declares into.</summary>
+    public void Apply(string path, HashSet<string> oldNamespaces, HashSet<string> newNamespaces)
+    {
+        lock ( _gate )
+        {
+            foreach ( string name in oldNamespaces )
+            {
+                if ( newNamespaces.Contains(name) || !_filesByNamespace.TryGetValue(name, out HashSet<string>? files) )
+                {
+                    continue;
+                }
+
+                files.Remove(path);
+                if ( files.Count == 0 )
+                {
+                    _filesByNamespace.Remove(name);
+                }
+            }
+
+            foreach ( string name in newNamespaces )
+            {
+                if ( !_filesByNamespace.TryGetValue(name, out HashSet<string>? files) )
+                {
+                    files = new HashSet<string>(StringComparer.Ordinal);
+                    _filesByNamespace[name] = files;
+                }
+
+                files.Add(path);
+            }
+        }
+    }
+
+    /// <summary>
+    /// The files declaring a function in this namespace, or empty when nothing does.
+    ///
+    /// Snapshotted under the gate, so a caller can walk the result while indexing continues — the
+    /// same contract the other two indexes offer.
+    /// </summary>
+    public ImmutableArray<string> FilesDeclaringInto(string namespaceName)
+    {
+        lock ( _gate )
+        {
+            if ( !_filesByNamespace.TryGetValue(namespaceName, out HashSet<string>? files) )
+            {
+                return [];
+            }
+
+            return [.. files];
+        }
+    }
+}

--- a/server/src/GSCode.Workspace/Database/PackedInvertedIndex.cs
+++ b/server/src/GSCode.Workspace/Database/PackedInvertedIndex.cs
@@ -1,0 +1,173 @@
+using System.Collections.Immutable;
+
+namespace GSCode.Workspace.Database;
+
+/// <summary>
+/// key → the files mentioning it, packed and sharded. The storage and the per-file diff that
+/// <see cref="ReferenceIndex"/> and <see cref="DeclarationIndex"/> both need, written once.
+///
+/// The two were the same class twice over: the same string-or-HashSet packing, the same
+/// remove-then-add diff, the same snapshot read, differing only in what a key is. Keeping them
+/// apart meant a change to the diff had to land in both to stay correct, and they had already
+/// drifted — the reference side was sharded for contention and the declaration side was not.
+///
+/// <see cref="NamespaceIndex"/> is deliberately NOT built on this. It holds a plain
+/// <c>HashSet</c> per key because a namespace is declared into by many files by nature, so the
+/// packing below saves nothing there and the diff it needs is genuinely simpler. Unifying the
+/// three would take a flag to tell the two shapes apart, which is the sign they are not one shape.
+/// </summary>
+/// <typeparam name="TKey">
+/// What identifies an entry: a symbol key on the reference side, a lowercase-canonical name on the
+/// declaration side.
+/// </typeparam>
+internal sealed class PackedInvertedIndex<TKey>
+    where TKey : notnull
+{
+    /// <summary>
+    /// Shard count. A power of two so the shard index is a mask rather than a division, and well
+    /// above any realistic core count so two threads rarely meet on one shard. The whole cost is
+    /// this many dictionaries and locks, allocated once.
+    ///
+    /// Sharding is what took <c>commit.upsert</c> from 28.6% of CoD4's cold-index thread-time to
+    /// 8.4%: one dictionary under one lock meant a file's whole diff — thousands of keys on a large
+    /// script — waited on every other indexing thread's. It is sound only because no invariant spans
+    /// two keys: an entry is complete on its own, and nothing reads a group of them expecting one
+    /// instant. See `PERF.md`.
+    /// </summary>
+    private const int ShardCount = 64;
+
+    private const int ShardMask = ShardCount - 1;
+
+    private sealed class Shard
+    {
+        /// <summary>
+        /// key → the one file that mentions it, as a bare <c>string</c>, promoted to a
+        /// <c>HashSet&lt;string&gt;</c> only once a second appears.
+        ///
+        /// The overwhelming majority of keys are mentioned by exactly one file, and a HashSet
+        /// holding a single reference costs on the order of 150 bytes against the 8 of the
+        /// reference itself. Measured on BO1, the largest corpus at 2,963 files, that is the
+        /// difference between the declaration index costing 5.1 MB and costing well under one; the
+        /// reference index is far larger again, since BO1 interns over a million references.
+        ///
+        /// The union is contained entirely within this class — nothing outside ever sees an
+        /// <c>object</c>.
+        /// </summary>
+        public Dictionary<TKey, object> Entries = null!;
+
+        public Lock Gate = null!;
+    }
+
+    private readonly Shard[] _shards;
+    private readonly IEqualityComparer<TKey> _comparer;
+
+    public PackedInvertedIndex(IEqualityComparer<TKey> comparer)
+    {
+        _comparer = comparer;
+        _shards = new Shard[ShardCount];
+
+        for ( int index = 0; index < _shards.Length; index++ )
+        {
+            _shards[index] = new Shard
+            {
+                Entries = new Dictionary<TKey, object>(comparer),
+                Gate = new Lock(),
+            };
+        }
+    }
+
+    /// <summary>
+    /// The shard owning a key. Uses the same comparer as the dictionaries, so a key that compares
+    /// equal always lands on the shard holding it.
+    /// </summary>
+    private Shard ShardFor(TKey key)
+    {
+        return _shards[_comparer.GetHashCode(key) & ShardMask];
+    }
+
+    /// <summary>
+    /// Replaces one file's contribution: removes the keys it no longer carries, adds the rest.
+    ///
+    /// One shard lock per key rather than one lock for the whole diff. An uncontended <c>Lock</c>
+    /// costs a few nanoseconds and a file carries thousands of keys, so the acquisitions are
+    /// microseconds against the milliseconds a single gate spent waiting.
+    /// </summary>
+    public void Apply(string path, HashSet<TKey> oldKeys, HashSet<TKey> newKeys)
+    {
+        foreach ( TKey key in oldKeys )
+        {
+            if ( newKeys.Contains(key) )
+            {
+                continue;
+            }
+
+            Shard shard = ShardFor(key);
+            lock ( shard.Gate )
+            {
+                if ( !shard.Entries.TryGetValue(key, out object? existing) )
+                {
+                    continue;
+                }
+
+                if ( existing is HashSet<string> many )
+                {
+                    many.Remove(path);
+
+                    // Not demoted back to a bare string on the way down: a key that has had two
+                    // files usually gets them back, and this path runs on edits rather than on the
+                    // cold index the memory shape is tuned for.
+                    if ( many.Count == 0 )
+                    {
+                        shard.Entries.Remove(key);
+                    }
+                }
+                else if ( string.Equals((string)existing, path, StringComparison.Ordinal) )
+                {
+                    shard.Entries.Remove(key);
+                }
+            }
+        }
+
+        foreach ( TKey key in newKeys )
+        {
+            Shard shard = ShardFor(key);
+            lock ( shard.Gate )
+            {
+                if ( !shard.Entries.TryGetValue(key, out object? existing) )
+                {
+                    shard.Entries[key] = path;
+                    continue;
+                }
+
+                if ( existing is HashSet<string> many )
+                {
+                    many.Add(path);
+                    continue;
+                }
+
+                string only = (string)existing;
+                if ( string.Equals(only, path, StringComparison.Ordinal) )
+                {
+                    continue;
+                }
+
+                shard.Entries[key] = new HashSet<string>(StringComparer.Ordinal) { only, path };
+            }
+        }
+    }
+
+    /// <summary>Paths of the files carrying this key (a snapshot, safe to walk while indexing).</summary>
+    public ImmutableArray<string> FilesFor(TKey key)
+    {
+        Shard shard = ShardFor(key);
+        lock ( shard.Gate )
+        {
+            if ( !shard.Entries.TryGetValue(key, out object? existing) )
+            {
+                return [];
+            }
+
+            return existing is HashSet<string> many ? [.. many] : [(string)existing];
+        }
+    }
+}

--- a/server/src/GSCode.Workspace/Database/ReferenceIndex.cs
+++ b/server/src/GSCode.Workspace/Database/ReferenceIndex.cs
@@ -5,11 +5,27 @@ namespace GSCode.Workspace.Database;
 
 /// <summary>
 /// The inverted index: which files mention a symbol key. Answers are path sets only —
-/// exact ranges come from scanning those files' (small) reference lists. One lock,
-/// held per-file-diff only; reads snapshot under the same lock.
+/// exact ranges come from scanning those files' (small) reference lists.
+///
+/// SHARDED by key, so a diff of one file and a diff of another only collide on the keys they
+/// actually share. It was one dictionary under one lock, which meant every indexing thread's whole
+/// per-file diff — thousands of keys on a large script — waited on every other thread's. That, plus
+/// the store-wide gate above it, is what made <c>commit.upsert</c> a quarter of CoD4's cold-index
+/// thread-time at 20x parallelism. Reads shard the same way, which matters for the lint pass rather
+/// than for indexing: <c>FilesFor</c> is on the hot path of the reference-based rules and used to
+/// contend with whatever was being committed.
 /// </summary>
 public sealed class ReferenceIndex
 {
+    /// <summary>
+    /// Shard count. Power of two so the shard index is a mask rather than a division, and well
+    /// above any realistic core count so two threads rarely meet on one shard. The whole cost is
+    /// this many dictionaries and locks, allocated once.
+    /// </summary>
+    private const int ShardCount = 64;
+
+    private const int ShardMask = ShardCount - 1;
+
     /// <summary>
     /// key → the file that mentions it, as a bare <c>string</c> while exactly one does and a
     /// <c>HashSet&lt;string&gt;</c> only once a second appears.
@@ -19,15 +35,36 @@ public sealed class ReferenceIndex
     /// of 150 bytes to carry 8. This index is far larger than the declaration one — BO1 interns over
     /// a million references — so the saving is correspondingly bigger.
     /// </summary>
-    private readonly Dictionary<SymbolKey, object> _filesByKey = [];
-    private readonly Lock _gate = new();
+    private sealed class Shard
+    {
+        public readonly Dictionary<SymbolKey, object> FilesByKey = [];
+        public readonly Lock Gate = new();
+    }
+
+    private readonly Shard[] _shards = CreateShards();
+
+    private static Shard[] CreateShards()
+    {
+        Shard[] shards = new Shard[ShardCount];
+        for ( int index = 0; index < shards.Length; index++ )
+        {
+            shards[index] = new Shard();
+        }
+
+        return shards;
+    }
+
+    private Shard ShardFor(SymbolKey key)
+    {
+        return _shards[key.GetHashCode() & ShardMask];
+    }
 
     /// <summary>
     /// The distinct keys a reference list mentions.
     ///
     /// Separate from <see cref="Apply"/> so the caller can build it OUTSIDE its own write gate. This
     /// walk is O(references in the file) — thousands for a large script — and it used to run while
-    /// <c>LanguageStore._writeGate</c> was held, so every indexing thread waited on every other
+    /// <c>LanguageStore</c>'s write gate was held, so every indexing thread waited on every other
     /// thread's hashing. That made the commit stage 22% of CoD4's cold-index thread-time.
     /// </summary>
     public static HashSet<SymbolKey> KeysOf(ImmutableArray<ReferenceEntry> references)
@@ -41,14 +78,28 @@ public sealed class ReferenceIndex
         return keys;
     }
 
-    /// <summary>Replaces one file's contribution: removes vanished keys, adds new ones.</summary>
+    /// <summary>
+    /// Replaces one file's contribution: removes vanished keys, adds new ones.
+    ///
+    /// One shard lock per key rather than one lock for the diff. An uncontended <c>Lock</c> costs a
+    /// few nanoseconds and a file carries thousands of keys, so the acquisitions are microseconds
+    /// against the milliseconds the single gate was spending WAITING. The trade only works because
+    /// no invariant spans two keys: a key's entry is complete on its own, and nothing reads a group
+    /// of them expecting one instant.
+    /// </summary>
     public void Apply(string path, HashSet<SymbolKey> oldKeys, HashSet<SymbolKey> newKeys)
     {
-        lock ( _gate )
+        foreach ( SymbolKey key in oldKeys )
         {
-            foreach ( SymbolKey key in oldKeys )
+            if ( newKeys.Contains(key) )
             {
-                if ( newKeys.Contains(key) || !_filesByKey.TryGetValue(key, out object? existing) )
+                continue;
+            }
+
+            Shard shard = ShardFor(key);
+            lock ( shard.Gate )
+            {
+                if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
                 {
                     continue;
                 }
@@ -58,20 +109,24 @@ public sealed class ReferenceIndex
                     many.Remove(path);
                     if ( many.Count == 0 )
                     {
-                        _filesByKey.Remove(key);
+                        shard.FilesByKey.Remove(key);
                     }
                 }
                 else if ( string.Equals((string)existing, path, StringComparison.Ordinal) )
                 {
-                    _filesByKey.Remove(key);
+                    shard.FilesByKey.Remove(key);
                 }
             }
+        }
 
-            foreach ( SymbolKey key in newKeys )
+        foreach ( SymbolKey key in newKeys )
+        {
+            Shard shard = ShardFor(key);
+            lock ( shard.Gate )
             {
-                if ( !_filesByKey.TryGetValue(key, out object? existing) )
+                if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
                 {
-                    _filesByKey[key] = path;
+                    shard.FilesByKey[key] = path;
                     continue;
                 }
 
@@ -84,7 +139,7 @@ public sealed class ReferenceIndex
                 string only = (string)existing;
                 if ( !string.Equals(only, path, StringComparison.Ordinal) )
                 {
-                    _filesByKey[key] = new HashSet<string>(StringComparer.Ordinal) { only, path };
+                    shard.FilesByKey[key] = new HashSet<string>(StringComparer.Ordinal) { only, path };
                 }
             }
         }
@@ -93,9 +148,10 @@ public sealed class ReferenceIndex
     /// <summary>Paths of files mentioning the key (snapshot).</summary>
     public ImmutableArray<string> FilesFor(SymbolKey key)
     {
-        lock ( _gate )
+        Shard shard = ShardFor(key);
+        lock ( shard.Gate )
         {
-            if ( !_filesByKey.TryGetValue(key, out object? existing) )
+            if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
             {
                 return [];
             }

--- a/server/src/GSCode.Workspace/Database/ReferenceIndex.cs
+++ b/server/src/GSCode.Workspace/Database/ReferenceIndex.cs
@@ -7,57 +7,13 @@ namespace GSCode.Workspace.Database;
 /// The inverted index: which files mention a symbol key. Answers are path sets only —
 /// exact ranges come from scanning those files' (small) reference lists.
 ///
-/// SHARDED by key, so a diff of one file and a diff of another only collide on the keys they
-/// actually share. It was one dictionary under one lock, which meant every indexing thread's whole
-/// per-file diff — thousands of keys on a large script — waited on every other thread's. That, plus
-/// the store-wide gate above it, is what made <c>commit.upsert</c> a quarter of CoD4's cold-index
-/// thread-time at 20x parallelism. Reads shard the same way, which matters for the lint pass rather
-/// than for indexing: <c>FilesFor</c> is on the hot path of the reference-based rules and used to
-/// contend with whatever was being committed.
+/// The storage, the packing and the per-file diff live in <see cref="PackedInvertedIndex{TKey}"/>,
+/// which <see cref="DeclarationIndex"/> shares. What is here is the reference side's own vocabulary
+/// and the walk that turns a record's reference list into keys.
 /// </summary>
 public sealed class ReferenceIndex
 {
-    /// <summary>
-    /// Shard count. Power of two so the shard index is a mask rather than a division, and well
-    /// above any realistic core count so two threads rarely meet on one shard. The whole cost is
-    /// this many dictionaries and locks, allocated once.
-    /// </summary>
-    private const int ShardCount = 64;
-
-    private const int ShardMask = ShardCount - 1;
-
-    /// <summary>
-    /// key → the file that mentions it, as a bare <c>string</c> while exactly one does and a
-    /// <c>HashSet&lt;string&gt;</c> only once a second appears.
-    ///
-    /// The same shape <see cref="DeclarationIndex"/> uses, and for the same reason: most symbol keys
-    /// are mentioned in a single file, and a HashSet holding one string reference costs on the order
-    /// of 150 bytes to carry 8. This index is far larger than the declaration one — BO1 interns over
-    /// a million references — so the saving is correspondingly bigger.
-    /// </summary>
-    private sealed class Shard
-    {
-        public readonly Dictionary<SymbolKey, object> FilesByKey = [];
-        public readonly Lock Gate = new();
-    }
-
-    private readonly Shard[] _shards = CreateShards();
-
-    private static Shard[] CreateShards()
-    {
-        Shard[] shards = new Shard[ShardCount];
-        for ( int index = 0; index < shards.Length; index++ )
-        {
-            shards[index] = new Shard();
-        }
-
-        return shards;
-    }
-
-    private Shard ShardFor(SymbolKey key)
-    {
-        return _shards[key.GetHashCode() & ShardMask];
-    }
+    private readonly PackedInvertedIndex<SymbolKey> _index = new(EqualityComparer<SymbolKey>.Default);
 
     /// <summary>
     /// The distinct keys a reference list mentions.
@@ -78,85 +34,15 @@ public sealed class ReferenceIndex
         return keys;
     }
 
-    /// <summary>
-    /// Replaces one file's contribution: removes vanished keys, adds new ones.
-    ///
-    /// One shard lock per key rather than one lock for the diff. An uncontended <c>Lock</c> costs a
-    /// few nanoseconds and a file carries thousands of keys, so the acquisitions are microseconds
-    /// against the milliseconds the single gate was spending WAITING. The trade only works because
-    /// no invariant spans two keys: a key's entry is complete on its own, and nothing reads a group
-    /// of them expecting one instant.
-    /// </summary>
+    /// <summary>Replaces one file's contribution: removes vanished keys, adds new ones.</summary>
     public void Apply(string path, HashSet<SymbolKey> oldKeys, HashSet<SymbolKey> newKeys)
     {
-        foreach ( SymbolKey key in oldKeys )
-        {
-            if ( newKeys.Contains(key) )
-            {
-                continue;
-            }
-
-            Shard shard = ShardFor(key);
-            lock ( shard.Gate )
-            {
-                if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
-                {
-                    continue;
-                }
-
-                if ( existing is HashSet<string> many )
-                {
-                    many.Remove(path);
-                    if ( many.Count == 0 )
-                    {
-                        shard.FilesByKey.Remove(key);
-                    }
-                }
-                else if ( string.Equals((string)existing, path, StringComparison.Ordinal) )
-                {
-                    shard.FilesByKey.Remove(key);
-                }
-            }
-        }
-
-        foreach ( SymbolKey key in newKeys )
-        {
-            Shard shard = ShardFor(key);
-            lock ( shard.Gate )
-            {
-                if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
-                {
-                    shard.FilesByKey[key] = path;
-                    continue;
-                }
-
-                if ( existing is HashSet<string> many )
-                {
-                    many.Add(path);
-                    continue;
-                }
-
-                string only = (string)existing;
-                if ( !string.Equals(only, path, StringComparison.Ordinal) )
-                {
-                    shard.FilesByKey[key] = new HashSet<string>(StringComparer.Ordinal) { only, path };
-                }
-            }
-        }
+        _index.Apply(path, oldKeys, newKeys);
     }
 
     /// <summary>Paths of files mentioning the key (snapshot).</summary>
     public ImmutableArray<string> FilesFor(SymbolKey key)
     {
-        Shard shard = ShardFor(key);
-        lock ( shard.Gate )
-        {
-            if ( !shard.FilesByKey.TryGetValue(key, out object? existing) )
-            {
-                return [];
-            }
-
-            return existing is HashSet<string> many ? [.. many] : [(string)existing];
-        }
+        return _index.FilesFor(key);
     }
 }

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -210,8 +210,15 @@ lints, `Completion/` and `Typing/` the information surfaces.
 ## Completion/SignatureEngine.cs
 
 - `SignatureParameter`/`SignatureResult` + `SignatureEngine.Resolve(...)` — scans back from
-  the cursor to the enclosing '(', identifies the callee (script function / builtin) and
+  the cursor to the enclosing '(', identifies the callee (macro / script function / builtin) and
   the active parameter (top-level comma count), and renders the signature + parameter docs.
+- The MACRO is asked first, and from `result.Preprocessed.Macros` rather than the store: the
+  preprocessor substitutes before the parser runs, so where a `#define` and a function share a name
+  the function's parameters describe code that never executes. The lookup is ORDINAL — macro names
+  are the language's one case-sensitive kind — and an object-like macro answers null, since
+  `MAX_PLAYERS( x )` is a body followed by a parenthesised expression rather than a call. Unlike
+  macro COMPLETION this is not gated on `HasMacros`: completion decides what to propose, this
+  describes a name already written, and the preprocessor expands a `#define` on every dialect.
 
 ## Database/SymbolAtPosition.cs
 

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -283,8 +283,10 @@ lints, `Completion/` and `Typing/` the information surfaces.
   effect immediately. Takes an optional `GameProfile`, null meaning `GameProfile.Active` at
   analysis time — which is what the server wants, selecting the game once at startup, and what
   a caller holding a profile must override: indexing under the wrong dialect does not fail, it
-  parses declarations away and leaves the store EMPTY. A `ConcurrentDictionary<path, Lazy<InsertedFile?>>` lexes each GSH
-  exactly once no matter how many scripts insert it; `InvalidateGsh` drops one on change.
+  parses declarations away and leaves the store EMPTY. Inserts go through the shared `InsertCache`
+  and a `ResolverInsertProvider`, the same two the document path uses, so each GSH is lexed once no
+  matter how many scripts insert it; `InvalidateGsh` drops one on change. The argument is optional
+  and the field is not — a caller supplying none gets its own cache rather than no cache.
   `IndexFile` is the single-file path the watcher reuses. `UseCache` enables warm-restore:
   the two-pass `IndexAsync` restores files whose on-disk content hash matches the cached
   `CachedEntry`, deserializing the blob only once that check passes and skipping the parse, then
@@ -374,9 +376,10 @@ lints, `Completion/` and `Typing/` the information surfaces.
 
 ## Resolution/ResolverInsertProvider.cs
 
-- `sealed class ResolverInsertProvider` — the real #insert provider: resolves the raw
-  path through the asking file's ResolutionContext, reads and lexes the target. The
-  shared lexed-GSH cache arrives with the indexer (P5).
+- `sealed class ResolverInsertProvider` — the ONLY #insert provider: resolves the raw
+  path through the asking file's ResolutionContext, then takes the target from `InsertCache` or
+  reads and lexes it. Both the document path and `WorkspaceIndexer` use it; the indexer had a
+  private one of its own over a second cache of the same headers until they were merged.
 
 ## Resolution/IFileSystem.cs
 
@@ -599,6 +602,10 @@ are out.
 - Validated by last-write time rather than by an invalidation message, because a watcher that drops
   an event leaves a stale header — and a stale header changes what macros expand to with no error to
   trace back. A failed read is not cached. See `PERF.md` for what the two caches were worth.
+- `SeedIfAbsent` takes a header the indexer has already read and lexed as one of its own targets,
+  rather than letting the insert path build it a second time. `TryAdd`, not an assignment: a `.gsc`
+  inserting the header may get there first, and its entry is equally current and may already carry a
+  walked contribution. The stamp must be read BEFORE the content it describes.
 
 ## Resolution/RawWriteGuard.cs
 

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -710,6 +710,10 @@ Bundled game data (copied to the build output) plus the loaders and doc renderer
 - `DevOnlyBuiltins.cs` — the conservative fallback set for development-only engine functions;
   API entries can override it when the data carries an explicit `devOnly` value.
 - `MacroExpansionPreview.cs` — renders a readable, length-limited macro body for hover and
-  substitutes call-site arguments token-by-token rather than by unsafe text replacement.
+  substitutes call-site arguments token-by-token rather than by unsafe text replacement. One
+  argument scan serves both readers: `ArgumentsFollowing` gives hover the text, and
+  `ArgumentSpansFollowing` gives the macro inlay hints the trimmed `MacroArgumentSpan` offsets a
+  label is placed at. Nesting counts brackets as well as parentheses, and an unterminated list —
+  the normal state while typing — yields what has been written so far.
 - `StockScripts.cs` — loads the profile's raw-relative stock-script list and canonicalizes slash
   style and casing for the raw-file warning setting.

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -42,19 +42,32 @@ lints, `Completion/` and `Typing/` the information surfaces.
   One gate for the store serialised every index diff in the workspace against every other one and
   made `commit.upsert` 28.6% of CoD4's cold-index thread-time. See `PERF.md`.
 
+## Database/PackedInvertedIndex.cs
+
+- `internal sealed class PackedInvertedIndex<TKey>` — key→files storage plus the per-file diff,
+  shared by `ReferenceIndex` and `DeclarationIndex`. They were the same class twice: same packing,
+  same remove-then-add diff, same snapshot read, differing only in what a key is. Keeping them apart
+  meant a change to the diff had to land in both, and they had already drifted.
+- Packed: a bare `string` while exactly one file carries a key, promoted to a `HashSet<string>` only
+  once a second appears. Most keys are carried by one file and a HashSet holding one reference costs
+  ~150 bytes to carry 8 — on BO1 that is the declaration index costing 5.1 MB against well under
+  one. The union never escapes the class.
+- Sharded 64 ways by key hash, each shard its own dictionary and lock, taking a shard lock per key
+  rather than one lock per diff. Sound only because no invariant spans two keys. This took
+  `commit.upsert` from 28.6% of CoD4's cold-index thread-time to 8.4%; see `PERF.md`.
+- `NamespaceIndex` is deliberately NOT built on this — see its entry.
+
 ## Database/ReferenceIndex.cs
 
-- `sealed class ReferenceIndex` — the inverted key→files index. SHARDED 64 ways by key, each
-  shard its own dictionary and lock, so a diff of one file meets a diff of another only on the keys
-  they share; exact ranges come from scanning the named files' reference lists. Reads shard the same
-  way, which matters for the lint pass rather than for indexing — `FilesFor` is on the hot path of
-  the reference rules and used to contend with whatever was being committed.
+- `sealed class ReferenceIndex` — the inverted key→files index. `KeysOf` turns a record's
+  reference list into keys outside the caller's write gate; the storage and the diff come from
+  `PackedInvertedIndex<SymbolKey>`. Exact ranges come from scanning the named files' reference lists.
 
 ## Database/DeclarationIndex.cs
 
 - `sealed class DeclarationIndex` — the name→declaring-files index, the counterpart to
-  `ReferenceIndex`. Maintained by the same Apply-on-upsert diff under that path's write gate, and
-  holds PATHS rather than records for the same reason: a record is swapped wholesale on every edit,
+  `ReferenceIndex`, and literally so — both are wrappers over `PackedInvertedIndex<TKey>`. Holds
+  PATHS rather than records for the same reason: a record is swapped wholesale on every edit,
   so holding one would pin a stale version. Keyed on `FunctionSymbol.KeyName` and compared ordinally
   — exactly the comparison `LookupFunctions` performs, so the candidate set is identical.
 - It exists because `LookupFunctions` used to walk every record and every function in each (~30,000
@@ -68,9 +81,11 @@ lints, `Completion/` and `Typing/` the information surfaces.
   inverted indexes and built for the same reason as the other two: a question that used to be
   answered by walking the whole store is answered by a lookup. `FilesDeclaringInto` narrows the
   candidate set for a namespace before anything reads a record.
-- Holds a plain `HashSet<string>` per namespace rather than the string-or-HashSet packing
-  `DeclarationIndex` and `ReferenceIndex` use, because a namespace is declared into by many files
-  by nature, where a function name usually is not — the packing saves nothing here.
+- Holds a plain `HashSet<string>` per namespace rather than sharing `PackedInvertedIndex<TKey>`
+  with the other two, because a namespace is declared into by many files by nature, where a function
+  name usually is not: the packing saves nothing here and the diff it needs is genuinely simpler.
+  Unifying all three would take a flag to tell the two shapes apart, which is the sign they are not
+  one shape.
 
 ## Database/FunctionLookupCache.cs
 

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -742,7 +742,11 @@ Bundled game data (copied to the build output) plus the loaders and doc renderer
 - `DevOnlyBuiltins.cs` — the conservative fallback set for development-only engine functions;
   API entries can override it when the data carries an explicit `devOnly` value.
 - `MacroExpansionPreview.cs` — renders a readable, length-limited macro body for hover and
-  substitutes call-site arguments token-by-token rather than by unsafe text replacement. One
+  signature help, and substitutes call-site arguments token-by-token rather than by unsafe text
+  replacement. The body keeps the LINES it was written on — the backslashes are gone from it by
+  then, but each token still carries its own line — and indentation is rendered as ranked LEVELS
+  four spaces apart rather than as the author's columns, since a tab is one character in a range
+  and subtracting columns gave a tab-indented header a one-space step. One
   argument scan serves both readers: `ArgumentsFollowing` gives hover the text, and
   `ArgumentSpansFollowing` gives the macro inlay hints the trimmed `MacroArgumentSpan` offsets a
   label is placed at. Nesting counts brackets as well as parentheses, and an unterminated list —

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -293,6 +293,11 @@ lints, `Completion/` and `Typing/` the information surfaces.
   two closes the changed-header set over the insert graph first, since a restored `.gsh`
   that inserts a changed one contributes something new despite its own bytes matching.
   `RemoveFile` drops a deleted file from the database, the cache, and the GSH lex cache.
+  The restore snapshot is held for one pass only: `IndexAsync` releases it in a `finally`, so a
+  server-lifetime singleton does not carry 21 MB (bo3) or 64 MB (bo1) of gzipped blobs for the
+  session. `ReloadRestoreSnapshot` re-reads it for the one caller that indexes twice — the
+  workspace-folder handler — and swallows a read failure, since a cache closed by
+  `gscode/clearCache` should give a cold index rather than an exception.
 
 ## Cache/CacheSchema.cs
 

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -376,7 +376,10 @@ lints, `Completion/` and `Typing/` the information surfaces.
 ## Resolution/IFileSystem.cs
 
 - `interface IFileSystem` — the thin disk seam (FileExists/DirectoryExists/ReadAllText/
-  EnumerateFiles) so resolver and indexer tests run on fake in-memory trees.
+  GetLastWriteTimeUtc/EnumerateFilesWithExtensions) so resolver and indexer tests run on fake
+  in-memory trees. `EnumerateFilesWithExtensions` is the only enumeration on it: a single-pattern
+  form was carried for a while after its last caller went and cost every implementer a method
+  nothing called.
 - `sealed class PhysicalFileSystem` — the real one.
 
 ## Resolution/RootConfig.cs

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -447,7 +447,7 @@ lints, `Completion/` and `Typing/` the information surfaces.
 
 ## Analysis/PreferBooleanLiteralLint.cs
 
-- `static PreferBooleanLiteralLint.Analyze(result, builtins)` — hints that a literal `0`/`1`
+- `PreferBooleanLiteralLint.InspectNode(node, builtins, …)` + `InspectRest(…)` — hints that a literal `0`/`1`
   passed to a builtin parameter declared `bool` should be `false`/`true`. Scoped to
   declared-bool parameters ONLY: an int parameter legitimately takes 0 and 1, and flagging
   those was the v1 bug this rule's original test existed to pin. Every overload must agree the
@@ -472,7 +472,7 @@ lints, `Completion/` and `Typing/` the information surfaces.
 
 ## Analysis/GlobalObjectWriteLint.cs
 
-- `static GlobalObjectWriteLint.Analyze(result)` — reports an assignment to one of the engine's
+- `GlobalObjectWriteLint.InspectNode(node, globals, …)` + `GlobalNames()` — reports an assignment to one of the engine's
   global objects (5035, Error): `level = 1`, `anim = 1`. The names come from
   `GameProfile.GlobalObjectNames`, never a table here, so `world` is a global on BO3 and an ordinary
   local name on CoD4. Only a BARE name counts — `level.things = []` and `game[ "k" ] = 1` write
@@ -496,9 +496,16 @@ lints, `Completion/` and `Typing/` the information surfaces.
 
 ## Analysis/ — the remaining lints
 
-Each is a `static Analyze(...)` returning diagnostics, run per open document and merged by the
-server's `TextSyncHandler`. Severity is chosen by MEASUREMENT over the corpus, not by taste: a rule
-reported as an Error must never land on code that ships and works.
+Each is run per open document by `WorkspaceLints` and merged by the server's `TextSyncHandler`.
+Severity is chosen by MEASUREMENT over the corpus, not by taste: a rule reported as an Error must
+never land on code that ships and works.
+
+Two entry shapes. A rule that needs its own traversal — per-function state, a flag threaded down the
+descent, a cache carried along — exposes `static Analyze(...)` and walks the tree itself. A rule
+whose judgement is about a single node exposes `InspectNode` instead and is driven by
+`NodeLintPass`'s one shared walk; it has no `Analyze`, because a second walker that nothing but a
+test called is how the two silently drift. `NodeLintPass` names which rules are in and why the rest
+are out.
 
 - `FunctionResolutionLint` (5013/5014/5025) — a call resolving to no script function and no builtin.
   Splits script from builtin so a corpus sweep of 5014 yields the candidate list for curating the

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -34,18 +34,26 @@ lints, `Completion/` and `Typing/` the information surfaces.
 ## Database/LanguageStore.cs
 
 - `sealed class LanguageStore` — ONE language world: path-keyed record map + its
-  ReferenceIndex, DeclarationIndex and ClassGraph. Upsert swaps records atomically and diffs all
-  three under one write gate; GSC/CSC isolation is two instances of this class, never a filter.
+  ReferenceIndex, DeclarationIndex, NamespaceIndex and ClassGraph. Upsert swaps records atomically
+  and diffs all four; GSC/CSC isolation is two instances of this class, never a filter.
+- The write gates are STRIPED by path, 64 of them, not one for the store. The race they stop is
+  between two writers of the SAME file — read-previous and swap are separate steps — and two writers
+  of different files share nothing here, because each index below serialises its own dictionary.
+  One gate for the store serialised every index diff in the workspace against every other one and
+  made `commit.upsert` 28.6% of CoD4's cold-index thread-time. See `PERF.md`.
 
 ## Database/ReferenceIndex.cs
 
-- `sealed class ReferenceIndex` — the inverted key→files index. One lock, held per
-  file-diff; exact ranges come from scanning the named files' reference lists.
+- `sealed class ReferenceIndex` — the inverted key→files index. SHARDED 64 ways by key, each
+  shard its own dictionary and lock, so a diff of one file meets a diff of another only on the keys
+  they share; exact ranges come from scanning the named files' reference lists. Reads shard the same
+  way, which matters for the lint pass rather than for indexing — `FilesFor` is on the hot path of
+  the reference rules and used to contend with whatever was being committed.
 
 ## Database/DeclarationIndex.cs
 
 - `sealed class DeclarationIndex` — the name→declaring-files index, the counterpart to
-  `ReferenceIndex`. Maintained by the same Apply-on-upsert diff under the store's write gate, and
+  `ReferenceIndex`. Maintained by the same Apply-on-upsert diff under that path's write gate, and
   holds PATHS rather than records for the same reason: a record is swapped wholesale on every edit,
   so holding one would pin a stale version. Keyed on `FunctionSymbol.KeyName` and compared ordinally
   — exactly the comparison `LookupFunctions` performs, so the candidate set is identical.
@@ -53,6 +61,16 @@ lints, `Completion/` and `Typing/` the information surfaces.
   symbols on BO3) once per CALL SITE, which made four lints 97% of the cross-file lint cost. It
   narrows WHERE to look and decides nothing: visibility, namespace, privacy and overlay shadowing
   all still apply after it. See `PERF.md`.
+
+## Database/NamespaceIndex.cs
+
+- `sealed class NamespaceIndex` — the namespace→declaring-files index, the third of the
+  inverted indexes and built for the same reason as the other two: a question that used to be
+  answered by walking the whole store is answered by a lookup. `FilesDeclaringInto` narrows the
+  candidate set for a namespace before anything reads a record.
+- Holds a plain `HashSet<string>` per namespace rather than the string-or-HashSet packing
+  `DeclarationIndex` and `ReferenceIndex` use, because a namespace is declared into by many files
+  by nature, where a function name usually is not — the packing saves nothing here.
 
 ## Database/FunctionLookupCache.cs
 
@@ -252,9 +270,10 @@ lints, `Completion/` and `Typing/` the information surfaces.
   a caller holding a profile must override: indexing under the wrong dialect does not fail, it
   parses declarations away and leaves the store EMPTY. A `ConcurrentDictionary<path, Lazy<InsertedFile?>>` lexes each GSH
   exactly once no matter how many scripts insert it; `InvalidateGsh` drops one on change.
-  `IndexFile` is the single-file path the watcher reuses. `UseCache` enables cold-restore:
+  `IndexFile` is the single-file path the watcher reuses. `UseCache` enables warm-restore:
   the two-pass `IndexAsync` restores files whose on-disk content hash matches the cached
-  record (skipping the parse), then re-parses restored files that #insert a header which
+  `CachedEntry`, deserializing the blob only once that check passes and skipping the parse, then
+  re-parses restored files that #insert a header which
   itself changed (phase two), and write-throughs every fresh analysis to the cache. Phase
   two closes the changed-header set over the insert graph first, since a restored `.gsh`
   that inserts a changed one contributes something new despite its own bytes matching.
@@ -281,12 +300,24 @@ lints, `Completion/` and `Typing/` the information surfaces.
   ScriptRecord to/from a gzipped JSON blob (no runtime reflection). Deserialize returns
   null on a corrupt blob so one bad row never fails the restore.
 
+## Cache/CachedEntry.cs
+
+- `sealed record CachedEntry(ulong ContentHash, byte[] Blob)` + `Materialize()` — one cached
+  record still in its stored form. The deserialize is deliberately NOT done when the cache is read:
+  `LoadAll` runs before the indexer knows which files are current, so materialising everything there
+  paid gzip inflation and a JSON parse for files about to be re-analysed anyway — on ONE thread, in
+  front of an index that runs on all of them. That made a warm start slower than having no cache at
+  all (bo3 1,509 ms of restore against a 390 ms cold index). Handing the indexer the blob moves both
+  halves into its parallel per-file loop, behind the content-hash check. The hash is stored beside
+  the blob rather than inside it for exactly that reason. See `PERF.md`.
+
 ## Cache/SqliteCache.cs
 
 - `sealed class SqliteCache : IAsyncDisposable` — the per-workspace cache.
   `ResolveDatabasePath` (→ %APPDATA%/gscode/cache/&lt;hash&gt;.db), `CleanUpLegacyCache`
   (deletes the old single-file gzip-JSON cache), `Open` (WAL + busy_timeout, creates
-  tables, wipes on version/identity mismatch), `LoadAll` (cold-restore input),
+  tables, wipes on version/identity mismatch), `LoadAll` (warm-restore input, as `CachedEntry`
+  rows rather than records — see below),
   `Enqueue`/`EnqueueDelete` (never block — a single background writer drains a bounded
   channel, coalescing batches into transactions; dirty records are skipped), and
   `DisposeAsync` (drains the writer + checkpoints so a clean exit loses nothing).
@@ -433,6 +464,20 @@ lints, `Completion/` and `Typing/` the information surfaces.
   THROUGH the object and are how every script in every corpus uses one. `classes` is excluded even
   where the profile lists it: nothing establishes what the compiler does with an assignment to it,
   and an Error has to be certain. Swept clean over 8,289 scripts across all five games.
+
+## Analysis/NodeLintPass.cs
+
+- `internal static NodeLintPass.Run(result, builtins, types, diagnostics)` — ONE walk of the tree
+  shared by the nine rules whose judgement is about a single node. Each of those descended the whole
+  file on its own, visiting the same million corpus nodes nine times to ask nine independent
+  questions; a bare walk that does nothing else is about 85 ms of a 2.1 s bo3 lint pass, so the
+  traversal was nearly all of what those rules cost.
+- A rule qualifies only when its own walk was PURE PASS-THROUGH. The six left out are named in the
+  type's doc comment with the reason each one cannot join — a threaded flag, per-function state, or
+  a cache carried down the descent. Read that list before adding a tenth.
+- Each rule exposes `InspectNode`, its whole judgement about one node with no descent, so there is
+  one copy of each judgement. Diagnostics land in one builder and `WorkspaceLints` sorts by position
+  before returning, so merging the walks cannot change what is published.
 
 ## Analysis/ — the remaining lints
 

--- a/server/src/GSCode.Workspace/FOLDER.md
+++ b/server/src/GSCode.Workspace/FOLDER.md
@@ -112,7 +112,9 @@ lints, `Completion/` and `Typing/` the information surfaces.
 
 - `static GscKeywords` — the statement-scope and top-level keyword/directive lists offered in
   completion (assert/assertmsg excluded — they come from the builtin API instead). Documented
-  entries get their KeywordDocs blurb as the completion's documentation.
+  entries get their KeywordDocs blurb as the completion's documentation. A body is offered
+  `StatementKeywords`; file scope is offered BOTH lists, since a top-level macro invocation opens
+  an expression there — see the engine below.
 - `BodyDirectives` is the third list: the directives the preprocessor dispatches from its flat
   token walk (`#if`/`#elif`/`#else`/`#endif`, `#define`, `#insert`), which are therefore legal
   inside a function body as well as at file scope. Everything else in the family is consumed by
@@ -126,9 +128,29 @@ lints, `Completion/` and `Typing/` the information surfaces.
   reference index (gated by `includeLiterals` = the completion.literals setting; disabled →
   nothing, since statement scope makes no sense in a string); otherwise `#precache(` asset types,
   `#using`/`#insert` path segments, `ns::` (that namespace's functions only), `owner.` fields
-  (+ `.size`), and statement/top-level scope (keywords, the dialect's global objects and snippets,
+  (+ `.size`), and statement scope (keywords, the dialect's global objects and snippets,
   the enclosing function's parameters and locals, every macro in scope, namespace functions,
   visible classes, namespace-less builtins as call snippets).
+- **File scope gets that same list.** It used to be keywords and snippets alone — a
+  `!insideFunction` return sat above every store query — so `REGISTER_SYSTEM`, written at column 0
+  in 477 of the shipped BO3 scripts, was never offered, nor was any macro, function or class. None
+  of those is a per-cursor fact; the macro table is per FILE and a function is in scope for the
+  file, so the return was hiding categories for no reason but the order they were added in. File
+  scope is also not declarations-only, which is why narrowing the list was not the fix instead: a
+  top-level macro invocation is a CALL, so it opens an expression there, and BO3 writes 510 function
+  pointers and 467 `undefined`s inside those argument lists. Hence both keyword lists at file scope.
+  What stays behind is what is not BOUND there: parameters and locals (nothing is bound outside a
+  declaration) and the engine globals (`self` at file scope is unwritable, and a global sorts in the
+  first tier, so it would head every list).
+- Two punctuation rules are decided once above the dispatch, since each is a fact about the POSITION
+  rather than about the list an arm produces. **File scope takes no terminator** —
+  `IsStatementPosition` finds the previous function's `}` and answers true, which is right in a body
+  and meaningless where there are no statements; all 447 `REGISTER_SYSTEM` uses carry no semicolon.
+  **A function pointer takes no parentheses at all** — `&foo` names the function where `&foo()`
+  calls it, and BO3 writes 4,564 pointers against four `&name(` of any kind. The pointer rule covers
+  `&ns::foo` too (585 of them), and is gated on `GameProfile.FunctionPointerStyle`, since pre-BO3 a
+  pointer is a bare qualified name and an `&` is arithmetic. Only the suffix changes: what may be
+  pointed at is what may be called, so the producers already answer that position.
 - `CollectLocalScope(function, position, entries)` — the names bound INSIDE the function being
   edited, and the only per-function list here. Parameters, then the locals introduced by an
   assignment AT OR ABOVE the cursor; an owner (`self.count = 1`) makes it a field rather than a
@@ -140,7 +162,10 @@ lints, `Completion/` and `Typing/` the information surfaces.
   file plus the headers it `#insert`s, so it already is "what this file can expand"; filtering it
   to `SourceFile is null` kept the root file's own and dropped every constant a shared `.gsh`
   exists to supply. A function-like macro takes the call punctuation a function does, since at the
-  use site it is a call; the detail names the defining header.
+  use site it is a call; the detail names the defining header. Gated on `GameProfile.HasMacros`,
+  like every other category here is gated on the dialect: the preprocessor records a `#define`
+  whatever game is active, but only BO3 has a preprocessor, and in the IW line the one `#define`
+  per corpus is a commented-out block of C in `_hud.gsc`.
 - A `#` INSIDE a body has two readings and gets both: `GscKeywords.BodyDirectives`, plus the
   `#"..."` literals where `GameProfile.HasHashStrings`. Reading it as a hash string alone lost the
   `#if` family everywhere and left the three dialects without hash strings an empty list.
@@ -153,7 +178,7 @@ lints, `Completion/` and `Typing/` the information surfaces.
   .Statements / .Expressions)`, and the same reason.
   - `.Context.cs` — WHERE the cursor is. All static, and reads only tokens, source text and the
     parse tree: `IsStatementPosition`, `FindLiteralAtOffset`, `EnclosingFunction`,
-    `PreviousSignificant`, `TryPrecacheContext` and the rest. `EnclosingFunction` is carried by the
+    `PreviousSignificant`, `TryPrecacheContext`, `IsAddressOfPosition` and the rest. `EnclosingFunction` is carried by the
     dispatcher as a symbol rather than reduced to a bool, since the same walk answers which keyword
     set is legal, whether `vararg` binds, and which parameters and locals are in scope. Nothing here
     touches the database, which is the property that makes the boundary hold.

--- a/server/src/GSCode.Workspace/GSCode.Workspace.csproj
+++ b/server/src/GSCode.Workspace/GSCode.Workspace.csproj
@@ -24,6 +24,13 @@
   </ItemGroup>
 
   <ItemGroup>
+    <!-- The lint tests drive the per-node rules through NodeLintPass's own entry points, which is
+         the walk the server actually runs. Each rule used to keep a public Analyze that walked the
+         tree itself, and nothing outside the tests called it. -->
+    <InternalsVisibleTo Include="GSCode.Workspace.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Every bundled game data file, by pattern rather than by name. Listing them individually
          meant a new game's data silently failed to reach the output while everything still built
          and most tests still passed, because the loaders treat a missing file as "this game ships

--- a/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
+++ b/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
@@ -127,7 +127,24 @@ public sealed class WorkspaceIndexer
     // Optional persistent cache and its warm-restore snapshot (set via UseCache). The snapshot
     // holds blobs rather than records: see CachedEntry for why the deserialize belongs down here.
     private SqliteCache? _cache;
-    private IReadOnlyDictionary<string, CachedEntry> _restored = new Dictionary<string, CachedEntry>();
+
+    /// <summary>
+    /// The blobs a warm start may restore from, held only for the duration of an indexing pass.
+    ///
+    /// It used to be set once and kept for the session, and this class is a singleton in the
+    /// server — so a bo3 workspace carried 21 MB of gzipped blobs, and a bo1 one 64 MB, for the
+    /// whole run after the last file that could use them was indexed. Against a 400 MB
+    /// steady-state budget that is worth reclaiming.
+    ///
+    /// <see cref="IndexAsync"/> releases it on the way out and <see cref="ReloadRestoreSnapshot"/>
+    /// puts it back for the one caller that indexes twice. Paying a second 13-54 ms read on a
+    /// workspace-folder change is the cheaper side of that trade: the snapshot is live for
+    /// milliseconds and dead for hours.
+    /// </summary>
+    private IReadOnlyDictionary<string, CachedEntry> _restored = EmptyRestore;
+
+    private static readonly IReadOnlyDictionary<string, CachedEntry> EmptyRestore =
+        new Dictionary<string, CachedEntry>(StringComparer.Ordinal);
 
     /// <summary>Reads the current resolver each call, so resolver swaps take effect immediately.</summary>
     private readonly IHeaderMacroCache? _headerCache;
@@ -156,11 +173,39 @@ public sealed class WorkspaceIndexer
         _profile = profile;
     }
 
-    /// <summary>Enables persistent caching: unchanged files restore from <paramref name="restored"/>, fresh analyses are written to <paramref name="cache"/>.</summary>
+    /// <summary>
+    /// Enables persistent caching: unchanged files restore from <paramref name="restored"/>, fresh
+    /// analyses are written to <paramref name="cache"/>.
+    ///
+    /// The snapshot is consumed by the NEXT indexing pass and released when it finishes. A caller
+    /// that indexes again wants <see cref="ReloadRestoreSnapshot"/> first; the cache itself stays
+    /// attached either way, so writes continue regardless.
+    /// </summary>
     public void UseCache(SqliteCache cache, IReadOnlyDictionary<string, CachedEntry> restored)
     {
         _cache = cache;
         _restored = restored;
+    }
+
+    /// <summary>
+    /// Re-reads the restore snapshot from the attached cache, for a second indexing pass in the
+    /// same session.
+    ///
+    /// A failed read leaves the snapshot empty rather than throwing: the cache may have been closed
+    /// and deleted by <c>gscode/clearCache</c> since it was attached, and the right answer to that
+    /// is the cold index the user asked for. It is not silent — the pass that follows reports zero
+    /// files restored, which is the same thing the log would say.
+    /// </summary>
+    public void ReloadRestoreSnapshot()
+    {
+        try
+        {
+            _restored = _cache?.LoadAll() ?? EmptyRestore;
+        }
+        catch ( Exception exception ) when ( exception is not OutOfMemoryException )
+        {
+            _restored = EmptyRestore;
+        }
     }
 
     private PathResolver Resolver
@@ -170,6 +215,22 @@ public sealed class WorkspaceIndexer
 
     /// <summary>Indexes everything the resolver can reach. Returns the number of files indexed.</summary>
     public async Task<IndexOutcome> IndexAsync(IndexingMode mode, IIndexProgressListener progress, CancellationToken cancellationToken)
+    {
+        try
+        {
+            return await IndexCoreAsync(mode, progress, cancellationToken).ConfigureAwait(false);
+        }
+        finally
+        {
+            // In a finally rather than after the return, so a cancelled pass releases it too. The
+            // folder-change caller passes a real token, and a cancellation there would otherwise
+            // pin the whole snapshot for the rest of the session — which is the case this exists
+            // to remove.
+            _restored = EmptyRestore;
+        }
+    }
+
+    private async Task<IndexOutcome> IndexCoreAsync(IndexingMode mode, IIndexProgressListener progress, CancellationToken cancellationToken)
     {
         if ( mode == IndexingMode.Off )
         {

--- a/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
+++ b/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
@@ -30,7 +30,32 @@ public enum IndexingMode
 /// <param name="Restored">Files served from the cache without re-analysis.</param>
 /// <param name="Analysed">Files taken through the full lex/preprocess/parse/extract pipeline.</param>
 /// <param name="SkippedOversized">Files past the size limit, left unanalysed.</param>
-public readonly record struct IndexOutcome(int Total, int Restored, int Analysed, int SkippedOversized = 0);
+/// <param name="Enumerate">
+/// How long it took to find the files. SERIAL, and it blocks every worker — a workspace folder
+/// that contains the whole game install is 295,640 files to find 1,105 scripts, and that showed up
+/// as slow "indexing" with no way to tell it from the analysis.
+/// </param>
+/// <param name="Analyse">Wall-clock for the parallel pass: reading, analysing and committing.</param>
+/// <param name="ThreadTime">
+/// The per-file elapsed times summed. Against <paramref name="Analyse"/> it gives the parallel
+/// speedup actually achieved, which is the number that separates "each file is slow" from "the
+/// threads are not running".
+/// </param>
+public readonly record struct IndexOutcome(
+    int Total,
+    int Restored,
+    int Analysed,
+    int SkippedOversized = 0,
+    TimeSpan Enumerate = default,
+    TimeSpan Analyse = default,
+    TimeSpan ThreadTime = default)
+{
+    /// <summary>Thread-time over analysis wall-clock: 1x means the parallelism bought nothing.</summary>
+    public double Parallelism
+    {
+        get { return Analyse.TotalMilliseconds <= 0 ? 0 : ThreadTime.TotalMilliseconds / Analyse.TotalMilliseconds; }
+    }
+}
 
 /// <summary>Receives indexing lifecycle events (the server maps these to notifications).</summary>
 public interface IIndexProgressListener
@@ -159,6 +184,7 @@ public sealed class WorkspaceIndexer
         PerfTracker.Begin("index.enumerate");
         List<string> targets = [.. Resolver.EnumerateIndexTargets()];
         PerfTracker.End();
+        TimeSpan enumerate = stopwatch.Elapsed;
 
         progress.Started(targets.Count);
 
@@ -176,13 +202,20 @@ public sealed class WorkspaceIndexer
         ConcurrentBag<ScriptRecord> restoredRecords = [];
         int reparsedAfterHeaderChange = 0;
 
+        // Summed across the workers, so it is thread-time rather than wall-clock. The listener is
+        // handed the same figure per file, but only for logging — this is the total the outcome
+        // reports, so a caller gets the parallelism without having to add up a thousand log lines.
+        long threadTicks = 0;
+
         await Parallel.ForEachAsync(targets, options, (path, token) =>
         {
             token.ThrowIfCancellationRequested();
 
             long startedTicks = System.Diagnostics.Stopwatch.GetTimestamp();
             FileOutcome outcome = ProcessFile(path, allowRestore: true);
-            progress.FileIndexed(path, System.Diagnostics.Stopwatch.GetElapsedTime(startedTicks), outcome.Restored);
+            TimeSpan fileElapsed = System.Diagnostics.Stopwatch.GetElapsedTime(startedTicks);
+            Interlocked.Add(ref threadTicks, fileElapsed.Ticks);
+            progress.FileIndexed(path, fileElapsed, outcome.Restored);
 
             if ( outcome.Restored && outcome.Record is not null )
             {
@@ -262,7 +295,14 @@ public sealed class WorkspaceIndexer
         // the workspace looks nonexistent.
         _database.MarkIndexComplete();
 
-        return new IndexOutcome(completed, restored, completed - restored, _skippedOversized);
+        return new IndexOutcome(
+            completed,
+            restored,
+            completed - restored,
+            _skippedOversized,
+            Enumerate: enumerate,
+            Analyse: stopwatch.Elapsed - enumerate,
+            ThreadTime: TimeSpan.FromTicks(Interlocked.Read(ref threadTicks)));
     }
 
     /// <summary>Outcome of processing one file: whether it came from cache, and the resulting record.</summary>

--- a/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
+++ b/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
@@ -124,9 +124,10 @@ public sealed class WorkspaceIndexer
     // path → lazily lexed insert target, shared by every file that inserts it.
     private readonly ConcurrentDictionary<string, Lazy<InsertedFile?>> _gshCache = new(StringComparer.Ordinal);
 
-    // Optional persistent cache and its cold-restore snapshot (set via UseCache).
+    // Optional persistent cache and its warm-restore snapshot (set via UseCache). The snapshot
+    // holds blobs rather than records: see CachedEntry for why the deserialize belongs down here.
     private SqliteCache? _cache;
-    private IReadOnlyDictionary<string, ScriptRecord> _restored = new Dictionary<string, ScriptRecord>();
+    private IReadOnlyDictionary<string, CachedEntry> _restored = new Dictionary<string, CachedEntry>();
 
     /// <summary>Reads the current resolver each call, so resolver swaps take effect immediately.</summary>
     private readonly IHeaderMacroCache? _headerCache;
@@ -156,7 +157,7 @@ public sealed class WorkspaceIndexer
     }
 
     /// <summary>Enables persistent caching: unchanged files restore from <paramref name="restored"/>, fresh analyses are written to <paramref name="cache"/>.</summary>
-    public void UseCache(SqliteCache cache, IReadOnlyDictionary<string, ScriptRecord> restored)
+    public void UseCache(SqliteCache cache, IReadOnlyDictionary<string, CachedEntry> restored)
     {
         _cache = cache;
         _restored = restored;
@@ -352,20 +353,33 @@ public sealed class WorkspaceIndexer
         }
 
         // Restore from cache when the on-disk content matches what was analysed before.
-        if ( allowRestore && _restored.TryGetValue(normalized, out ScriptRecord? cached) )
+        //
+        // The hash is checked BEFORE the record is materialised, which is the whole point of
+        // holding blobs rather than records: a file that has changed costs one hash here and never
+        // pays the gzip inflation or the JSON parse behind it. On a genuinely warm start that saves
+        // nothing, since every file matches — what it saves is doing all of that work serially at
+        // startup, ahead of this loop, instead of on the loop's own threads.
+        if ( allowRestore && _restored.TryGetValue(normalized, out CachedEntry? cached) )
         {
             PerfTracker.Begin("index.restore");
-            bool matches = cached.ContentHash == ScriptDatabase.ComputeContentHash(content);
-            if ( matches )
+
+            ScriptRecord? restored = null;
+            if ( cached.ContentHash == ScriptDatabase.ComputeContentHash(content) )
             {
-                _database.CommitRecord(cached);
+                // Null when the blob is corrupt, which falls through to a normal analysis below
+                // rather than failing the file — the same outcome a missing cache entry has.
+                restored = cached.Materialize();
+                if ( restored is not null )
+                {
+                    _database.CommitRecord(restored);
+                }
             }
 
             PerfTracker.End();
 
-            if ( matches )
+            if ( restored is not null )
             {
-                return new FileOutcome(Restored: true, Record: cached);
+                return new FileOutcome(Restored: true, Record: restored);
             }
         }
 

--- a/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
+++ b/server/src/GSCode.Workspace/Indexing/WorkspaceIndexer.cs
@@ -6,7 +6,6 @@ using GSCode.Core.Paths;
 using GSCode.Core.Symbols;
 using GSCode.Core.Text;
 using GSCode.Parser;
-using GSCode.Parser.Lexing;
 using GSCode.Parser.Preprocessing;
 using GSCode.Workspace.Cache;
 using GSCode.Workspace.Database;
@@ -104,7 +103,8 @@ public sealed class NullIndexProgressListener : IIndexProgressListener
 /// <summary>
 /// Cold-start indexing: enumerate every reachable script, run the per-file pipeline
 /// under bounded parallelism (across files, never within one), and commit records.
-/// GSH files inserted by many scripts are lexed exactly once via a Lazy cache.
+/// GSH files inserted by many scripts are lexed exactly once, via the shared
+/// <see cref="InsertCache"/>.
 /// </summary>
 public sealed class WorkspaceIndexer
 {
@@ -121,8 +121,22 @@ public sealed class WorkspaceIndexer
 
     private int _skippedOversized;
 
-    // path → lazily lexed insert target, shared by every file that inserts it.
-    private readonly ConcurrentDictionary<string, Lazy<InsertedFile?>> _gshCache = new(StringComparer.Ordinal);
+    /// <summary>
+    /// Lexed <c>#insert</c> targets, shared by every file that inserts one.
+    ///
+    /// This used to be a second cache of its own — a <c>ConcurrentDictionary&lt;path,
+    /// Lazy&lt;InsertedFile?&gt;&gt;</c> beside the <see cref="InsertCache"/> the same constructor
+    /// was already handed for macros. Two caches of the same headers, keyed the same way and living
+    /// the same session, so BO3's 114 distinct headers were held twice over; and the local one was
+    /// the weaker of the two, keyed ordinally where paths are not case-sensitive, never revalidated
+    /// against the file, and caching a failed read for good.
+    ///
+    /// Never null: a caller that supplies none gets one of its own rather than no cache at all,
+    /// which is what the argument being optional used to mean. Without it a header is re-read and
+    /// re-lexed once per file that inserts it — BO3 writes 2,137 insert directives naming those
+    /// 114 headers.
+    /// </summary>
+    private readonly InsertCache _inserts;
 
     // Optional persistent cache and its warm-restore snapshot (set via UseCache). The snapshot
     // holds blobs rather than records: see CachedEntry for why the deserialize belongs down here.
@@ -146,9 +160,6 @@ public sealed class WorkspaceIndexer
     private static readonly IReadOnlyDictionary<string, CachedEntry> EmptyRestore =
         new Dictionary<string, CachedEntry>(StringComparer.Ordinal);
 
-    /// <summary>Reads the current resolver each call, so resolver swaps take effect immediately.</summary>
-    private readonly IHeaderMacroCache? _headerCache;
-
     /// <summary>
     /// The dialect every indexed file is parsed as. Null defers to <see cref="GameProfile.Active"/>
     /// at analysis time, which is what the server wants — it selects the game once, at startup.
@@ -163,13 +174,13 @@ public sealed class WorkspaceIndexer
 
     public WorkspaceIndexer(
         ScriptDatabase database, Func<PathResolver> resolverProvider, IFileSystem fileSystem, NameTable names,
-        IHeaderMacroCache? headerCache = null, GameProfile? profile = null)
+        InsertCache? inserts = null, GameProfile? profile = null)
     {
         _database = database;
         _resolverProvider = resolverProvider;
         _fileSystem = fileSystem;
         _names = names;
-        _headerCache = headerCache;
+        _inserts = inserts ?? new InsertCache();
         _profile = profile;
     }
 
@@ -380,6 +391,15 @@ public sealed class WorkspaceIndexer
     {
         string normalized = PathUtil.NormalizeAbsolute(path);
 
+        ScriptLanguage language = ScriptAnalysis.LanguageFromPath(normalized);
+
+        // Read BEFORE the content, and only for the file the seed below can apply to. A stamp taken
+        // afterwards would date a write that landed between the two as already seen, and the seeded
+        // entry would then stay stale until the file changed a second time.
+        DateTime headerStamp = language == ScriptLanguage.Gsh
+            ? _fileSystem.GetLastWriteTimeUtc(normalized)
+            : default;
+
         // The scopes below split the per-file cost the way the cold path actually spends it: read is
         // blocking I/O inside the parallel body, analyse is the four-phase pipeline, commit is where
         // the store's single write gate is waited on, and enqueue hands off to the cache writer.
@@ -449,27 +469,21 @@ public sealed class WorkspaceIndexer
         PerfTracker.Begin("index.analyse");
         ParseResult result = ScriptAnalysis.Analyze(
             normalized,
-            ScriptAnalysis.LanguageFromPath(normalized),
+            language,
             SourceText.From(content),
-            new CachingInsertProvider(this, context),
+            new ResolverInsertProvider(Resolver, context, _fileSystem, _inserts),
             _names,
             profile: _profile,
-            headerCache: _headerCache);
+            headerCache: _inserts);
         PerfTracker.End();
 
         // A header is an index target in its own right (it matches *.gsh) AND an insert source, and
-        // those two paths each read and lexed it independently — the analysis above has already
-        // produced exactly what LoadInsert would go on to build from scratch. Seed it here instead.
-        //
-        // GetOrAdd rather than an assignment because the race is real and unordered: a .gsc that
-        // inserts this header may be processed first and populate the entry itself. Whoever arrives
-        // first wins, and the two would produce identical content anyway — same file, same lexer,
-        // same profile. So this halves the header work rather than eliminating it.
+        // the analysis above has already produced exactly what the insert path would go on to build
+        // from scratch. See InsertCache.SeedIfAbsent for why it is offered rather than assigned.
         if ( result.Language == ScriptLanguage.Gsh )
         {
-            _gshCache.GetOrAdd(
-                normalized,
-                new Lazy<InsertedFile?>(new InsertedFile(normalized, result.Text, result.Lexed.Tokens)));
+            _inserts.SeedIfAbsent(
+                normalized, new InsertedFile(normalized, result.Text, result.Lexed.Tokens), headerStamp);
         }
 
         string relativePath = Resolver.GetScriptRelativePath(normalized, context);
@@ -485,75 +499,27 @@ public sealed class WorkspaceIndexer
         return new FileOutcome(Restored: false, Record: record);
     }
 
-    /// <summary>Drops a GSH from the lex cache (called when the file changes on disk).</summary>
+    /// <summary>
+    /// Drops a GSH from the insert cache (called when the file changes on disk).
+    ///
+    /// The timestamp check inside the cache is the backstop and would catch this on its own; this
+    /// is the fast path for a caller that already knows. It now also drops the header's walked
+    /// CONTRIBUTION, which the local cache it replaced could not reach — that was left to the same
+    /// timestamp check, one call later.
+    /// </summary>
     public void InvalidateGsh(string normalizedPath)
     {
-        _gshCache.TryRemove(normalizedPath, out _);
+        _inserts.Invalidate(normalizedPath);
     }
 
-    /// <summary>Removes a deleted file from the database, persistent cache, and GSH lex cache.</summary>
+    /// <summary>Removes a deleted file from the database, persistent cache, and insert cache.</summary>
     public void RemoveFile(string normalizedPath, ScriptLanguage language)
     {
         _database.Remove(normalizedPath, language);
         _cache?.EnqueueDelete(normalizedPath);
         if ( language == ScriptLanguage.Gsh )
         {
-            _gshCache.TryRemove(normalizedPath, out _);
-        }
-    }
-
-    private InsertedFile? LoadInsert(string rawInsertPath, ResolutionContext context)
-    {
-        string? resolved = Resolver.Resolve(context, rawInsertPath);
-        if ( resolved is null )
-        {
-            return null;
-        }
-
-        Lazy<InsertedFile?> lazy = _gshCache.GetOrAdd(resolved, key => new Lazy<InsertedFile?>(() =>
-        {
-            try
-            {
-                SourceText text = SourceText.From(_fileSystem.ReadAllText(key));
-                return new InsertedFile(key, text, Lexer.Lex(text).Tokens);
-            }
-            catch ( IOException )
-            {
-                return null;
-            }
-            catch ( UnauthorizedAccessException )
-            {
-                return null;
-            }
-        }));
-
-        return lazy.Value;
-    }
-
-    /// <summary>Insert provider backed by the shared Lazy GSH cache.</summary>
-    private sealed class CachingInsertProvider : IInsertProvider
-    {
-        private readonly WorkspaceIndexer _indexer;
-        private readonly ResolutionContext _context;
-
-        public CachingInsertProvider(WorkspaceIndexer indexer, ResolutionContext context)
-        {
-            _indexer = indexer;
-            _context = context;
-        }
-
-        public bool TryGetInsert(string rawInsertPath, out InsertedFile inserted)
-        {
-            InsertedFile? loaded = _indexer.LoadInsert(rawInsertPath, _context);
-            inserted = loaded!;
-            return loaded is not null;
-        }
-
-        public bool TryResolveInsertPath(string rawInsertPath, out string resolvedPath)
-        {
-            string? resolved = _indexer.Resolver.Resolve(_context, rawInsertPath);
-            resolvedPath = resolved ?? "";
-            return resolved is not null;
+            _inserts.Invalidate(normalizedPath);
         }
     }
 }

--- a/server/src/GSCode.Workspace/Resolution/IFileSystem.cs
+++ b/server/src/GSCode.Workspace/Resolution/IFileSystem.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using System.IO.Enumeration;
 using System.Text;
@@ -24,17 +24,14 @@ public interface IFileSystem
     /// </summary>
     DateTime GetLastWriteTimeUtc(string absolutePath);
 
-    /// <summary>Recursively enumerates files under <paramref name="directory"/> matching the pattern (e.g. "*.gsc").</summary>
-    IEnumerable<string> EnumerateFiles(string directory, string searchPattern);
-
     /// <summary>
     /// Recursively enumerates files under <paramref name="directory"/> whose extension is one of
     /// <paramref name="extensions"/> (each including the dot, compared case-insensitively).
     ///
-    /// Separate from <see cref="EnumerateFiles"/> because the indexer wants several extensions at
-    /// once and neither obvious spelling is good enough: one call per pattern walks the whole tree
-    /// once per extension, while a single "*" walk hands back every file on disk to be filtered in
-    /// managed code. Black Ops 1's raw folder holds 160,382 files of which 2,960 are scripts, so
+    /// The one enumeration this seam offers, because neither obvious single-pattern spelling is
+    /// good enough for what the indexer wants: one call per pattern walks the whole tree once per
+    /// extension, while a single "*" walk hands back every file on disk to be filtered in managed
+    /// code. Black Ops 1's raw folder holds 160,382 files of which 2,960 are scripts, so
     /// that second spelling would allocate 157,422 strings to throw them all away.
     /// </summary>
     IEnumerable<string> EnumerateFilesWithExtensions(string directory, ImmutableArray<string> extensions);
@@ -132,20 +129,6 @@ public sealed class PhysicalFileSystem : IFileSystem
         }
     }
 
-    public IEnumerable<string> EnumerateFiles(string directory, string searchPattern)
-    {
-        return Directory.EnumerateFiles(directory, searchPattern, SearchOption.AllDirectories);
-    }
-
-    /// <summary>
-    /// One walk of the tree, with the extension test applied to the entry's name in place.
-    ///
-    /// <see cref="FileSystemEnumerable{TResult}"/> rather than <see cref="Directory.EnumerateFiles(string, string)"/>
-    /// because its predicate sees a <see cref="FileSystemEntry"/> whose FileName is a span over the
-    /// buffer the OS already filled. A file that is not a script is rejected without a string ever
-    /// existing for it, so the 157,422 non-scripts in a Black Ops 1 install cost a comparison each
-    /// and nothing else.
-    /// </summary>
     /// <summary>
     /// Every script under a root, walked ONCE per subtree and in parallel across them.
     ///
@@ -210,6 +193,15 @@ public sealed class PhysicalFileSystem : IFileSystem
         return false;
     }
 
+    /// <summary>
+    /// One walk of the tree, with the extension test applied to the entry's name in place.
+    ///
+    /// <see cref="FileSystemEnumerable{TResult}"/> rather than <c>Directory.EnumerateFiles</c>
+    /// because its predicate sees a <see cref="FileSystemEntry"/> whose FileName is a span over the
+    /// buffer the OS already filled. A file that is not a script is rejected without a string ever
+    /// existing for it, so the 157,422 non-scripts in a Black Ops 1 install cost a comparison each
+    /// and nothing else.
+    /// </summary>
     private static IEnumerable<string> WalkOne(
         string directory, ImmutableArray<string> extensions, bool recurse = true)
     {

--- a/server/src/GSCode.Workspace/Resolution/IFileSystem.cs
+++ b/server/src/GSCode.Workspace/Resolution/IFileSystem.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using GSCode.Core;
 using System.IO.Enumeration;
 using System.Text;
 
@@ -145,11 +146,76 @@ public sealed class PhysicalFileSystem : IFileSystem
     /// existing for it, so the 157,422 non-scripts in a Black Ops 1 install cost a comparison each
     /// and nothing else.
     /// </summary>
+    /// <summary>
+    /// Every script under a root, walked ONCE per subtree and in parallel across them.
+    ///
+    /// The walk is serial work that blocks every indexing worker behind it, and its cost is set by
+    /// the size of the WORKSPACE rather than by the number of scripts: a workspace folder that is a
+    /// whole Black Ops III install is 295,640 files hiding 1,105 scripts. Measured on that install,
+    /// warm: 741-792 ms as it was, 483-504 ms fanned out across the top-level subtrees, 277-281 ms
+    /// pruned, and 231-233 ms with both. All four return the same 1,105 files.
+    ///
+    /// The fan-out is per TOP-LEVEL subdirectory, which is uneven by nature — one subtree can hold
+    /// most of the files — so it is worth less than the pruning and is kept because it costs
+    /// nothing and helps any tree that happens to be wide.
+    /// </summary>
     public IEnumerable<string> EnumerateFilesWithExtensions(string directory, ImmutableArray<string> extensions)
+    {
+        List<string> results = [];
+
+        string[] subdirectories;
+        try
+        {
+            subdirectories = Directory.GetDirectories(directory);
+        }
+        catch ( Exception exception ) when ( exception is IOException or UnauthorizedAccessException )
+        {
+            // Same contract as the enumerator below: a root that cannot be opened contributes
+            // nothing rather than throwing part-way through indexing.
+            return results;
+        }
+
+        Parallel.ForEach(
+            subdirectories.Where(subdirectory => !IsToolOutput(subdirectory)),
+            new ParallelOptions { MaxDegreeOfParallelism = Math.Max(1, Environment.ProcessorCount - 1) },
+            subdirectory =>
+            {
+                List<string> found = [.. WalkOne(subdirectory, extensions)];
+                lock ( results )
+                {
+                    results.AddRange(found);
+                }
+            });
+
+        // The root's own files, which the fan-out skips because it starts one level down.
+        foreach ( string file in WalkOne(directory, extensions, recurse: false) )
+        {
+            results.Add(file);
+        }
+
+        return results;
+    }
+
+    private static bool IsToolOutput(string directory)
+    {
+        string name = Path.GetFileName(directory);
+        foreach ( string toolOutput in GameProfile.ToolOutputDirectories )
+        {
+            if ( string.Equals(name, toolOutput, StringComparison.OrdinalIgnoreCase) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static IEnumerable<string> WalkOne(
+        string directory, ImmutableArray<string> extensions, bool recurse = true)
     {
         EnumerationOptions options = new()
         {
-            RecurseSubdirectories = true,
+            RecurseSubdirectories = recurse,
 
             // Matches Directory.EnumerateFiles, which skips what it cannot open rather than
             // throwing part-way through a walk.
@@ -178,6 +244,22 @@ public sealed class PhysicalFileSystem : IFileSystem
                 }
 
                 return false;
+            },
+
+            // Nothing under a tool-output tree is source, and on a game install those trees are
+            // most of the files. Checked here as well as at the fan-out because they nest: BO3
+            // keeps assetconvert under `share`, not at the root.
+            ShouldRecursePredicate = static (ref FileSystemEntry entry) =>
+            {
+                foreach ( string toolOutput in GameProfile.ToolOutputDirectories )
+                {
+                    if ( entry.FileName.Equals(toolOutput, StringComparison.OrdinalIgnoreCase) )
+                    {
+                        return false;
+                    }
+                }
+
+                return true;
             },
         };
     }

--- a/server/src/GSCode.Workspace/Resolution/InsertCache.cs
+++ b/server/src/GSCode.Workspace/Resolution/InsertCache.cs
@@ -65,6 +65,28 @@ public sealed class InsertCache : IHeaderMacroCache
     }
 
     /// <summary>
+    /// Offers a header the caller has already read and lexed, if nothing holds one yet.
+    ///
+    /// A <c>.gsh</c> is an index target in its own right AND an insert source, and those two paths
+    /// each read and lexed it independently. The indexer's analysis of the header produces exactly
+    /// what <see cref="GetOrAdd"/> would go on to build from scratch, so it is offered here instead.
+    ///
+    /// Offered rather than assigned, because the race is real and unordered: a <c>.gsc</c> that
+    /// inserts this header may be processed first and fill the entry itself. Whoever arrives first
+    /// wins, and the two would produce identical content anyway - same file, same lexer, same
+    /// profile. So this halves the header work rather than eliminating it, and it never discards a
+    /// contribution already walked against an entry that is equally current.
+    ///
+    /// <paramref name="lastWriteUtc"/> must be read BEFORE the content it describes. Taken after,
+    /// a write landing between the two would be stamped as already seen, and the entry would stay
+    /// stale until the file changed again.
+    /// </summary>
+    public void SeedIfAbsent(string resolvedPath, InsertedFile file, DateTime lastWriteUtc)
+    {
+        _entries.TryAdd(resolvedPath, new Entry(file, lastWriteUtc));
+    }
+
+    /// <summary>
     /// What a header CONTRIBUTES once walked - the macros it defines and the insert edges it
     /// carries - so the next file inserting it need not walk it again. Kept beside the lexed
     /// tokens because it is the same header, the same key and the same lifetime; a header whose

--- a/server/src/GSCode.Workspace/Typing/FlowTyper.cs
+++ b/server/src/GSCode.Workspace/Typing/FlowTyper.cs
@@ -1,4 +1,4 @@
-using System.Globalization;
+﻿using System.Globalization;
 using GSCode.Parser.Preprocessing;
 using System.Collections.Immutable;
 using GSCode.Core;
@@ -111,6 +111,20 @@ public sealed class FlowTyper
     /// for a whole file's map to answer it.
     /// </summary>
     private Dictionary<ExprNode, ScrValue>? _recorded;
+
+    /// <summary>
+    /// The last <see cref="InferValues"/> answer, and the parse it was computed from, so the three
+    /// lints that all want a file's types share one walk instead of taking one each.
+    ///
+    /// Keyed by REFERENCE, like <see cref="ScriptTypes"/>'s own keys and for the same reason: a
+    /// <c>ParseResult</c> is a record, so structural equality would compare two whole trees to
+    /// settle what reference identity settles exactly. A keystroke produces a new
+    /// <c>ParseResult</c>, so a stale answer can never be served, and every instance of this class
+    /// is a local in one request or one lint pass — the memo dies with the pass rather than
+    /// retaining a tree.
+    /// </summary>
+    private ParseResult? _typedParse;
+    private ScriptTypes? _typed;
 
     /// <summary>
     /// <paramref name="profile"/> defaults to the active one, matching how every <c>Analyze</c>
@@ -270,15 +284,29 @@ public sealed class FlowTyper
     /// The transpiler entry point. Unlike <see cref="InferAssignments(ParseResult)"/>, which reports
     /// the sites an editor wants to decorate, this keeps the value of EVERY expression walked —
     /// including the ones nothing is reported about, which is most of them.
+    ///
+    /// The answer is memoised per <c>ParseResult</c>, which is what makes it the entry point for the
+    /// FIELD-WRITE lints as well: a <see cref="ScriptTypes"/> already carries the assignments and
+    /// the writes, so three rules asking three different questions of one file pay for one walk
+    /// between them. Asking <see cref="InferAssignments(ParseResult, out ImmutableArray{FieldWrite})"/>
+    /// instead is still right for the hover and hint surfaces, which want one name or one position
+    /// and should not pay to record a whole file.
     /// </summary>
     public ScriptTypes InferValues(ParseResult result)
     {
+        if ( _typed is not null && ReferenceEquals(_typedParse, result) )
+        {
+            return _typed;
+        }
+
         _recorded = new Dictionary<ExprNode, ScrValue>(ReferenceEqualityComparer.Instance);
 
         try
         {
             ImmutableArray<InferredAssignment> assignments = InferAssignments(result, out ImmutableArray<FieldWrite> writes);
-            return new ScriptTypes(_recorded, assignments, writes);
+            _typed = new ScriptTypes(_recorded, assignments, writes);
+            _typedParse = result;
+            return _typed;
         }
         finally
         {

--- a/server/src/GSCode.Workspace/Typing/FlowTyper.cs
+++ b/server/src/GSCode.Workspace/Typing/FlowTyper.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using GSCode.Parser.Preprocessing;
 using System.Collections.Immutable;
 using GSCode.Core;

--- a/server/tests/FOLDER.md
+++ b/server/tests/FOLDER.md
@@ -266,4 +266,8 @@ request · `OnTypeBlockScopeTests` · `UntitledDocumentTests` documents with no 
 request · `RenameScopeTests` what may be renamed, drawn on ownership rather than kind.
 
 **Configuration and mapping.** `SettingsReachTheServerTests` that a setting actually arrives ·
+`SupportedGamesHandlerTests` the game picker's roster — exactly the supported profiles, the tick on
+what the server SELECTED rather than what was asked for, and the two cross-file checks that close
+the gap the original bug lived in: that the roster and the `gscode.game` enum are the same list,
+and that `gscode.selectGame` is both declared in the manifest and registered in `extension.ts` ·
 `EffectiveSummaryTests` · `DiagnosticMappingTests` our diagnostics to LSP.

--- a/server/tests/FOLDER.md
+++ b/server/tests/FOLDER.md
@@ -169,7 +169,14 @@ preprocessor that game does not have.
 supplies offered outside a body, the functions in scope and the expression atoms a macro
 invocation's arguments need, and the engine globals still withheld there. The punctuation pair
 (no terminator at file scope, no parentheses on a function pointer) lives with the other call
-punctuation cases in `CompletionEngineTests`.
+punctuation cases in `CompletionEngineTests`. `FakeInserts` — the `IInsertProvider` that serves a
+header's text — is shared between them, since both features have to be asked about a macro that
+lives in a `.gsh` rather than the file under test.
+
+`SignatureEngineTests` holds the MACRO cases beside the function and builtin ones: parameter names
+and the active argument, the reported case of an `#insert`ed macro invoked at file scope, and the
+three positions that must NOT answer with a macro — an object-like one, a name whose case does not
+match, and a qualified `namespace::NAME(`.
 
 **Database and resolution.** `ScriptDatabaseTests` · `PathResolverTests` raw/mod resolution order ·
 `DependencyRewriteTests` · `RawWriteGuardTests` refusing to write into a game install ·

--- a/server/tests/FOLDER.md
+++ b/server/tests/FOLDER.md
@@ -53,11 +53,13 @@ heaviest rules stand down without a finished index — timing them against a par
 cheap half as the total. CoD4 and BO3 only, since each game measured pays a full index.
 
 `Completion_WhereTheTimeGoes` times `CompletionEngine.Complete` at ten evenly spaced call sites per
-file — one report row per REQUEST, since the question is whether a keystroke is answered in time and
-a per-file sum answers nothing anybody waits for. It also prints how many ENTRIES came back, and
-that line is what makes the timings admissible: `Complete` has ~10 arms and only the statement-scope
-one queries the store, so a sample that quietly hit the cheap arms would report fast completions and
-have measured nothing. Adds BO1 to the usual CoD4/BO3 pair, because every query on this path reads
+file, plus one FILE-SCOPE position — one report row per REQUEST, since the question is whether a
+keystroke is answered in time and a per-file sum answers nothing anybody waits for. The call sites
+come from the extraction's call references and every one of those is inside a body, so until the
+file-scope sample was added this sweep could not see the other arm at all. It also prints how many
+ENTRIES came back, and that line is what makes the timings admissible: `Complete` has ~10 arms and
+only the statement-scope one queries the store, so a sample that quietly hit the cheap arms would
+report fast completions and have measured nothing. Adds BO1 to the usual CoD4/BO3 pair, because every query on this path reads
 the record store and BO1 is the only corpus large enough to show whether store size drives the cost.
 It does not — see PERF.md, which also records why the quadratic found here was left alone.
 
@@ -159,8 +161,15 @@ to CSC — covering both how BO3 marks them (a `client` prefix) and how WaW/BO1 
 `ClassMethodCompletionTests` inherited and overriding methods · `ArrowSignatureTests` signatures
 for unknown-receiver method calls · `DialectCompletionTests` that a dialect is offered only its
 own keywords, global objects, snippets and DIRECTIVES — including the reported case end to end, a
-`#` at file scope under CoD4 returning exactly `#include` and `#using_animtree`, and that
-`#animtree` is a body position in every game.
+`#` at file scope under CoD4 returning exactly `#include` and `#using_animtree`, that `#animtree` is
+a body position in every game, and that a CoD4 file-scope list carries no macro rows for a
+preprocessor that game does not have.
+
+`LocalScopeCompletionTests` also holds the FILE-SCOPE cases: the macros an `#insert`ed header
+supplies offered outside a body, the functions in scope and the expression atoms a macro
+invocation's arguments need, and the engine globals still withheld there. The punctuation pair
+(no terminator at file scope, no parentheses on a function pointer) lives with the other call
+punctuation cases in `CompletionEngineTests`.
 
 **Database and resolution.** `ScriptDatabaseTests` · `PathResolverTests` raw/mod resolution order ·
 `DependencyRewriteTests` · `RawWriteGuardTests` refusing to write into a game install ·

--- a/server/tests/FOLDER.md
+++ b/server/tests/FOLDER.md
@@ -230,6 +230,25 @@ line means "suppressed on this game" rather than "run twice".
   than gating on a count. It went 2,742 reports on CoD4 alone down to 17 across all 7,309 scripts
   as each dialect fact was learned, so a jump means a gap in the rule's exclusions.
 
+**Samples.** `SampleScriptTests` — the hand-written worked example per game per language world in
+`server/samples`, run through the whole diagnostic pipeline and checked against the `// expect`
+comments in the scripts themselves. Two halves: that every declared diagnostic is produced, and that
+NOTHING else is — the showcase files declare none, so a finding there is a false positive caught on
+code written to be correct. `EveryLanguageWorldTheGameHasIsSampled` reads `ScriptExtensions` off the
+profile, so a game that gains `.csc` fails until its showcase exists. Joins `GameProfileCollection`
+like the corpus classes; needs no game install, since each sample folder IS a raw root.
+`SampleExpectations` parses the comments, `SampleWorkspace` indexes and analyses one game.
+See `server/samples/FOLDER.md`.
+
+This suite is why `GSCode.Server.Tests` no longer runs its collections in parallel, and why
+`SampleWorkspace` puts `GameProfile.Active` back when it is done. It is the first class OUTSIDE
+`Corpus/` to move the active dialect, and three hundred classes here read that global without
+saying so: leaving it on CoD4 failed 132 of them in the formatter and the handlers, for reasons that
+looked like the thing under test. Serializing alone still left 121, since a class running after a
+sample run reads the leftover as happily as one running beside it — both halves are needed while a
+global decides what the parser and the lints do. The serialization costs about a second on 313
+tests, and nothing within a test: the corpus sweeps still parallelise their own file walk.
+
 **Formatting.** `GscFormatterTests` the formatter at large · `FormatMinimalEditsTests` minimal edits ·
 `StaleFormatEditTests` edits against a changed buffer · `UnbracedBodyFormattingTests`,
 `UnbracedBodyShapeTests` braceless bodies · `ElseIfChainTests` · `OperatorSpacingTests`,

--- a/server/tests/GSCode.Parser.Tests/Syntax/ChildEnumerationTests.cs
+++ b/server/tests/GSCode.Parser.Tests/Syntax/ChildEnumerationTests.cs
@@ -1,0 +1,213 @@
+using GSCode.Parser.Syntax;
+using GSCode.Parser.Syntax.Ast;
+using Xunit;
+
+namespace GSCode.Parser.Tests.Syntax;
+
+/// <summary>
+/// What <see cref="AstSearch.ChildrenOf"/> yields, and in what order, for each shape in the tree.
+///
+/// Every AST walk in the server goes through it — fifteen lints, the reference index, the inlay
+/// hints, the parameter typer — so a child that is skipped or reordered is a wrong answer in all of
+/// them at once, and silently: a rule that never sees a node simply reports nothing about it. These
+/// pin the order per shape, and the last one pins that the walk allocates nothing, which is the
+/// reason the enumerable is a struct.
+/// </summary>
+public class ChildEnumerationTests
+{
+    /// <summary>The child type names of one node, in order.</summary>
+    private static string ChildrenOf(AstNode node)
+    {
+        List<string> names = [];
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            names.Add(child.GetType().Name);
+        }
+
+        return string.Join(" ", names);
+    }
+
+    private static AstNode FirstElement(string source)
+    {
+        return Assert.Single(ParserTestHelper.Parse(source).Root.Elements);
+    }
+
+    /// <summary>The first statement of "function test() { ... }".</summary>
+    private static AstNode FirstStatement(string statements)
+    {
+        FunctionNode function = Assert.IsType<FunctionNode>(FirstElement("function test()\n{\n" + statements + "\n}"));
+        BlockNode body = Assert.IsType<BlockNode>(function.Body);
+        return body.Statements[0];
+    }
+
+    [Fact]
+    public void AFunctionYieldsItsParametersThenItsBody()
+    {
+        AstNode function = FirstElement("function test( a, b = 1 )\n{\n}");
+
+        Assert.Equal("ParameterNode ParameterNode BlockNode", ChildrenOf(function));
+    }
+
+    [Fact]
+    public void AParameterYieldsItsDefaultOnlyWhenItHasOne()
+    {
+        FunctionNode function = Assert.IsType<FunctionNode>(FirstElement("function test( a, b = 1 )\n{\n}"));
+
+        Assert.Equal("", ChildrenOf(function.Parameters[0]));
+        Assert.Equal("LiteralNode", ChildrenOf(function.Parameters[1]));
+    }
+
+    [Fact]
+    public void AnIfYieldsConditionThenBranchAndTheElseOnlyWhenPresent()
+    {
+        Assert.Equal("IdentifierNode BlockNode", ChildrenOf(FirstStatement("if ( a )\n{\n}")));
+        Assert.Equal("IdentifierNode BlockNode BlockNode", ChildrenOf(FirstStatement("if ( a )\n{\n}\nelse\n{\n}")));
+    }
+
+    [Fact]
+    public void AForYieldsOnlyTheClausesItHas()
+    {
+        Assert.Equal(
+            "ExprStatementNode BinaryNode ExprStatementNode BlockNode",
+            ChildrenOf(FirstStatement("for ( i = 0; i < 4; i++ )\n{\n}")));
+
+        // A bare `for ( ;; )` keeps its body and nothing else, so the body must not be mistaken for
+        // an initializer by a walk that counts positions rather than reading them.
+        Assert.Equal("BlockNode", ChildrenOf(FirstStatement("for ( ;; )\n{\n}")));
+    }
+
+    [Fact]
+    public void ADoWhileYieldsItsBodyBeforeItsCondition()
+    {
+        Assert.Equal("BlockNode IdentifierNode", ChildrenOf(FirstStatement("do\n{\n}\nwhile ( a );")));
+    }
+
+    [Fact]
+    public void ASwitchYieldsItsSubjectThenItsCaseGroups()
+    {
+        Assert.Equal(
+            "IdentifierNode CaseGroupNode CaseGroupNode",
+            ChildrenOf(FirstStatement("switch ( a )\n{\ncase 1:\n    break;\ndefault:\n    break;\n}")));
+    }
+
+    [Fact]
+    public void ACaseGroupYieldsItsLabelValuesThenItsStatements()
+    {
+        SwitchNode switchNode = Assert.IsType<SwitchNode>(
+            FirstStatement("switch ( a )\n{\ncase 1:\ncase 2:\n    b = 1;\n    break;\n}"));
+
+        Assert.Equal("LiteralNode LiteralNode ExprStatementNode BreakNode", ChildrenOf(switchNode.Cases[0]));
+    }
+
+    [Fact]
+    public void ADefaultLabelContributesNoChild()
+    {
+        // `default:` is a label with no value. It must be skipped rather than yielded as null, and
+        // rather than stopping the labels that follow it in a group.
+        SwitchNode switchNode = Assert.IsType<SwitchNode>(
+            FirstStatement("switch ( a )\n{\ndefault:\ncase 1:\n    break;\n}"));
+
+        Assert.Equal("LiteralNode BreakNode", ChildrenOf(switchNode.Cases[0]));
+    }
+
+    [Fact]
+    public void ACallYieldsItsTargetThenItsCalleeThenItsArguments()
+    {
+        ExprStatementNode statement = Assert.IsType<ExprStatementNode>(FirstStatement("player thread f( 1, 2 );"));
+        CallNode call = Assert.IsType<CallNode>(statement.Expression);
+
+        Assert.Equal("IdentifierNode IdentifierNode LiteralNode LiteralNode", ChildrenOf(call));
+    }
+
+    [Fact]
+    public void ACallWithNoTargetYieldsItsCalleeFirst()
+    {
+        ExprStatementNode statement = Assert.IsType<ExprStatementNode>(FirstStatement("f( 1 );"));
+        CallNode call = Assert.IsType<CallNode>(statement.Expression);
+
+        Assert.Equal("IdentifierNode LiteralNode", ChildrenOf(call));
+    }
+
+    [Fact]
+    public void AVectorYieldsThreeComponentsAndATernaryThreeOperands()
+    {
+        ExprStatementNode vectorStatement = Assert.IsType<ExprStatementNode>(FirstStatement("a = ( 1, 2, 3 );"));
+        AssignmentNode vectorAssignment = Assert.IsType<AssignmentNode>(vectorStatement.Expression);
+        Assert.Equal("LiteralNode LiteralNode LiteralNode", ChildrenOf(vectorAssignment.Value));
+
+        ExprStatementNode ternaryStatement = Assert.IsType<ExprStatementNode>(FirstStatement("a = b ? 1 : 2;"));
+        AssignmentNode ternaryAssignment = Assert.IsType<AssignmentNode>(ternaryStatement.Expression);
+        Assert.Equal("IdentifierNode LiteralNode LiteralNode", ChildrenOf(ternaryAssignment.Value));
+    }
+
+    [Fact]
+    public void ALeafYieldsNothing()
+    {
+        ExprStatementNode statement = Assert.IsType<ExprStatementNode>(FirstStatement("a;"));
+
+        Assert.Equal("", ChildrenOf(statement.Expression));
+    }
+
+    [Fact]
+    public void AReturnYieldsItsValueOnlyWhenItHasOne()
+    {
+        Assert.Equal("", ChildrenOf(FirstStatement("return;")));
+        Assert.Equal("LiteralNode", ChildrenOf(FirstStatement("return 1;")));
+    }
+
+    [Fact]
+    public void WalkingTheWholeTreeAllocatesNothing()
+    {
+        // The point of the struct enumerable. The iterator this replaced allocated one state machine
+        // per node VISITED, which a walk repeated by every rule pays for again each time.
+        ScriptNode root = ParserTestHelper.Parse(
+            """
+            #using scripts\shared\util_shared;
+
+            function test( a, b = 1 )
+            {
+                for ( i = 0; i < 4; i++ )
+                {
+                    if ( a[ i ] > 2 )
+                    {
+                        a thread f( i, ( 1, 2, 3 ) );
+                    }
+                    else
+                    {
+                        switch ( b )
+                        {
+                            case 1:
+                            default:
+                                b = b ? 1 : 2;
+                                break;
+                        }
+                    }
+                }
+
+                return b;
+            }
+            """).Root;
+
+        // Warmed first: the assertion is about the walk, not about the JIT reaching it.
+        int warm = Count(root);
+        Assert.True(warm > 30, $"expected a tree worth walking, counted {warm}");
+
+        long before = GC.GetAllocatedBytesForCurrentThread();
+        int counted = Count(root);
+        long after = GC.GetAllocatedBytesForCurrentThread();
+
+        Assert.Equal(warm, counted);
+        Assert.Equal(0, after - before);
+    }
+
+    private static int Count(AstNode node)
+    {
+        int count = 1;
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            count += Count(child);
+        }
+
+        return count;
+    }
+}

--- a/server/tests/GSCode.Server.Tests/AssemblyInfo.cs
+++ b/server/tests/GSCode.Server.Tests/AssemblyInfo.cs
@@ -1,0 +1,24 @@
+using Xunit;
+
+// Test COLLECTIONS in this assembly run one at a time.
+//
+// GameProfile.Active is process-global, and this assembly now contains classes that WRITE it — the
+// corpus sweeps, which select a game before analysing it, and SampleScriptTests, which does the same
+// for each sample folder — alongside three hundred that read it without saying so. xUnit's unit of
+// parallelism is the collection, so those two groups ran at the same time: 132 handler and formatter
+// tests failed because a sample run had left the active dialect on CoD4.
+//
+// GameProfileCollection serializes the writers against each other and cannot do more than that; a
+// collection only orders the classes that join it. The readers are every other class here, and they
+// join nothing, because reading a global is invisible at the call site.
+//
+// This is the second half of the fix and not the whole of it. SampleWorkspace also puts Active back
+// when it is done, which is what stopped the failures — serializing alone left 121 of them, since a
+// class that runs AFTER a sample run reads the leftover dialect just as happily as one running
+// beside it. The restore closes the window this closes the race on; neither is sufficient alone
+// while a global decides what the parser and the lints do.
+//
+// Measured rather than assumed: 313 tests, 1s parallel against 2s serial. Within a test parallelism
+// is untouched — the corpus sweeps still walk their files through Parallel.ForEachAsync, which is
+// where this assembly's time actually goes.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/server/tests/GSCode.Server.Tests/Configuration/InlayFamiliesTests.cs
+++ b/server/tests/GSCode.Server.Tests/Configuration/InlayFamiliesTests.cs
@@ -1,0 +1,77 @@
+using GSCode.Server.Configuration;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace GSCode.Server.Tests.Configuration;
+
+/// <summary>
+/// The change detector behind the inlay-hint refresh.
+///
+/// Hints are computed per request and then cached by the client, so toggling a family is invisible
+/// until something else invalidates the document — which reads as the setting not working, and
+/// worse when turning one OFF, because the stale hints stay on screen. `ConfigurationHandler` asks
+/// for `workspace/inlayHint/refresh` when this value moves, and clients push their WHOLE
+/// configuration on any settings edit, so it has to move on exactly the three families and nothing
+/// else.
+/// </summary>
+public class InlayFamiliesTests
+{
+    [Fact]
+    public void EachFamilyMovesIt()
+    {
+        ServerSettings settings = new();
+        string atStart = settings.InlayFamilies;
+
+        settings.InlayInferredTypes = !settings.InlayInferredTypes;
+        string afterTypes = settings.InlayFamilies;
+        Assert.NotEqual(atStart, afterTypes);
+
+        settings.InlayParameterNames = !settings.InlayParameterNames;
+        string afterParameters = settings.InlayFamilies;
+        Assert.NotEqual(afterTypes, afterParameters);
+
+        settings.InlayMacroParameterNames = !settings.InlayMacroParameterNames;
+        Assert.NotEqual(afterParameters, settings.InlayFamilies);
+    }
+
+    [Fact]
+    public void AnUnrelatedSettingDoesNot()
+    {
+        // A refresh per font-size edit is the cost of getting this wrong.
+        ServerSettings settings = new();
+        string before = settings.InlayFamilies;
+
+        settings.ServerLogLevel = "debug";
+        settings.FormatPadParens = false;
+        settings.DiagnosticsScope = "open";
+
+        Assert.Equal(before, settings.InlayFamilies);
+    }
+
+    [Fact]
+    public void APushThatSaysNothingAboutInlayHintsChangesNothing()
+    {
+        ServerSettings settings = new();
+        string before = settings.InlayFamilies;
+
+        settings.Apply(JToken.Parse("""{ "gscode": { "serverLogLevel": "debug" } }"""));
+
+        Assert.Equal(before, settings.InlayFamilies);
+    }
+
+    [Theory]
+    [InlineData("""{ "gscode": { "inlayHints.macroParameterNames": true } }""")]
+    [InlineData("""{ "gscode": { "inlayHints": { "macroParameterNames": true } } }""")]
+    public void TheMacroFamilyIsReadFromEitherKeyForm(string payload)
+    {
+        // Both forms because a client may send the settings flat or nested, as the other
+        // inlayHints.* keys already accept.
+        ServerSettings settings = new();
+        Assert.False(settings.InlayMacroParameterNames);
+
+        settings.Apply(JToken.Parse(payload));
+
+        Assert.True(settings.InlayMacroParameterNames);
+        Assert.Contains("macroParameters=on", settings.InlayFamilies, StringComparison.Ordinal);
+    }
+}

--- a/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
+++ b/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
@@ -288,6 +288,112 @@ public class CorpusPerfTests
         }
     }
 
+
+    /// <summary>
+    /// What the cache costs BEFORE indexing starts, which is the part of a warm start that runs on
+    /// the thread the server is starting on.
+    ///
+    /// `Program.cs` does four things between `OnStarted` firing and the indexing task being queued:
+    /// sweeps the legacy cache directory, hashes the bundled data files into a build identity,
+    /// opens the database, and reads the blobs. All four are ahead of the `Task.Run`, so they are
+    /// startup latency rather than indexing, and the server's log rolls them into one `cache 0.1s`
+    /// figure that cannot say which of the four to attack.
+    /// </summary>
+    [Fact]
+    public async Task CacheOpen_WhereTheStartupTimeGoes()
+    {
+        if ( !CorpusFixture.Available && !GameCorpusFixture.Available().Any() )
+        {
+            _output.WriteLine("SKIPPED: no %GSCODE_CORPUS_<GAME>% found.");
+            return;
+        }
+
+        string databasePath = Path.Combine(Path.GetTempPath(), $"gscode-startup-{Guid.NewGuid():N}.db");
+
+        try
+        {
+            // Warm the file cache and the JIT the way a second start would find them; the first
+            // read of a 2.8 MB data file off cold disk is a different question.
+            _ = ServerBuildIdentity.Compute(BundledDataFilePaths(), GameProfile.Active.ShortName);
+
+            Stopwatch watch = Stopwatch.StartNew();
+            SqliteCache.CleanUpLegacyCache();
+            double sweep = watch.Elapsed.TotalMilliseconds;
+
+            watch.Restart();
+            string identity = ServerBuildIdentity.Compute(BundledDataFilePaths(), GameProfile.Active.ShortName);
+            double fingerprint = watch.Elapsed.TotalMilliseconds;
+
+            watch.Restart();
+            SqliteCache cache = SqliteCache.Open(databasePath, identity);
+            double open = watch.Elapsed.TotalMilliseconds;
+
+            watch.Restart();
+            int rows = cache.LoadAll().Count;
+            double read = watch.Elapsed.TotalMilliseconds;
+
+            await cache.DisposeAsync();
+
+            // A SECOND open, which is what splits the number above. Microsoft.Data.Sqlite loads its
+            // native provider on first use, so the first Open in a process pays an assembly load, a
+            // native library load and the JIT behind them; every one after it pays the file.
+            string secondPath = Path.Combine(Path.GetTempPath(), $"gscode-startup2-{Guid.NewGuid():N}.db");
+            watch.Restart();
+            SqliteCache second = SqliteCache.Open(secondPath, identity);
+            double reopen = watch.Elapsed.TotalMilliseconds;
+            await second.DisposeAsync();
+            try
+            {
+                File.Delete(secondPath);
+            }
+            catch ( IOException )
+            {
+            }
+
+            _output.WriteLine("");
+            _output.WriteLine($"########## {GameProfile.Active.ShortName} cache open, empty database, {rows} rows");
+            _output.WriteLine($"     legacy sweep   {sweep,8:F1} ms");
+            _output.WriteLine($"     build identity {fingerprint,8:F1} ms   {DataFileBytes() / 1048576.0:F1} MB hashed");
+            _output.WriteLine($"     open           {open,8:F1} ms");
+            _output.WriteLine($"     LoadAll        {read,8:F1} ms");
+            _output.WriteLine($"     open (2nd)     {reopen,8:F1} ms");
+            _output.WriteLine($"     total          {sweep + fingerprint + open + read,8:F1} ms");
+        }
+        finally
+        {
+            try
+            {
+                File.Delete(databasePath);
+            }
+            catch ( IOException )
+            {
+            }
+        }
+    }
+
+    private static IEnumerable<string> BundledDataFilePaths()
+    {
+        string apiDirectory = Path.Combine(AppContext.BaseDirectory, "Api");
+        foreach ( string fileName in GameProfile.Active.BundledDataFileNames )
+        {
+            yield return Path.Combine(apiDirectory, fileName);
+        }
+    }
+
+    private static long DataFileBytes()
+    {
+        long total = 0;
+        foreach ( string path in BundledDataFilePaths() )
+        {
+            if ( File.Exists(path) )
+            {
+                total += new FileInfo(path).Length;
+            }
+        }
+
+        return total;
+    }
+
     private async Task MeasureWarmIndexAsync(GameProfile profile, Func<PathResolver> resolverFactory)
     {
         GameProfile previous = GameProfile.Active;

--- a/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
+++ b/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
@@ -10,6 +10,7 @@ using GSCode.Core.Symbols;
 using GSCode.Parser;
 using GSCode.Workspace.Analysis;
 using GSCode.Workspace.Api;
+using GSCode.Workspace.Cache;
 using GSCode.Workspace.Completion;
 using GSCode.Workspace.Database;
 using GSCode.Workspace.Indexing;
@@ -35,6 +36,13 @@ namespace GSCode.Server.Tests.Corpus;
 [Collection(GameProfileCollection.Name)]
 public class CorpusPerfTests
 {
+    /// <summary>
+    /// Stands in for <c>ServerBuildIdentity.Compute</c>, which keys the real cache on the bundled
+    /// data files. Any constant works here as long as both opens agree: a mismatch makes
+    /// <c>SqliteCache.Open</c> discard the database, and the "warm" run would silently be a cold one.
+    /// </summary>
+    private const string WarmCacheIdentity = "warm-perf-identity";
+
     private readonly ITestOutputHelper _output;
 
     public CorpusPerfTests(ITestOutputHelper output)
@@ -219,6 +227,211 @@ public class CorpusPerfTests
         {
             GameProfile.Select(previous.ShortName);
         }
+    }
+
+    /// <summary>
+    /// Where a WARM start spends its time — the path a user takes on every start after their
+    /// first, and the one nothing in this class has ever timed.
+    ///
+    /// <see cref="ColdIndex_WhereTheTimeGoes"/> attaches no cache on purpose, and its comment says
+    /// why: "a warm run measures the restore path instead, which is a different question with a
+    /// different answer". That question was then never asked. Everything measured since has landed
+    /// on the cold arm — the server GC, the pruned enumeration, the one-pass reader — which took a
+    /// BO3 cold index from 2.6 s to under one. The arm that got none of it is now the one worth
+    /// looking at, and the last warm figure on record (2.6 s) predates all three.
+    ///
+    /// The cache read is timed SEPARATELY from the index, because they are not the same shape and
+    /// one number cannot say which to attack. It is what found the problem: <c>LoadAll</c> was a
+    /// single thread gzip-inflating and JSON-parsing every record to completion before
+    /// <c>IndexAsync</c> was called at all, and in the server it was not merely unsplit but
+    /// entirely OUTSIDE the stopwatch, being an argument to the <c>UseCache</c> call that precedes
+    /// the timed block. Measured here for the first time it was 91% of a warm start.
+    ///
+    /// It now reads blobs only, so this stage is the SQLite read and the deserialize shows up under
+    /// <c>index.restore</c> on the indexing threads. Keep both numbers: the point of the split is
+    /// that either half can regress on its own.
+    ///
+    /// Two indexes per game. The first exists only to leave a populated database behind, and its
+    /// drain is not optional: the writer serializes and gzips on its own thread well after
+    /// <c>IndexAsync</c> returns, so without <c>WaitForIdleAsync</c> the measured run restores
+    /// whatever happened to have been flushed and reports a warm start that is half cold.
+    /// </summary>
+    [Fact]
+    public async Task WarmIndex_WhereTheTimeGoes()
+    {
+        bool measured = false;
+
+        if ( CorpusFixture.Available )
+        {
+            await MeasureWarmIndexAsync(GameProfile.BlackOps3, CorpusFixture.Resolver);
+            measured = true;
+        }
+
+        // The same two as the cold sweep, and for the same reasons: CoD4 is the #include dialect,
+        // and BO1 is the only corpus large enough for a per-record cost to be visible.
+        foreach ( GameProfile profile in new[] { GameProfile.Cod4, GameProfile.BlackOps } )
+        {
+            GameCorpus? corpus = GameCorpusFixture.For(profile);
+            if ( corpus is null )
+            {
+                continue;
+            }
+
+            GameCorpus captured = corpus;
+            await MeasureWarmIndexAsync(captured.Profile, () => GameCorpusFixture.Resolver(captured));
+            measured = true;
+        }
+
+        if ( !measured )
+        {
+            _output.WriteLine("SKIPPED: no %GSCODE_CORPUS_BO3%, %GSCODE_CORPUS_COD4% or %GSCODE_CORPUS_BO1% found.");
+        }
+    }
+
+    private async Task MeasureWarmIndexAsync(GameProfile profile, Func<PathResolver> resolverFactory)
+    {
+        GameProfile previous = GameProfile.Active;
+        string databasePath = Path.Combine(Path.GetTempPath(), $"gscode-warm-{Guid.NewGuid():N}.db");
+
+        try
+        {
+            GameProfile.Select(profile.ShortName);
+
+            int dropped = await PopulateCacheAsync(databasePath, resolverFactory);
+
+            // Fresh everything, so nothing the populating run interned, resolved or committed is
+            // available to the measured one. Only the database file crosses between them.
+            PathResolver resolver = resolverFactory();
+            NameTable names = new();
+            ScriptDatabase database = new();
+            WorkspaceIndexer indexer = new(database, () => resolver, new PhysicalFileSystem(), names);
+
+            await using SqliteCache cache = SqliteCache.Open(databasePath, WarmCacheIdentity);
+
+            PerfTracker.Reset();
+
+            Stopwatch restoreWatch = Stopwatch.StartNew();
+            IReadOnlyDictionary<string, CachedEntry> restored = cache.LoadAll();
+            restoreWatch.Stop();
+
+            indexer.UseCache(cache, restored);
+
+            Stopwatch indexWatch = Stopwatch.StartNew();
+            IndexOutcome outcome = await indexer.IndexAsync(
+                IndexingMode.Full, NullIndexProgressListener.Instance, CancellationToken.None);
+            indexWatch.Stop();
+
+            double restoreMs = restoreWatch.Elapsed.TotalMilliseconds;
+            double indexMs = indexWatch.Elapsed.TotalMilliseconds;
+            double startMs = restoreMs + indexMs;
+            long databaseBytes = DatabaseBytes(databasePath);
+
+            _output.WriteLine("");
+            _output.WriteLine(
+                $"########## {profile.ShortName} warm start: {outcome.Total} files in {startMs:F0} ms "
+                + $"({outcome.Restored} restored, {outcome.Total - outcome.Restored} re-analysed)");
+
+            // Two stages, and the split moved once the deserialize did. This first one is now the
+            // SQLite read alone — blobs off the connection, nothing inflated — so a large figure
+            // here means the database itself is slow, not that the records are expensive. The
+            // records became expensive inside the index instead, under `index.restore`.
+            _output.WriteLine(
+                $"     cache read (serial) {restoreMs,8:F0} ms  {restored.Count,7:N0} records  "
+                + $"{restoreMs / startMs * 100,5:F1}% of warm start");
+            _output.WriteLine(
+                $"     index               {indexMs,8:F0} ms  {outcome.Total,7:N0} files    "
+                + $"{indexMs / startMs * 100,5:F1}% of warm start");
+            _output.WriteLine(
+                $"     per record          {(restored.Count == 0 ? 0 : restoreMs / restored.Count * 1000),8:F0} us  "
+                + $"cache file {databaseBytes / 1048576.0:F1} MB");
+
+            // Not fatal, but it makes every number above a mixture: a dropped write is a file the
+            // populating run never persisted, so the measured run re-analysed it and charged the
+            // time to the index rather than to the restore.
+            if ( dropped > 0 || outcome.Restored != outcome.Total )
+            {
+                _output.WriteLine(
+                    $"     WARNING: not fully warm - {dropped:N0} write(s) dropped while populating, "
+                    + $"{outcome.Total - outcome.Restored:N0} file(s) re-analysed. Read the split with that in mind.");
+            }
+
+            Dictionary<string, (double Milliseconds, long Count)> scopes = [];
+            PerfTracker.Snapshot(scopes);
+
+            if ( scopes.Count == 0 )
+            {
+                _output.WriteLine("     scopes: not instrumented (rebuild with -p:GscodeInstrumentation=true)");
+            }
+            else
+            {
+                // Same two denominators as the cold sweep, and the same reason. index.restore is
+                // the per-file hash-and-commit inside IndexAsync, which is NOT the LoadAll above:
+                // one is the deserialize, the other is the freshness check that decides whether the
+                // deserialized record may be used at all.
+                string[] topLevel = ["index.read", "index.analyse", "index.commit", "index.enqueue", "index.restore"];
+                double threadTime = scopes.Where(s => topLevel.Contains(s.Key)).Sum(s => s.Value.Milliseconds);
+
+                foreach ( KeyValuePair<string, (double Milliseconds, long Count)> scope in scopes
+                    .Where(s => s.Key != "index.total")
+                    .OrderByDescending(s => s.Value.Milliseconds) )
+                {
+                    bool nested = !topLevel.Contains(scope.Key) && scope.Key != "index.enumerate";
+                    string share = scope.Key == "index.enumerate"
+                        ? $"{scope.Value.Milliseconds / indexMs * 100,5:F1}% of INDEX WALL (serial)"
+                        : $"{scope.Value.Milliseconds / threadTime * 100,5:F1}% of thread-time{(nested ? " (nested)" : "")}";
+
+                    _output.WriteLine(
+                        $"     {scope.Key,-20} {scope.Value.Milliseconds,8:F0} ms  {scope.Value.Count,7:N0} calls  {share}");
+                }
+            }
+
+            PerfReport.Memory memory = PerfReport.Sample();
+            _output.WriteLine(
+                $"     memory: live {memory.ManagedLive / 1048576.0:F0} MB | heap {memory.HeapSize / 1048576.0:F0} MB | "
+                + $"fragmented {memory.Fragmented / 1048576.0:F0} MB | working set {memory.WorkingSet / 1048576.0:F0} MB");
+        }
+        finally
+        {
+            GameProfile.Select(previous.ShortName);
+            SqliteCache.DeleteDatabase(databasePath);
+        }
+    }
+
+    /// <summary>
+    /// Indexes once into a fresh cache and waits for the writer to drain, so the database is
+    /// complete before anything reads it. Returns the writes the channel refused, which is the
+    /// difference between a warm start and a warm start that quietly re-analyses part of the tree.
+    /// </summary>
+    private static async Task<int> PopulateCacheAsync(string databasePath, Func<PathResolver> resolverFactory)
+    {
+        PathResolver resolver = resolverFactory();
+        NameTable names = new();
+        ScriptDatabase database = new();
+        WorkspaceIndexer indexer = new(database, () => resolver, new PhysicalFileSystem(), names);
+
+        await using SqliteCache cache = SqliteCache.Open(databasePath, WarmCacheIdentity);
+        indexer.UseCache(cache, cache.LoadAll());
+
+        await indexer.IndexAsync(IndexingMode.Full, NullIndexProgressListener.Instance, CancellationToken.None);
+        await cache.WaitForIdleAsync(CancellationToken.None);
+
+        return cache.DroppedWrites;
+    }
+
+    /// <summary>The cache and its two SQLite side files, which is what a user's disk actually holds.</summary>
+    private static long DatabaseBytes(string databasePath)
+    {
+        long total = 0;
+        foreach ( string suffix in new[] { "", "-wal", "-shm" } )
+        {
+            FileInfo file = new(databasePath + suffix);
+            if ( file.Exists )
+            {
+                total += file.Length;
+            }
+        }
+
+        return total;
     }
 
     /// <summary>

--- a/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
+++ b/server/tests/GSCode.Server.Tests/Corpus/CorpusPerfTests.cs
@@ -670,7 +670,8 @@ public class CorpusPerfTests
     }
 
     /// <summary>
-    /// How many completion requests to time per file. Ten rather than every call site, because this
+    /// How many CALL-SITE completion requests to time per file — one file-scope request is timed
+    /// besides, so a file contributes up to eleven. Ten rather than every call site, because this
     /// sweep pays a full index per game before it starts and a completion is far more expensive than
     /// a lint: BO3's 980 files at every call site would be tens of thousands of requests.
     ///
@@ -898,6 +899,12 @@ public class CorpusPerfTests
     /// </summary>
     private static List<Position> CompletionSamplePositions(ParseResult parsed)
     {
+        // The first sample is FILE SCOPE — the top of the file, outside every declaration. A call
+        // reference can only ever be inside a function body, so a sweep built from them alone timed
+        // one of the two arms: file scope used to return a static word list before any store query
+        // ran, and now runs the same queries a body does.
+        List<Position> sampled = [new Position(0, 0)];
+
         List<Position> calls = [];
         foreach ( ReferenceEntry entry in parsed.Extraction.References )
         {
@@ -909,11 +916,11 @@ public class CorpusPerfTests
 
         if ( calls.Count <= CompletionSamplesPerFile )
         {
-            return calls;
+            sampled.AddRange(calls);
+            return sampled;
         }
 
         // Evenly spaced, so the sample spans the file rather than clustering in its first function.
-        List<Position> sampled = new(CompletionSamplesPerFile);
         for ( int i = 0; i < CompletionSamplesPerFile; i++ )
         {
             sampled.Add(calls[i * calls.Count / CompletionSamplesPerFile]);

--- a/server/tests/GSCode.Server.Tests/Corpus/MemoryProbeTests.cs
+++ b/server/tests/GSCode.Server.Tests/Corpus/MemoryProbeTests.cs
@@ -151,6 +151,106 @@ public class MemoryProbeTests
         }
     }
 
+
+    /// <summary>
+    /// What a WARM index retains, which neither probe above can see.
+    ///
+    /// The one with a cache attached opens a fresh database per run, so `LoadAll` returns nothing
+    /// and every file is analysed: it measures the cache being WRITTEN. The restore snapshot only
+    /// exists on the arm where the database already has rows in it, and until this ran, the bytes
+    /// that snapshot costs had never been on a scale.
+    ///
+    /// They were worth putting there. The snapshot is a `byte[]` per cached file - the gzipped
+    /// record, held unopened so the freshness check can be answered without inflating it - and the
+    /// indexer used to keep the whole dictionary in a field for the life of the process. In the
+    /// server that is a DI singleton, so "the life of the process" is the session.
+    /// </summary>
+    [Fact]
+    public async Task EachGame_WarmIndexWithCache_ThenWatchRetainedMemory()
+    {
+        if ( !GameCorpusFixture.Available().Any() && !CorpusFixture.Available )
+        {
+            _output.WriteLine("SKIPPED: no %GSCODE_CORPUS_<GAME>% found.");
+            return;
+        }
+
+        if ( CorpusFixture.Available )
+        {
+            await ProbeWarmAsync(GameProfile.BlackOps3, CorpusFixture.Resolver);
+        }
+
+        foreach ( GameCorpus corpus in GameCorpusFixture.Available() )
+        {
+            GameCorpus captured = corpus;
+            await ProbeWarmAsync(captured.Profile, () => GameCorpusFixture.Resolver(captured));
+        }
+    }
+
+    private async Task ProbeWarmAsync(GameProfile profile, Func<PathResolver> resolverFactory)
+    {
+        GameProfile previous = GameProfile.Active;
+        string databasePath = Path.Combine(Path.GetTempPath(), $"gscode-warmprobe-{Guid.NewGuid():N}.db");
+        const string Identity = "warm-probe-identity";
+
+        try
+        {
+            GameProfile.Select(profile.ShortName);
+
+            // Populate, then DRAIN. The writer serializes and gzips on its own thread well after
+            // IndexAsync returns, so without the wait the measured run restores whatever happened
+            // to have been flushed and reports a warm start that is half cold.
+            {
+                PathResolver seedResolver = resolverFactory();
+                ScriptDatabase seedDatabase = new();
+                WorkspaceIndexer seedIndexer = new(
+                    seedDatabase, () => seedResolver, new PhysicalFileSystem(), new NameTable());
+
+                await using SqliteCache seedCache = SqliteCache.Open(databasePath, Identity);
+                seedIndexer.UseCache(seedCache, seedCache.LoadAll());
+                await seedIndexer.IndexAsync(
+                    IndexingMode.Full, NullIndexProgressListener.Instance, CancellationToken.None);
+                await seedCache.WaitForIdleAsync(CancellationToken.None);
+            }
+
+            // Fresh everything, so nothing the populating run interned, resolved or committed is
+            // available to the measured one. Only the database file crosses between them.
+            PathResolver resolver = resolverFactory();
+            ScriptDatabase database = new();
+            WorkspaceIndexer indexer = new(database, () => resolver, new PhysicalFileSystem(), new NameTable());
+
+            await using SqliteCache cache = SqliteCache.Open(databasePath, Identity);
+            indexer.UseCache(cache, cache.LoadAll());
+
+            IndexOutcome outcome = await indexer.IndexAsync(
+                IndexingMode.Full, NullIndexProgressListener.Instance, CancellationToken.None);
+
+            await cache.WaitForIdleAsync(CancellationToken.None);
+
+            _output.WriteLine("");
+            _output.WriteLine(
+                $"########## {profile.ShortName} WARM: {outcome.Total} files, {outcome.Restored} restored");
+            _output.WriteLine(RowHeader);
+            _output.WriteLine(Row("wrm", Sample()));
+
+            // The indexer, not just the database. What is being asked is what the SERVER holds, and
+            // there the indexer outlives every index it runs - so a probe that lets it be collected
+            // measures the wrong object and reads clean whatever the indexer is keeping.
+            GC.KeepAlive(indexer);
+            GC.KeepAlive(database);
+        }
+        finally
+        {
+            GameProfile.Select(previous.ShortName);
+            try
+            {
+                File.Delete(databasePath);
+            }
+            catch ( IOException )
+            {
+            }
+        }
+    }
+
     [Fact]
     public async Task EachGame_IndexThenWatchRetainedMemory()
     {

--- a/server/tests/GSCode.Server.Tests/GSCode.Server.Tests.csproj
+++ b/server/tests/GSCode.Server.Tests/GSCode.Server.Tests.csproj
@@ -19,4 +19,16 @@
     <ProjectReference Include="..\..\src\GSCode.Server\GSCode.Server.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--
+      The sample scripts are analysed from disk beside the test assembly, so they are copied rather
+      than located by walking up to the repo. LinkBase keeps the per-game folder shape, which the
+      resolver needs: each game's folder IS its raw root.
+    -->
+    <Content Include="..\..\samples\**\*.gsc;..\..\samples\**\*.csc;..\..\samples\**\*.gsh">
+      <LinkBase>Samples</LinkBase>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>

--- a/server/tests/GSCode.Server.Tests/Handlers/InlayHintMacroTests.cs
+++ b/server/tests/GSCode.Server.Tests/Handlers/InlayHintMacroTests.cs
@@ -1,0 +1,154 @@
+using System.Threading;
+using GSCode.Core;
+using GSCode.Core.Symbols;
+using GSCode.Parser;
+using GSCode.Parser.Preprocessing;
+using GSCode.Server.Configuration;
+using GSCode.Server.Handlers;
+using GSCode.Workspace.Api;
+using GSCode.Workspace.Database;
+using GSCode.Workspace.Documents;
+using GSCode.Workspace.Resolution;
+using OmniSharp.Extensions.LanguageServer.Protocol;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using Xunit;
+
+namespace GSCode.Server.Tests.Handlers;
+
+/// <summary>
+/// The macro parameter-name inlay family, driven through the handler the way the editor drives
+/// it, because everything that can go wrong here lives between the request and the hint: the
+/// setting has to be read, the invocation has to survive preprocessing, and the label has to land
+/// on the argument rather than on the parenthesis before it.
+/// </summary>
+public class InlayHintMacroTests
+{
+    private const string Path = @"c:\bo3\share\raw\scripts\main.gsc";
+
+    private const string Source =
+        "#define IS_TRUE(__a) (isdefined(__a) && __a)\n"
+        + "#define MAX_PLAYERS 18\n"
+        + "\n"
+        + "function s()\n"
+        + "{\n"
+        + "    if ( !IS_TRUE( level.friendlyContentOutlines ) )\n"
+        + "    {\n"
+        + "        return false;\n"
+        + "    }\n"
+        + "\n"
+        + "    return MAX_PLAYERS;\n"
+        + "}\n";
+
+    private static InlayHintHandler BuildHandler(ServerSettings settings)
+    {
+        DocumentStore documents = new(static _ => NullInsertProvider.Instance, new NameTable());
+        OpenDocument document = documents.Open(Path, Source, 1);
+        documents.AnalyzeIfStale(document);
+
+        NavigationSupport support = new(documents, new ScriptDatabase(), new ResolverHolder(new PhysicalFileSystem()));
+
+        return new InlayHintHandler(
+            support,
+            new BuiltinApiSet(BuiltinApi.Empty, BuiltinApi.Empty),
+            ObjectFields.Empty,
+            settings,
+            TextDocumentSelector.ForLanguage("gsc"));
+    }
+
+    private static async Task<List<InlayHint>> HintsAsync(ServerSettings settings)
+    {
+        InlayHintParams request = new()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = DocumentUri.FromFileSystemPath(Path) },
+            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(0, 0, 20, 0),
+        };
+
+        InlayHintContainer? container = await BuildHandler(settings).Handle(request, CancellationToken.None);
+
+        return [.. container ?? []];
+    }
+
+    /// <summary>Only the macro family on, so nothing else can supply the hint under test.</summary>
+    private static ServerSettings MacroOnly()
+    {
+        return new ServerSettings
+        {
+            InlayInferredTypes = false,
+            InlayParameterNames = false,
+            InlayMacroParameterNames = true,
+        };
+    }
+
+    [Fact]
+    public void TheFamilyIsOffByDefault()
+    {
+        Assert.False(new ServerSettings().InlayMacroParameterNames);
+    }
+
+    [Fact]
+    public async Task NoMacroHintsWhenTheSettingIsOff()
+    {
+        ServerSettings settings = MacroOnly();
+        settings.InlayMacroParameterNames = false;
+
+        Assert.Empty(await HintsAsync(settings));
+    }
+
+    [Fact]
+    public async Task TheArgumentIsLabelledWithTheMacrosParameterName()
+    {
+        // The reported shape: `IS_TRUE( level.friendlyContentOutlines )` should read `__a:` before
+        // the argument. The call is gone by the time there is a tree, so this can only come from
+        // the preprocessor's invocation list.
+        InlayHint hint = Assert.Single(await HintsAsync(MacroOnly()));
+
+        Assert.Equal("__a:", hint.Label.String);
+        Assert.Equal(InlayHintKind.Parameter, hint.Kind);
+        Assert.True(hint.PaddingRight);
+
+        // Line 5, at `level` — not at the '(' and not at the space after it.
+        Assert.Equal(5, hint.Position.Line);
+        Assert.Equal(Source.Split('\n')[5].IndexOf("level", StringComparison.Ordinal), hint.Position.Character);
+    }
+
+    [Fact]
+    public async Task AnObjectLikeMacroIsNotLabelled()
+    {
+        // `MAX_PLAYERS` is invoked too, and takes no arguments — the single hint above is already
+        // the proof, pinned here as the thing that would regress if the parameter check went away.
+        List<InlayHint> hints = await HintsAsync(MacroOnly());
+
+        Assert.DoesNotContain(hints, hint => (hint.Label.String ?? "").Contains("MAX_PLAYERS", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task AnInvocationOutsideTheWindowIsNotHinted()
+    {
+        InlayHintParams request = new()
+        {
+            TextDocument = new TextDocumentIdentifier { Uri = DocumentUri.FromFileSystemPath(Path) },
+            Range = new OmniSharp.Extensions.LanguageServer.Protocol.Models.Range(8, 0, 11, 0),
+        };
+
+        InlayHintContainer? container = await BuildHandler(MacroOnly()).Handle(request, CancellationToken.None);
+
+        Assert.Empty(container ?? []);
+    }
+
+    [Fact]
+    public async Task TheCallSitePassStillSkipsTheExpansion()
+    {
+        // The macro body expands to `isdefined( … )`, whose tokens all report the INVOCATION's
+        // range. With the call-site family on as well, that must still be skipped — otherwise the
+        // expansion's own parameter names stack onto the one call site.
+        List<InlayHint> hints = await HintsAsync(new ServerSettings
+        {
+            InlayInferredTypes = false,
+            InlayParameterNames = true,
+            InlayMacroParameterNames = true,
+        });
+
+        Assert.Single(hints);
+        Assert.Equal("__a:", hints[0].Label.String);
+    }
+}

--- a/server/tests/GSCode.Server.Tests/Handlers/SupportedGamesHandlerTests.cs
+++ b/server/tests/GSCode.Server.Tests/Handlers/SupportedGamesHandlerTests.cs
@@ -1,0 +1,199 @@
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using GSCode.Core;
+using GSCode.Server.Handlers;
+using GSCode.Server.Tests.Corpus;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GSCode.Server.Tests.Handlers;
+
+/// <summary>
+/// The roster behind the game picker, and the two lists it has to keep agreeing with.
+///
+/// This exists because the client used to own the list and it drifted: to nine games, four of them
+/// cores with no dialect implemented, so picking one wrote a <c>gscode.game</c> value the setting's
+/// own enum rejects and the server then resolved back to Black Ops III silently. Moving the list
+/// to the server fixed the copy; nothing yet stopped the SETTING from drifting away from it, which
+/// is the same bug one file over.
+///
+/// Joins <see cref="GameProfileCollection"/>: the roster and the selected game are both read off
+/// <c>GameProfile.Active</c> and the supported set, which a sample or corpus run moves.
+/// </summary>
+[Collection(GameProfileCollection.Name)]
+public class SupportedGamesHandlerTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SupportedGamesHandlerTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    private static async Task<SupportedGamesResponse> AskAsync()
+    {
+        return await new SupportedGamesHandler().Handle(new SupportedGamesParams(), CancellationToken.None);
+    }
+
+    /// <summary>Walks up from the test assembly to the client's manifest.</summary>
+    private static string? FindClientManifest()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+
+        while ( directory is not null )
+        {
+            string candidate = Path.Combine(directory.FullName, "client", "package.json");
+            if ( File.Exists(candidate) )
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// Exactly the supported profiles, and nothing else. A core has no dialect filled in, so
+    /// offering one is offering a game the server cannot actually parse as.
+    /// </summary>
+    [Fact]
+    public async Task TheRosterIsExactlyTheSupportedProfiles()
+    {
+        SupportedGamesResponse response = await AskAsync();
+
+        List<string> expected = [.. GameProfile.All.Where(p => p.Supported).Select(p => p.ShortName)];
+        List<string> offered = [.. response.Games.Select(g => g.Id)];
+
+        // Order included: the roster is in release order and the picker shows it as given, so a
+        // reordering is a user-visible change rather than an implementation detail.
+        Assert.Equal(expected, offered);
+        Assert.NotEmpty(offered);
+    }
+
+    /// <summary>
+    /// The selected game is what the server SELECTED, not what was asked for.
+    ///
+    /// An unrecognised name falls back to BO3, so the two differ exactly when something is wrong.
+    /// A picker that ticks a game which is not in use rules out the very thing being looked for.
+    /// </summary>
+    [Fact]
+    public async Task TheSelectedGameIsTheActiveProfile()
+    {
+        GameProfile previous = GameProfile.Active;
+        try
+        {
+            GameProfile.Select("cod4");
+
+            SupportedGamesResponse response = await AskAsync();
+
+            Assert.Equal("cod4", response.SelectedGame);
+            Assert.Equal(GameProfile.Cod4.DisplayName, response.SelectedDisplayName);
+
+            // The tick has to land on something the picker is showing, or it lands on nothing.
+            Assert.Contains(response.Games, game => game.Id == response.SelectedGame);
+        }
+        finally
+        {
+            GameProfile.Select(previous.ShortName);
+        }
+    }
+
+    /// <summary>
+    /// A label separates two games that share a display name. Nothing does today, but the lineage
+    /// holds two Modern Warfare 2s and two Modern Warfare 3s, and the year is what will tell them
+    /// apart the moment a core is promoted.
+    /// </summary>
+    [Fact]
+    public async Task EveryLabelCarriesItsReleaseYear()
+    {
+        SupportedGamesResponse response = await AskAsync();
+
+        foreach (SupportedGame game in response.Games)
+        {
+            GameProfile profile = GameProfile.ByName(game.Id)!;
+            Assert.Contains(profile.ReleaseYear.ToString(), game.Label, StringComparison.Ordinal);
+        }
+
+        Assert.Equal(response.Games.Count, response.Games.Select(g => g.Label).Distinct().Count());
+    }
+
+    /// <summary>
+    /// The roster and the <c>gscode.game</c> enum are the same list.
+    ///
+    /// This is the assertion the original bug needed and did not have. The picker writes the id it
+    /// was given straight into the setting, so an id the enum does not accept is a write VSCode
+    /// marks invalid and the server resolves back to BO3 — reported nowhere the user is looking.
+    /// The failure runs the other way too: a game in the enum but not the roster is one a user can
+    /// select by hand and the picker will never offer.
+    ///
+    /// A cross-file check, because the bug lives in a gap no compiler relates.
+    /// </summary>
+    [Fact]
+    public async Task TheRosterAndTheSettingEnumAreTheSameList()
+    {
+        string? manifestPath = FindClientManifest();
+        if ( manifestPath is null )
+        {
+            _output.WriteLine("SKIPPED: client/package.json not found from the test output directory.");
+            return;
+        }
+
+        using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+
+        List<string> enumValues = [];
+        foreach ( JsonElement section in manifest.RootElement
+            .GetProperty("contributes").GetProperty("configuration").EnumerateArray() )
+        {
+            if ( section.TryGetProperty("properties", out JsonElement properties)
+                && properties.TryGetProperty("gscode.game", out JsonElement game)
+                && game.TryGetProperty("enum", out JsonElement values) )
+            {
+                enumValues = [.. values.EnumerateArray().Select(v => v.GetString()!)];
+            }
+        }
+
+        Assert.NotEmpty(enumValues);
+
+        SupportedGamesResponse response = await AskAsync();
+        List<string> offered = [.. response.Games.Select(g => g.Id)];
+
+        _output.WriteLine($"roster: {string.Join(", ", offered)}");
+        _output.WriteLine($"enum:   {string.Join(", ", enumValues)}");
+
+        Assert.Equal(offered, enumValues);
+    }
+
+    /// <summary>
+    /// The command is declared in the manifest. A command registered only in <c>extension.ts</c>
+    /// does not appear in the palette at all, so the picker would exist and be unreachable — which
+    /// is the state this whole feature was added to leave.
+    /// </summary>
+    [Fact]
+    public void ThePickerCommandIsDeclaredInTheManifest()
+    {
+        string? manifestPath = FindClientManifest();
+        if ( manifestPath is null )
+        {
+            _output.WriteLine("SKIPPED: client/package.json not found from the test output directory.");
+            return;
+        }
+
+        string manifest = File.ReadAllText(manifestPath);
+        using JsonDocument parsed = JsonDocument.Parse(manifest);
+
+        List<string> commands = [.. parsed.RootElement.GetProperty("contributes").GetProperty("commands")
+            .EnumerateArray().Select(c => c.GetProperty("command").GetString()!)];
+
+        Assert.Contains("gscode.selectGame", commands);
+
+        // And registered on the other side. A declared command with no handler throws
+        // "command not found" when the palette runs it.
+        string? extension = Path.Combine(Path.GetDirectoryName(manifestPath)!, "src", "extension.ts");
+        Assert.True(File.Exists(extension));
+        Assert.Matches(
+            new Regex(@"registerCommand\(\s*""gscode\.selectGame"""),
+            File.ReadAllText(extension));
+    }
+}

--- a/server/tests/GSCode.Server.Tests/Samples/SampleExpectations.cs
+++ b/server/tests/GSCode.Server.Tests/Samples/SampleExpectations.cs
@@ -1,0 +1,141 @@
+using System.Globalization;
+using GSCode.Core.Diagnostics;
+
+namespace GSCode.Server.Tests.Samples;
+
+/// <summary>
+/// One expected diagnostic, read out of a sample script's own comments.
+///
+/// <see cref="Line"/> is zero-based to match <c>Diagnostic.Range</c>, and is -1 for an
+/// expectation written as <c>expect-anywhere</c> — the form for a diagnostic that has no line to
+/// stand above, such as one anchored on the first line of the file.
+/// </summary>
+internal sealed record SampleExpectation(GscDiagnosticCode Code, int Line, string Note)
+{
+    public bool Anywhere => Line < 0;
+}
+
+/// <summary>
+/// Reads the <c>// expect</c> comments that ARE the specification for a sample script.
+///
+/// The expectation lives in the file it describes, one line above the code that produces it, so a
+/// sample reads as a tutorial and is its own golden file at the same time. A sidecar list would say
+/// the same thing while drifting from the script on every edit, and a snapshot file would say
+/// nothing to a person reading it.
+///
+/// <code>
+/// // expect 5008 — assigned and never read
+/// unused_thing = 4;
+/// </code>
+///
+/// A run of consecutive expectation comments all anchor to the first line below them that is not
+/// itself one, which is how a single line carrying two diagnostics is written. Everything after the
+/// code — an em dash, a colon, prose — is a note for the reader and is not matched against
+/// anything; the CODE is the assertion.
+/// </summary>
+internal static class SampleExpectations
+{
+    private const string ExpectPrefix = "expect";
+    private const string AnywhereMarker = "expect-anywhere";
+
+    /// <summary>
+    /// Every expectation in <paramref name="text"/>, in file order. Lines and codes only —
+    /// severity and message are deliberately not asserted, since both are edited far more often
+    /// than a rule's identity and pinning them would turn a wording change into a failing suite.
+    /// </summary>
+    public static IReadOnlyList<SampleExpectation> Parse(string text)
+    {
+        string[] lines = text.Replace("\r\n", "\n").Split('\n');
+
+        List<SampleExpectation> expectations = [];
+
+        // Expectations gathered but not yet anchored: everything in the current run of comments,
+        // waiting for the line of code they describe.
+        List<(GscDiagnosticCode Code, string Note)> pending = [];
+
+        for ( int index = 0; index < lines.Length; index++ )
+        {
+            string trimmed = lines[index].Trim();
+
+            if ( !trimmed.StartsWith("//", StringComparison.Ordinal) )
+            {
+                foreach ( (GscDiagnosticCode code, string note) in pending )
+                {
+                    expectations.Add(new SampleExpectation(code, index, note));
+                }
+
+                pending.Clear();
+                continue;
+            }
+
+            string body = trimmed[2..].Trim();
+
+            if ( body.StartsWith(AnywhereMarker, StringComparison.Ordinal) )
+            {
+                foreach ( (GscDiagnosticCode code, string note) in Codes(body[AnywhereMarker.Length..]) )
+                {
+                    expectations.Add(new SampleExpectation(code, -1, note));
+                }
+
+                continue;
+            }
+
+            if ( body.StartsWith(ExpectPrefix, StringComparison.Ordinal) )
+            {
+                pending.AddRange(Codes(body[ExpectPrefix.Length..]));
+            }
+
+            // Any other comment is prose. It neither anchors a pending run nor breaks it, so a
+            // sample may explain itself between the expectation and the code it describes.
+        }
+
+        return expectations;
+    }
+
+    /// <summary>
+    /// The codes in one expectation comment's tail, e.g. <c> 5008, 5016 — both, on one line</c>.
+    /// Reading stops at the first token that is not a number, which is what makes the trailing note
+    /// free-form.
+    /// </summary>
+    private static List<(GscDiagnosticCode Code, string Note)> Codes(string tail)
+    {
+        string trimmed = tail.TrimStart(' ', '\t', ':');
+
+        List<(GscDiagnosticCode, string)> found = [];
+        int position = 0;
+
+        while ( position < trimmed.Length )
+        {
+            int start = position;
+            while ( position < trimmed.Length && char.IsDigit(trimmed[position]) )
+            {
+                position++;
+            }
+
+            if ( position == start )
+            {
+                break;
+            }
+
+            int value = int.Parse(trimmed[start..position], CultureInfo.InvariantCulture);
+            found.Add(((GscDiagnosticCode)value, trimmed[position..].Trim()));
+
+            while ( position < trimmed.Length && (trimmed[position] == ',' || trimmed[position] == ' ') )
+            {
+                position++;
+            }
+        }
+
+        // The note is the whole tail after the last code, shared by every code on the line.
+        if ( found.Count > 0 )
+        {
+            string note = found[^1].Item2;
+            for ( int index = 0; index < found.Count; index++ )
+            {
+                found[index] = (found[index].Item1, note);
+            }
+        }
+
+        return found;
+    }
+}

--- a/server/tests/GSCode.Server.Tests/Samples/SampleScriptTests.cs
+++ b/server/tests/GSCode.Server.Tests/Samples/SampleScriptTests.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using GSCode.Core;
+using GSCode.Core.Diagnostics;
+using GSCode.Server.Tests.Corpus;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace GSCode.Server.Tests.Samples;
+
+/// <summary>
+/// The gate on <c>server/samples</c> — a hand-written script per game per language world, showing
+/// the whole surface of the dialect and of the diagnostics, checked against its own
+/// <c>// expect</c> comments.
+///
+/// The files exist to be OPENED: they are what a contributor loads to see hover, completion,
+/// go-to-definition, semantic tokens and every rule firing on one page, and what a screenshot of the
+/// extension is taken from. A demo file with nothing asserting its output stops being true within
+/// two releases and nobody notices, so the same files are the golden corpus here — one artifact,
+/// checked, rather than a demo and a fixture that drift apart.
+///
+/// Three roles per world, because errors and demonstration fight each other:
+/// <list type="bullet">
+/// <item><c>gscode.*</c> — the showcase. Must produce ZERO diagnostics, so it stays the file where
+/// "does hover still work" is a fair question.</item>
+/// <item><c>gscode_lints.*</c> — one deliberate 4000/5000-range finding at a time. It still parses
+/// cleanly, so every rule is judged against a complete tree.</item>
+/// <item><c>gscode_broken.*</c> — the 1000/2000/3000 ranges. Kept apart because a syntax error puts
+/// the parser into recovery and everything below it is analysed degraded; mixed in with the lints,
+/// half of them would silently stop being tested.</item>
+/// </list>
+/// <c>gscode_target.*</c> is the second file the cross-file rules need to have an opinion at all.
+///
+/// Joins <c>GameProfileCollection</c>: <c>SampleWorkspace.AnalyzeAsync</c> moves <c>GameProfile.Active</c>,
+/// and a game analysed under another's dialect fails in ways that look like the rule under test.
+/// </summary>
+[Collection(GameProfileCollection.Name)]
+public class SampleScriptTests
+{
+    private readonly ITestOutputHelper _output;
+
+    public SampleScriptTests(ITestOutputHelper output)
+    {
+        _output = output;
+    }
+
+    public static TheoryData<string> Games()
+    {
+        TheoryData<string> data = [];
+        foreach ( GameProfile profile in SampleWorkspace.Games() )
+        {
+            data.Add(profile.ShortName);
+        }
+
+        return data;
+    }
+
+    /// <summary>
+    /// Every diagnostic a sample produces is one it asked for, and every one it asked for is
+    /// produced.
+    ///
+    /// Both halves matter and for different reasons. A missing diagnostic is a rule that regressed.
+    /// An EXTRA one is the more valuable half: the showcase files expect nothing at all, so any
+    /// finding there is a false positive caught on code that was written to be correct — which is
+    /// the same bug-finding the corpus sweep does, on scripts anyone can read without owning the
+    /// game.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Games))]
+    public async Task Samples_ProduceExactlyTheDiagnosticsTheyDeclare(string game)
+    {
+        GameProfile profile = GameProfile.ByName(game) ?? throw new InvalidOperationException(game);
+
+        StringBuilder failures = new();
+
+        foreach ( SampleFile file in await SampleWorkspace.AnalyzeAsync(profile) )
+        {
+            IReadOnlyList<SampleExpectation> expectations = SampleExpectations.Parse(file.Text);
+
+            // Anchored expectations are matched on (line, code); "anywhere" ones on the code alone.
+            // Both are multisets, so two of the same code on one line must be written twice.
+            List<(GscDiagnosticCode Code, int Line)> outstanding =
+            [
+                .. expectations.Where(static e => !e.Anywhere).Select(static e => (e.Code, e.Line)),
+            ];
+            List<GscDiagnosticCode> anywhere = [.. expectations.Where(static e => e.Anywhere).Select(static e => e.Code)];
+
+            List<Diagnostic> unexpected = [];
+
+            foreach ( Diagnostic diagnostic in file.Diagnostics )
+            {
+                int index = outstanding.IndexOf((diagnostic.Code, diagnostic.Range.Start.Line));
+                if ( index >= 0 )
+                {
+                    outstanding.RemoveAt(index);
+                    continue;
+                }
+
+                int loose = anywhere.IndexOf(diagnostic.Code);
+                if ( loose >= 0 )
+                {
+                    anywhere.RemoveAt(loose);
+                    continue;
+                }
+
+                unexpected.Add(diagnostic);
+            }
+
+            foreach ( Diagnostic diagnostic in unexpected )
+            {
+                failures.AppendLine(
+                    $"{file.RelativePath}:{diagnostic.Range.Start.Line + 1}  UNEXPECTED {(int)diagnostic.Code} " +
+                    $"{diagnostic.Code} — {diagnostic.Message}");
+            }
+
+            foreach ( (GscDiagnosticCode code, int line) in outstanding )
+            {
+                failures.AppendLine($"{file.RelativePath}:{line + 1}  MISSING {(int)code} {code}");
+            }
+
+            foreach ( GscDiagnosticCode code in anywhere )
+            {
+                failures.AppendLine($"{file.RelativePath}  MISSING (anywhere) {(int)code} {code}");
+            }
+        }
+
+        if ( failures.Length > 0 )
+        {
+            _output.WriteLine(failures.ToString());
+        }
+
+        Assert.True(failures.Length == 0, $"{game} samples disagree with their // expect comments:\n{failures}");
+    }
+
+    /// <summary>
+    /// The showcase file of every world a game HAS is present, and no world it lacks has one.
+    ///
+    /// This is the half a per-file test cannot see. A missing <c>gscode.csc</c> under BO1 is not a
+    /// failing assertion anywhere — the file is simply never enumerated, and a suite that only
+    /// checks the files it finds reports green on an empty folder. The profile's own capability
+    /// flags are the specification: <c>HasClientScripts</c> decides whether a <c>.csc</c> is owed,
+    /// <c>HasHeaders</c> whether a <c>.gsh</c> is.
+    /// </summary>
+    [Theory]
+    [MemberData(nameof(Games))]
+    public void EveryLanguageWorldTheGameHasIsSampled(string game)
+    {
+        GameProfile profile = GameProfile.ByName(game) ?? throw new InvalidOperationException(game);
+        string root = SampleWorkspace.RootFor(profile)!;
+
+        foreach ( string extension in profile.ScriptExtensions )
+        {
+            string[] showcases = Directory.GetFiles(root, "gscode" + extension, SearchOption.AllDirectories);
+            Assert.True(
+                showcases.Length == 1,
+                $"{game} has {extension} scripts, so exactly one showcase 'gscode{extension}' is owed " +
+                $"under server/samples/{game}; found {showcases.Length}.");
+        }
+
+        // The other direction: a world the game does not have must not be sampled, or the sample
+        // claims a capability the profile denies.
+        foreach ( string extension in new[] { ".gsc", ".csc", ".gsh" } )
+        {
+            if ( profile.ScriptExtensions.Contains(extension) )
+            {
+                continue;
+            }
+
+            string[] strays = Directory.GetFiles(root, "*" + extension, SearchOption.AllDirectories);
+            Assert.True(
+                strays.Length == 0,
+                $"{game} has no {extension} world, but server/samples/{game} contains " +
+                $"{string.Join(", ", strays.Select(Path.GetFileName))}.");
+        }
+    }
+}

--- a/server/tests/GSCode.Server.Tests/Samples/SampleWorkspace.cs
+++ b/server/tests/GSCode.Server.Tests/Samples/SampleWorkspace.cs
@@ -1,0 +1,165 @@
+using GSCode.Core;
+using GSCode.Core.Diagnostics;
+using GSCode.Core.Symbols;
+using GSCode.Core.Text;
+using GSCode.Parser;
+using GSCode.Parser.Preprocessing;
+using GSCode.Workspace.Analysis;
+using GSCode.Workspace.Api;
+using GSCode.Workspace.Database;
+using GSCode.Workspace.Indexing;
+using GSCode.Workspace.Resolution;
+
+namespace GSCode.Server.Tests.Samples;
+
+/// <summary>One sample script and everything the editor would say about it.</summary>
+internal sealed record SampleFile(string Path, string RelativePath, string Text, IReadOnlyList<Diagnostic> Diagnostics);
+
+/// <summary>
+/// Indexes one game's sample folder as a workspace and runs the WHOLE diagnostic pipeline over every
+/// file in it — the same call the corpus sweep makes, so a sample is judged by the pipeline the
+/// editor runs rather than by a reduced one.
+///
+/// The samples are a real directory on disk, indexed through the real <see cref="WorkspaceIndexer"/>
+/// over a <see cref="PhysicalFileSystem"/>, because half of what they demonstrate is cross-file:
+/// <c>#using</c>/<c>#include</c> resolution, <c>#insert</c>, and the lints that can only fire once a
+/// second file exists. A <c>FakeFileSystem</c> would serve the parse diagnostics and quietly report
+/// nothing for the rest.
+///
+/// Each game gets its own raw root — <c>Samples/bo3</c>, <c>Samples/cod4</c> — so a path is
+/// resolved against that game's tree alone and the folder layout can follow the game's own
+/// conventions (<c>scripts\shared</c> on BO3, <c>maps\mp</c> on the Infinity Ward line).
+/// </summary>
+internal static class SampleWorkspace
+{
+    /// <summary>Where the samples are copied to beside the test assembly. See the csproj.</summary>
+    public static string Root => Path.Combine(AppContext.BaseDirectory, "Samples");
+
+    private static string ApiDirectory => Path.Combine(AppContext.BaseDirectory, "Api");
+
+    /// <summary>The sample raw root for a game, or null when that game has no sample folder yet.</summary>
+    public static string? RootFor(GameProfile profile)
+    {
+        string root = Path.Combine(Root, profile.ShortName);
+        return Directory.Exists(root) ? root : null;
+    }
+
+    /// <summary>Every supported game that has samples committed.</summary>
+    public static IReadOnlyList<GameProfile> Games()
+    {
+        List<GameProfile> games = [];
+        foreach ( GameProfile profile in GameProfile.All )
+        {
+            if ( profile.Supported && RootFor(profile) is not null )
+            {
+                games.Add(profile);
+            }
+        }
+
+        return games;
+    }
+
+    /// <summary>
+    /// Indexes <paramref name="profile"/>'s samples and analyses every one of them.
+    ///
+    /// <c>GameProfile.Select</c> is called first because several lints and the parser's directive
+    /// handling fall back to <c>Active</c> when nothing hands them a profile — <c>WorkspaceLints</c>
+    /// takes no profile at all — so passing the profile to the indexer alone would analyse a file
+    /// under one dialect and lint it under another.
+    ///
+    /// And it is put BACK afterwards. <c>Active</c> is process-global and every other class in this
+    /// assembly reads it without saying so, expecting the BO3 default; leaving it on CoD4 failed 132
+    /// of them, in the formatter and the handlers, for a reason that looked like the thing under
+    /// test. Restoring it is what keeps this class's business its own — the collection membership
+    /// only orders the classes that join, and a reader joins nothing.
+    /// </summary>
+    public static async Task<IReadOnlyList<SampleFile>> AnalyzeAsync(GameProfile profile)
+    {
+        GameProfile previous = GameProfile.Active;
+        try
+        {
+            return await AnalyzeUnderProfileAsync(profile);
+        }
+        finally
+        {
+            GameProfile.Select(previous.ShortName);
+        }
+    }
+
+    private static async Task<IReadOnlyList<SampleFile>> AnalyzeUnderProfileAsync(GameProfile profile)
+    {
+        string root = RootFor(profile) ?? throw new DirectoryNotFoundException(
+            $"No sample folder for {profile.ShortName}; expected {Path.Combine(Root, profile.ShortName)}.");
+
+        GameProfile.Select(profile.ShortName);
+
+        PhysicalFileSystem fileSystem = new();
+        RootConfig config = RootConfig.Create(
+            rawEnabled: true, rawPath: root, modsPath: null, workspaceFolders: [], fileSystem: fileSystem);
+        PathResolver resolver = new(config, fileSystem);
+
+        NameTable names = new();
+        ScriptDatabase database = new();
+
+        WorkspaceIndexer indexer = new(database, () => resolver, fileSystem, names, profile: profile);
+        await indexer.IndexAsync(IndexingMode.Full, NullIndexProgressListener.Instance, CancellationToken.None);
+
+        BuiltinApiSet builtins = BuiltinApiSet.Load(ApiDirectory);
+        ObjectFields objectFields = ObjectFields.Load(ApiDirectory);
+
+        // A cache per call rather than a shared static: two games' headers are different files that
+        // can share a relative path, and a sample run is small enough that re-lexing costs nothing.
+        InsertCache inserts = new();
+
+        List<SampleFile> analysed = [];
+
+        foreach ( string path in Scripts(profile, root) )
+        {
+            ScriptLanguage language = profile.LanguageFromPath(path);
+            string text = File.ReadAllText(path);
+
+            ResolverInsertProvider provider = new(resolver, resolver.GetContext(path), fileSystem, inserts);
+            ParseResult result = ScriptAnalysis.Analyze(
+                path, language, SourceText.From(text), provider, names, profile, inserts);
+
+            List<Diagnostic> diagnostics =
+            [
+                .. WorkspaceLints.Analyze(result, language, path, database, resolver, builtins, objectFields),
+            ];
+
+            analysed.Add(new SampleFile(
+                path,
+                Path.GetRelativePath(root, path).Replace('\\', '/'),
+                text,
+                diagnostics));
+        }
+
+        return analysed;
+    }
+
+    /// <summary>
+    /// Every sample under the root, in the game's own extensions and a stable order. Filtering by
+    /// <c>ScriptExtensions</c> means a <c>.csc</c> left in a game without client scripts is simply
+    /// not analysed, which the extension-coverage test then reports as the mistake it is.
+    /// </summary>
+    private static IReadOnlyList<string> Scripts(GameProfile profile, string root)
+    {
+        List<string> files = [];
+
+        foreach ( string path in Directory.EnumerateFiles(root, "*.*", SearchOption.AllDirectories) )
+        {
+            string extension = Path.GetExtension(path);
+            foreach ( string candidate in profile.ScriptExtensions )
+            {
+                if ( extension.Equals(candidate, StringComparison.OrdinalIgnoreCase) )
+                {
+                    files.Add(path);
+                    break;
+                }
+            }
+        }
+
+        files.Sort(StringComparer.OrdinalIgnoreCase);
+        return files;
+    }
+}

--- a/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
+++ b/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
@@ -1,5 +1,11 @@
 {
   "configProperties": {
-    "System.GC.ConserveMemory": 5
+    "System.GC.ConserveMemory": 5,
+
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,091-2,182 ms with Workstation and 601-702 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "System.GC.Server": true,
+
+    "_comment_HeapCount": "Eight, not one per core. Unbounded on a 24-thread machine is no faster (733-768 ms) and leaves 35 MB of large-object holes and a larger working set, because each heap keeps its own LOH; at eight, fragmentation measures 0.7 MB. Retained memory is identical either way - 51.0-51.1 MB live on bo3, the same as Workstation - so this trades working set for throughput and nothing else.",
+    "System.GC.HeapCount": 8
   }
 }

--- a/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
+++ b/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
@@ -2,10 +2,10 @@
   "configProperties": {
     "System.GC.ConserveMemory": 5,
 
-    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,177-2,182 ms with Workstation and 768 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap. Measured end to end on the real server, bo3, 1,085 files: 2.6-2.7 s with Workstation against 0.4-0.5 s with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms in the harness, so the contention is the heap count and not the collection frequency.",
     "System.GC.Server": true,
 
-    "_comment_HeapCount": "Four. This is a resident language server, so the number to protect is the memory it sits at between edits, and the heap count buys throughput with exactly that: measured on bo3, four heaps rest at 200 MB and eight at 281, against Workstation's 127. Four is 768 ms against eight's 564-638 and Workstation's 2,177, so it keeps most of the speedup for half the extra footprint. Retained memory and fragmentation are identical at every setting - 51.0-51.1 MB live, 0.6-0.7 MB fragmented - and so is the PEAK right after indexing, around 450 MB; only the resting set differs.",
-    "System.GC.HeapCount": 4
+    "_comment_HeapCount": "Eight. The heap count changes the PEAK while indexing and not the memory the server rests at, because Program.cs compacts the large-object heap once at the indexing to serving transition and that returns the pages: measured on the real server, four heaps rest at 125.4-125.9 MB, eight at 125.0-126.8 and one per core at 128.3-128.9, against Workstation's 127. Eight indexes in 0.4-0.5 s against four's 0.5-0.6 with a peak within a few MB of it; one per core is no faster and peaks at 392-453 MB. Retained memory is 55 MB at every setting.",
+    "System.GC.HeapCount": 8
   }
 }

--- a/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
+++ b/server/tests/GSCode.Server.Tests/runtimeconfig.template.json
@@ -2,10 +2,10 @@
   "configProperties": {
     "System.GC.ConserveMemory": 5,
 
-    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,091-2,182 ms with Workstation and 601-702 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
+    "_comment_Server": "Server GC with a BOUNDED heap count. Indexing runs at ProcessorCount - 1 and allocates a token array, a PToken stream, an AST and extraction builders per file, and under Workstation GC those threads serialise on one heap: measured on bo3, a cold index of 1,085 files takes 2,177-2,182 ms with Workstation and 768 ms with this. Raising the Workstation gen0 budget to 256 MB only reaches ~1,350 ms, so the contention is the heap count and not the collection frequency.",
     "System.GC.Server": true,
 
-    "_comment_HeapCount": "Eight, not one per core. Unbounded on a 24-thread machine is no faster (733-768 ms) and leaves 35 MB of large-object holes and a larger working set, because each heap keeps its own LOH; at eight, fragmentation measures 0.7 MB. Retained memory is identical either way - 51.0-51.1 MB live on bo3, the same as Workstation - so this trades working set for throughput and nothing else.",
-    "System.GC.HeapCount": 8
+    "_comment_HeapCount": "Four. This is a resident language server, so the number to protect is the memory it sits at between edits, and the heap count buys throughput with exactly that: measured on bo3, four heaps rest at 200 MB and eight at 281, against Workstation's 127. Four is 768 ms against eight's 564-638 and Workstation's 2,177, so it keeps most of the speedup for half the extra footprint. Retained memory and fragmentation are identical at every setting - 51.0-51.1 MB live, 0.6-0.7 MB fragmented - and so is the PEAK right after indexing, around 450 MB; only the resting set differs.",
+    "System.GC.HeapCount": 4
   }
 }

--- a/server/tests/GSCode.Workspace.Tests/Analysis/ArithmeticLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/ArithmeticLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -30,7 +30,7 @@ public class ArithmeticLintTests
         // below passes while proving nothing.
         Assert.DoesNotContain(result.AllDiagnostics, d => (int)d.Code is >= 3000 and < 4000);
 
-        return ArithmeticLint.Analyze(result);
+        return NodeLintHarness.Run(result, ArithmeticLint.InspectNode);
     }
 
     [Theory]

--- a/server/tests/GSCode.Workspace.Tests/Analysis/CaseLabelLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/CaseLabelLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -28,7 +28,7 @@ public class CaseLabelLintTests
         ParseResult result = ScriptAnalysis.Analyze(
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
-        return CaseLabelLint.Analyze(result);
+        return NodeLintHarness.RunOnStatements(result, CaseLabelLint.InspectNode);
     }
 
     [Fact]
@@ -93,7 +93,7 @@ public class CaseLabelLintTests
         ParseResult result = ScriptAnalysis.Analyze(
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
-        Assert.Equal(GscDiagnosticCode.CaseUndefined, Assert.Single(CaseLabelLint.Analyze(result)).Code);
+        Assert.Equal(GscDiagnosticCode.CaseUndefined, Assert.Single(NodeLintHarness.RunOnStatements(result, CaseLabelLint.InspectNode)).Code);
     }
 
     // --- 5017: a label the switch already has ---
@@ -200,7 +200,7 @@ public class CaseLabelLintTests
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
         Assert.DoesNotContain(
-            CaseLabelLint.Analyze(result),
+            NodeLintHarness.RunOnStatements(result, CaseLabelLint.InspectNode),
             diagnostic => diagnostic.Code == GscDiagnosticCode.MultipleDefaultLabels);
     }
 

--- a/server/tests/GSCode.Workspace.Tests/Analysis/ConstDeclarationLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/ConstDeclarationLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -20,6 +20,18 @@ namespace GSCode.Workspace.Tests.Analysis;
 /// </summary>
 public class ConstDeclarationLintTests
 {
+    /// <summary>
+    /// Both halves the server runs for this rule: the per-node judgement over the shared walk, and
+    /// `InspectRest`, which `WorkspaceLints` calls once per file outside that walk.
+    /// </summary>
+    private static ImmutableArray<Diagnostic> RunRule(ParseResult result)
+    {
+        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+        diagnostics.AddRange(NodeLintHarness.Run(result, ConstDeclarationLint.InspectNode));
+        ConstDeclarationLint.InspectRest(result, diagnostics);
+        return diagnostics.ToImmutable();
+    }
+
     private static ImmutableArray<Diagnostic> Lint(string body)
     {
         string source = "function f( a )\n{\n" + body + "\n}\n";
@@ -31,7 +43,7 @@ public class ConstDeclarationLintTests
         // and every Assert.Empty passes. `const` is Black Ops III's, which is the test default.
         Assert.DoesNotContain(result.AllDiagnostics, d => (int)d.Code is >= 3000 and < 4000);
 
-        return ConstDeclarationLint.Analyze(result);
+        return RunRule(result);
     }
 
     // --- 5029 ---
@@ -91,7 +103,7 @@ public class ConstDeclarationLintTests
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
         Assert.DoesNotContain(
-            ConstDeclarationLint.Analyze(result),
+            RunRule(result),
             d => d.Code == GscDiagnosticCode.ExpectedConstantExpression);
     }
 
@@ -159,7 +171,7 @@ public class ConstDeclarationLintTests
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
         Assert.DoesNotContain(
-            ConstDeclarationLint.Analyze(result),
+            RunRule(result),
             d => d.Code == GscDiagnosticCode.CannotAssignToConstant);
     }
 
@@ -175,7 +187,7 @@ public class ConstDeclarationLintTests
             @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
 
         Diagnostic reported = Assert.Single(
-            ConstDeclarationLint.Analyze(result),
+            RunRule(result),
             d => d.Code == GscDiagnosticCode.CannotAssignToConstant);
 
         // Line 3 (zero-based) is `duration = 1;` in function a, not the write in function b.

--- a/server/tests/GSCode.Workspace.Tests/Analysis/ExpressionStatementLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/ExpressionStatementLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -20,6 +20,21 @@ namespace GSCode.Workspace.Tests.Analysis;
 /// </summary>
 public class ExpressionStatementLintTests
 {
+    /// <summary>
+    /// The rule as the server runs it: the shared walk, but only when `Applies` says the file's
+    /// premise holds. A file the parser could not read silences the rule, and two of the tests below
+    /// exist to prove that gate, so the harness has to carry it.
+    /// </summary>
+    private static ImmutableArray<Diagnostic> RunRule(ParseResult result)
+    {
+        if ( !ExpressionStatementLint.Applies(result) )
+        {
+            return [];
+        }
+
+        return NodeLintHarness.Run(result, ExpressionStatementLint.InspectNode);
+    }
+
     private static ImmutableArray<Diagnostic> Lint(string body)
     {
         string source = "function f( a, b )\n{\n" + body + "\n}\n";
@@ -32,7 +47,7 @@ public class ExpressionStatementLintTests
         // pass for the wrong reason.
         Assert.DoesNotContain(result.AllDiagnostics, d => (int)d.Code is >= 3000 and < 4000);
 
-        return ExpressionStatementLint.Analyze(result);
+        return RunRule(result);
     }
 
     [Theory]
@@ -126,7 +141,7 @@ public class ExpressionStatementLintTests
 
         // The premise: this file really did fail to parse.
         Assert.Contains(result.Tree.Diagnostics, d => (int)d.Code is >= 3000 and < 4000);
-        Assert.Empty(ExpressionStatementLint.Analyze(result));
+        Assert.Empty(RunRule(result));
     }
 
     [Fact]

--- a/server/tests/GSCode.Workspace.Tests/Analysis/GlobalObjectWriteLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/GlobalObjectWriteLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -29,7 +29,9 @@ public class GlobalObjectWriteLintTests
             NullInsertProvider.Instance,
             new NameTable());
 
-        return GlobalObjectWriteLint.Analyze(result);
+        return NodeLintHarness.Run(
+            result,
+            (node, diagnostics) => GlobalObjectWriteLint.InspectNode(node, GlobalObjectWriteLint.GlobalNames(), diagnostics));
     }
 
     [Fact]

--- a/server/tests/GSCode.Workspace.Tests/Analysis/NodeLintHarness.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/NodeLintHarness.cs
@@ -1,0 +1,63 @@
+using System.Collections.Immutable;
+using GSCode.Core.Diagnostics;
+using GSCode.Parser;
+using GSCode.Parser.Syntax;
+using GSCode.Parser.Syntax.Ast;
+
+namespace GSCode.Workspace.Tests.Analysis;
+
+/// <summary>
+/// Runs ONE per-node lint rule over a file, the way <c>NodeLintPass</c> runs all nine.
+///
+/// Each of those rules used to carry a public <c>Analyze</c> that walked the tree itself, and after
+/// the walks were merged nothing outside these tests called any of them. That left every rule with
+/// two walkers: the one the server runs, and the one the tests proved. They agreed by inspection
+/// only — <c>CaseLabelLint</c>'s rule about not descending into expressions was written once in its
+/// own walk and again as a guard in the shared pass — and if they had drifted the tests would have
+/// gone on passing, because they exercised the walk production does not use.
+///
+/// So the walkers are gone and this drives <c>InspectNode</c> directly. The descent here is the same
+/// three lines the shared pass uses, which is the point: a rule's tests now fail when the rule's
+/// judgement about a node changes, and nothing else.
+/// </summary>
+internal static class NodeLintHarness
+{
+    /// <summary>What one rule asks of one node.</summary>
+    internal delegate void Inspect(AstNode node, ImmutableArray<Diagnostic>.Builder diagnostics);
+
+    /// <summary>
+    /// Every node of the file, in the shared pass's order.
+    /// </summary>
+    internal static ImmutableArray<Diagnostic> Run(ParseResult result, Inspect inspect)
+    {
+        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+        Visit(result.Tree.Root, inspect, statementsOnly: false, diagnostics);
+        return diagnostics.ToImmutable();
+    }
+
+    /// <summary>
+    /// Statements only — the two rules whose subject cannot appear inside an expression, and which
+    /// the shared pass therefore does not ask about one. The descent still covers the whole tree, so
+    /// this skips the QUESTION rather than the walk, exactly as the pass does.
+    /// </summary>
+    internal static ImmutableArray<Diagnostic> RunOnStatements(ParseResult result, Inspect inspect)
+    {
+        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+        Visit(result.Tree.Root, inspect, statementsOnly: true, diagnostics);
+        return diagnostics.ToImmutable();
+    }
+
+    private static void Visit(
+        AstNode node, Inspect inspect, bool statementsOnly, ImmutableArray<Diagnostic>.Builder diagnostics)
+    {
+        if ( !statementsOnly || node is not ExprNode )
+        {
+            inspect(node, diagnostics);
+        }
+
+        foreach ( AstNode child in AstSearch.ChildrenOf(node) )
+        {
+            Visit(child, inspect, statementsOnly, diagnostics);
+        }
+    }
+}

--- a/server/tests/GSCode.Workspace.Tests/Analysis/PreferBooleanLiteralLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/PreferBooleanLiteralLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -45,7 +45,14 @@ public class PreferBooleanLiteralLintTests
             ],
             []);
 
-        return PreferBooleanLiteralLint.Analyze(result, api, fields, new FlowTyper(api, fields));
+        ImmutableArray<Diagnostic>.Builder diagnostics = ImmutableArray.CreateBuilder<Diagnostic>();
+        diagnostics.AddRange(NodeLintHarness.Run(
+            result,
+            (node, into) => PreferBooleanLiteralLint.InspectNode(node, api, into)));
+
+        // The second half, which the server calls once per file outside the shared walk.
+        PreferBooleanLiteralLint.InspectRest(result, fields, new FlowTyper(api, fields), diagnostics);
+        return diagnostics.ToImmutable();
     }
 
     [Theory]

--- a/server/tests/GSCode.Workspace.Tests/Analysis/TypeMismatchLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/TypeMismatchLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -35,7 +35,10 @@ public class TypeMismatchLintTests
         Assert.DoesNotContain(result.AllDiagnostics, d => (int)d.Code is >= 3000 and < 4000);
 
         FlowTyper typer = new(ApiLoader.Load(ApiDirectory, ScriptLanguage.Gsc), ObjectFields.Load(ApiDirectory));
-        return TypeMismatchLint.Analyze(result, typer);
+        ScriptTypes types = typer.InferValues(result);
+        return NodeLintHarness.Run(
+            result,
+            (node, diagnostics) => TypeMismatchLint.InspectNode(node, types, diagnostics));
     }
 
     // --- 5033: enumerating something that cannot be enumerated ---

--- a/server/tests/GSCode.Workspace.Tests/Analysis/UnreachableCodeLintTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/UnreachableCodeLintTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -29,7 +29,7 @@ public class UnreachableCodeLintTests
             NullInsertProvider.Instance,
             new NameTable());
 
-        return UnreachableCodeLint.Analyze(result);
+        return NodeLintHarness.RunOnStatements(result, UnreachableCodeLint.InspectNode);
     }
 
     [Theory]
@@ -102,7 +102,7 @@ public class UnreachableCodeLintTests
             NullInsertProvider.Instance,
             new NameTable());
 
-        Assert.Single(UnreachableCodeLint.Analyze(result));
+        Assert.Single(NodeLintHarness.RunOnStatements(result, UnreachableCodeLint.InspectNode));
     }
 
     [Fact]
@@ -119,7 +119,7 @@ public class UnreachableCodeLintTests
             NullInsertProvider.Instance,
             new NameTable());
 
-        Diagnostic diagnostic = Assert.Single(UnreachableCodeLint.Analyze(result));
+        Diagnostic diagnostic = Assert.Single(NodeLintHarness.RunOnStatements(result, UnreachableCodeLint.InspectNode));
         Assert.Equal(GscDiagnosticCode.UnreachableCode, diagnostic.Code);
     }
 }

--- a/server/tests/GSCode.Workspace.Tests/Analysis/WorkspaceDiagnosticBatchTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Analysis/WorkspaceDiagnosticBatchTests.cs
@@ -1,4 +1,4 @@
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Diagnostics;
 using GSCode.Core.Symbols;
@@ -57,6 +57,22 @@ public class WorkspaceDiagnosticBatchTests
             Analyze("#using scripts\\shared\\util;\n#using scripts\\shared\\array;\n")));
     }
 
+    /// <summary>
+    /// The rule as the server runs it: the shared per-node walk, gated on `Applies`, which stands
+    /// the rule down on a game that bundles no builtin library.
+    /// </summary>
+    private static ImmutableArray<Diagnostic> RunVoidResultLint(ParseResult result, BuiltinApi builtins)
+    {
+        if ( !VoidResultLint.Applies(builtins) )
+        {
+            return [];
+        }
+
+        return NodeLintHarness.Run(
+            result,
+            (node, diagnostics) => VoidResultLint.InspectNode(node, builtins, diagnostics));
+    }
+
     // --- 5019: keeping the result of something that returns nothing ---
 
     [Fact]
@@ -64,7 +80,7 @@ public class WorkspaceDiagnosticBatchTests
     {
         BuiltinApi builtins = ApiLoader.Load(ApiDirectory, ScriptLanguage.Gsc);
 
-        Diagnostic diagnostic = Assert.Single(VoidResultLint.Analyze(
+        Diagnostic diagnostic = Assert.Single(RunVoidResultLint(
             Analyze("function f()\n{\n\tx = PrintLn( \"a\" );\n}\n"), builtins));
 
         Assert.Equal(GscDiagnosticCode.VoidResultAssigned, diagnostic.Code);
@@ -76,7 +92,7 @@ public class WorkspaceDiagnosticBatchTests
         // The mistake is only visible where the value is KEPT; the call itself is ordinary.
         BuiltinApi builtins = ApiLoader.Load(ApiDirectory, ScriptLanguage.Gsc);
 
-        Assert.Empty(VoidResultLint.Analyze(
+        Assert.Empty(RunVoidResultLint(
             Analyze("function f()\n{\n\tPrintLn( \"a\" );\n}\n"), builtins));
     }
 
@@ -85,7 +101,7 @@ public class WorkspaceDiagnosticBatchTests
     {
         BuiltinApi builtins = ApiLoader.Load(ApiDirectory, ScriptLanguage.Gsc);
 
-        Assert.Empty(VoidResultLint.Analyze(
+        Assert.Empty(RunVoidResultLint(
             Analyze("function f()\n{\n\tt = GetTime();\n}\n"), builtins));
     }
 
@@ -96,7 +112,7 @@ public class WorkspaceDiagnosticBatchTests
         // end on others is legal, so the same claim about a script function would be a guess.
         BuiltinApi builtins = ApiLoader.Load(ApiDirectory, ScriptLanguage.Gsc);
 
-        Assert.Empty(VoidResultLint.Analyze(
+        Assert.Empty(RunVoidResultLint(
             Analyze("function f()\n{\n\tx = helper();\n}\nfunction helper()\n{\n}\n"), builtins));
     }
 

--- a/server/tests/GSCode.Workspace.Tests/Api/MacroArgumentSpanTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Api/MacroArgumentSpanTests.cs
@@ -1,0 +1,164 @@
+using System.Collections.Immutable;
+using GSCode.Core;
+using GSCode.Core.Symbols;
+using GSCode.Core.Text;
+using GSCode.Parser;
+using GSCode.Parser.Preprocessing;
+using GSCode.Workspace.Api;
+using Xunit;
+
+namespace GSCode.Workspace.Tests.Api;
+
+/// <summary>
+/// The macro parameter-name inlay hints, as the handler computes them: from an invocation's name
+/// range to a POSITION for each argument.
+///
+/// The hint answers with a line and a character, so unlike the hover it is wrong visibly and
+/// silently — a label one character off sits inside the argument it names. These pin the spans
+/// against the file they came from rather than against a hand-written offset.
+/// </summary>
+public class MacroArgumentSpanTests
+{
+    private static ParseResult Analyze(string source)
+    {
+        return ScriptAnalysis.Analyze(
+            @"c:\ws\scripts\t.gsc", ScriptLanguage.Gsc, SourceText.From(source), NullInsertProvider.Instance, new NameTable());
+    }
+
+    /// <summary>Mirrors the handler: find the invocation, then the spans of what it was passed.</summary>
+    private static ImmutableArray<MacroArgumentSpan> SpansAt(ParseResult result, string macroName)
+    {
+        foreach ( MacroInvocation invocation in result.Preprocessed.MacroInvocations )
+        {
+            if ( invocation.SourceFile is not null || !string.Equals(invocation.Name, macroName, StringComparison.Ordinal) )
+            {
+                continue;
+            }
+
+            int afterName = result.Text.GetOffset(invocation.Range.End);
+            return MacroExpansionPreview.ArgumentSpansFollowing(result.Text.Text, afterName);
+        }
+
+        throw new InvalidOperationException($"no invocation of {macroName} found");
+    }
+
+    [Fact]
+    public void TheSpanStartsAtTheArgumentsFirstCharacter()
+    {
+        // The reported shape, and the one the hint is judged by: `__a:` goes immediately before
+        // `level`, not before the space or the parenthesis.
+        const string source =
+            "#define IS_TRUE(__a) (isdefined(__a) && __a)\n"
+            + "function f()\n"
+            + "{\n"
+            + "    if ( IS_TRUE( level.ready ) )\n"
+            + "    {\n"
+            + "    }\n"
+            + "}\n";
+
+        ParseResult result = Analyze(source);
+        MacroArgumentSpan span = Assert.Single(SpansAt(result, "IS_TRUE"));
+
+        Assert.Equal("level.ready", result.Text.Text[span.Start..span.End]);
+
+        Position position = result.Text.GetPosition(span.Start);
+        Assert.Equal(3, position.Line);
+        Assert.Equal(source.Split('\n')[3].IndexOf("level", StringComparison.Ordinal), position.Character);
+    }
+
+    [Fact]
+    public void EverySpanAgreesWithTheTextTheHoverShows()
+    {
+        // Hover and hints read the same scan, so a hint can never name an argument the hover
+        // reports differently.
+        const string source =
+            "#define PAIR(a, b) use( a, b )\n"
+            + "function f()\n"
+            + "{\n"
+            + "    PAIR( first( x, y ), things[0, 1] );\n"
+            + "}\n";
+
+        ParseResult result = Analyze(source);
+
+        MacroInvocation invocation = Assert.Single(result.Preprocessed.MacroInvocations);
+        int afterName = result.Text.GetOffset(invocation.Range.End);
+
+        ImmutableArray<string> texts = MacroExpansionPreview.ArgumentsFollowing(result.Text.Text, afterName);
+        ImmutableArray<MacroArgumentSpan> spans = MacroExpansionPreview.ArgumentSpansFollowing(result.Text.Text, afterName);
+
+        // Compared as arrays: ImmutableArray's own Equals is reference equality on the backing
+        // store, so two matching arrays would fail the value comparison this is asking for.
+        Assert.Equal(["first( x, y )", "things[0, 1]"], texts.ToArray());
+        string[] fromSpans = [.. spans.Select(span => result.Text.Text[span.Start..span.End])];
+        Assert.Equal(texts.ToArray(), fromSpans);
+    }
+
+    [Fact]
+    public void AnArgumentOnItsOwnLineKeepsThatLine()
+    {
+        // A macro call broken across lines is normal in this code, and an offset-to-position
+        // conversion that ignored newlines would stack both hints on the first line.
+        const string source =
+            "#define PAIR(a, b) use( a, b )\n"
+            + "function f()\n"
+            + "{\n"
+            + "    PAIR(\n"
+            + "        one,\n"
+            + "        two );\n"
+            + "}\n";
+
+        ParseResult result = Analyze(source);
+        ImmutableArray<MacroArgumentSpan> spans = SpansAt(result, "PAIR");
+
+        Assert.Equal(2, spans.Length);
+        Assert.Equal(new Position(4, 8), result.Text.GetPosition(spans[0].Start));
+        Assert.Equal(new Position(5, 8), result.Text.GetPosition(spans[1].Start));
+    }
+
+    [Fact]
+    public void AnObjectLikeMacroHasNothingToLabel()
+    {
+        const string source =
+            "#define MAX_PLAYERS 18\n"
+            + "function f()\n"
+            + "{\n"
+            + "    x = MAX_PLAYERS;\n"
+            + "}\n";
+
+        ParseResult result = Analyze(source);
+
+        // The definition carries no parameters, which is what the handler gates on, and the text
+        // after the name is not an argument list either.
+        MacroInvocation invocation = Assert.Single(result.Preprocessed.MacroInvocations);
+        Assert.Null(invocation.Definition.Parameters);
+        Assert.Empty(SpansAt(result, "MAX_PLAYERS"));
+    }
+
+    [Fact]
+    public void AHalfWrittenInvocationLabelsWhatIsThere()
+    {
+        // Every keystroke reaches this handler, so an unterminated argument list is the normal
+        // state rather than an error case.
+        ImmutableArray<MacroArgumentSpan> spans =
+            MacroExpansionPreview.ArgumentSpansFollowing("PAIR( one, tw", afterName: 4);
+
+        Assert.Equal(2, spans.Length);
+        Assert.Equal("one", "PAIR( one, tw"[spans[0].Start..spans[0].End]);
+        Assert.Equal("tw", "PAIR( one, tw"[spans[1].Start..spans[1].End]);
+    }
+
+    [Fact]
+    public void AnEmptyArgumentListYieldsNoSpans()
+    {
+        Assert.Empty(MacroExpansionPreview.ArgumentSpansFollowing("NONE()", afterName: 4));
+        Assert.Empty(MacroExpansionPreview.ArgumentSpansFollowing("NONE(  )", afterName: 4));
+    }
+
+    [Fact]
+    public void AMacroFollowedByAnUnrelatedParenthesisIsNotAnArgumentList()
+    {
+        // `MAX_PLAYERS` on its own line, with a call on the next: the scan skips whitespace, so it
+        // must not walk past the end of the invocation into whatever follows.
+        Assert.Empty(MacroExpansionPreview.ArgumentSpansFollowing("MAX_PLAYERS;\n    f( x );", afterName: 11));
+    }
+}

--- a/server/tests/GSCode.Workspace.Tests/Api/MacroExpansionPreviewTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Api/MacroExpansionPreviewTests.cs
@@ -113,20 +113,69 @@ public class MacroExpansionPreviewTests
     }
 
     [Fact]
-    public void MultiLineMacro_CollapsesItsContinuations()
+    public void MultiLineMacro_KeepsItsLinesAndDropsItsBackslashes()
     {
-        // The reported NEW_STATE shape: a multi-statement body joined by backslashes.
+        // The reported NEW_STATE shape: a multi-statement body joined by backslashes. The body
+        // opens on the #define's own line, so the base column is out at that opening statement and
+        // the continuations underneath it clamp to the left margin rather than going negative.
         string source = "#define NEW_STATE(__state) flagsys::clear( \"ready\" ); \\\n"
             + "    _str_state = __state; \\\n"
             + "    self notify( __state );\n";
 
         string preview = MacroExpansionPreview.Render(BodyOf(source, "NEW_STATE"));
 
-        // One line, no backslashes, and the statements still separated.
         Assert.DoesNotContain("\\", preview);
-        Assert.DoesNotContain("\n", preview);
-        Assert.Contains("flagsys::clear", preview);
-        Assert.Contains("notify", preview);
+        Assert.Equal(
+            // `notify` lexes as a keyword rather than an identifier, so the spacing heuristic does
+            // not hug its parenthesis. That is the heuristic's own pre-existing answer; what this
+            // test is about is the three lines it is spread over.
+            "flagsys::clear(\"ready\");\n_str_state = __state;\nself notify (__state);",
+            preview);
+    }
+
+    /// <summary>
+    /// The reported REGISTER_SYSTEM shape, and the reason indentation is relative: the whole body
+    /// sits one level in from a `#define` at column 0, so rendering the author's ABSOLUTE columns
+    /// would push every line of every macro to the right inside the code fence.
+    /// </summary>
+    [Fact]
+    public void MultiLineMacro_IndentsRelativeToItsFirstLine()
+    {
+        string source = "#define REGISTER_SYSTEM(__sys,__func,__reqs) \\\n"
+            + "    function autoexec __init__system__() { \\\n"
+            + "        system::register(__sys,__func,undefined,__reqs); \\\n"
+            + "    }\n";
+
+        string preview = MacroExpansionPreview.Render(BodyOf(source, "REGISTER_SYSTEM"));
+
+        Assert.Equal(
+            "function autoexec __init__system__() {\n"
+            + "    system::register(__sys, __func, undefined, __reqs);\n"
+            + "}",
+            preview);
+    }
+
+    /// <summary>
+    /// The same header written with TABS. A tab is one character in a token's range, so rendering
+    /// the difference between two columns gave a tab-indented body a one-space step — the structure
+    /// present and unreadable. Levels are ranked instead, so how the file was indented does not
+    /// reach the preview.
+    /// </summary>
+    [Fact]
+    public void MultiLineMacro_RendersTabsAndSpacesTheSame()
+    {
+        string spaces = "#define REGISTER_SYSTEM(__sys,__func,__reqs) \\\n"
+            + "    function autoexec __init__system__() { \\\n"
+            + "        system::register(__sys,__func,undefined,__reqs); \\\n"
+            + "    }\n";
+        string tabs = "#define REGISTER_SYSTEM(__sys,__func,__reqs) \\\n"
+            + "\tfunction autoexec __init__system__() { \\\n"
+            + "\t\tsystem::register(__sys,__func,undefined,__reqs); \\\n"
+            + "\t}\n";
+
+        Assert.Equal(
+            MacroExpansionPreview.Render(BodyOf(spaces, "REGISTER_SYSTEM")),
+            MacroExpansionPreview.Render(BodyOf(tabs, "REGISTER_SYSTEM")));
     }
 
     [Fact]

--- a/server/tests/GSCode.Workspace.Tests/Cache/SqliteCacheTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Cache/SqliteCacheTests.cs
@@ -98,9 +98,16 @@ public class SqliteCacheTests : IDisposable
 
         await using ( SqliteCache reopened = SqliteCache.Open(_dbPath, "identity-a") )
         {
-            IReadOnlyDictionary<string, ScriptRecord> restored = reopened.LoadAll();
+            IReadOnlyDictionary<string, CachedEntry> restored = reopened.LoadAll();
 
-            ScriptRecord loaded = Assert.Single(restored).Value;
+            CachedEntry entry = Assert.Single(restored).Value;
+
+            // The hash comes off its own COLUMN now, not out of the blob, and that is the whole
+            // reason a warm start can decide a file is stale without deserializing it.
+            Assert.Equal(record.ContentHash, entry.ContentHash);
+
+            ScriptRecord? loaded = entry.Materialize();
+            Assert.NotNull(loaded);
             Assert.Equal(record.Path, loaded.Path);
             Assert.Equal(record.ContentHash, loaded.ContentHash);
             Assert.Equal("Sample", Assert.Single(loaded.Functions).Name);
@@ -186,12 +193,19 @@ public class SqliteCacheTests : IDisposable
 
         await using ( SqliteCache reopened = SqliteCache.Open(_dbPath, "id") )
         {
-            IReadOnlyDictionary<string, ScriptRecord> restored = reopened.LoadAll();
+            IReadOnlyDictionary<string, CachedEntry> restored = reopened.LoadAll();
 
             Assert.Equal(8, restored.Count);
             for ( int index = 0; index < 8; index++ )
             {
-                ScriptRecord loaded = restored[PathUtil.NormalizeAbsolute(@$"c:\ws\scripts\keep{index}.gsc")];
+                CachedEntry entry = restored[PathUtil.NormalizeAbsolute(@$"c:\ws\scripts\keep{index}.gsc")];
+
+                // Both sides of the row, because leakage between records is what this test is for:
+                // the column the freshness check reads, and the blob behind it.
+                Assert.Equal((ulong)(100 + index), entry.ContentHash);
+
+                ScriptRecord? loaded = entry.Materialize();
+                Assert.NotNull(loaded);
                 Assert.Equal((ulong)(100 + index), loaded.ContentHash);
             }
         }
@@ -245,7 +259,7 @@ public class ColdRestoreTests : IDisposable
         (ScriptDatabase db2, WorkspaceIndexer indexer2, _) = Build(files);
         await using ( SqliteCache cache2 = SqliteCache.Open(_dbPath, "id") )
         {
-            IReadOnlyDictionary<string, ScriptRecord> restored = cache2.LoadAll();
+            IReadOnlyDictionary<string, CachedEntry> restored = cache2.LoadAll();
             Assert.Single(restored);
             indexer2.UseCache(cache2, restored);
             await indexer2.IndexAsync(IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);

--- a/server/tests/GSCode.Workspace.Tests/Cache/SqliteCacheTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Cache/SqliteCacheTests.cs
@@ -269,6 +269,56 @@ public class ColdRestoreTests : IDisposable
     }
 
     /// <summary>
+    /// The restore snapshot is released when a pass finishes, and re-read by the one caller that
+    /// indexes twice.
+    ///
+    /// It used to be held for the life of the indexer, which is a singleton in the server: a bo3
+    /// workspace kept 21 MB of gzipped blobs and a bo1 one 64 MB, long after the last file that
+    /// could restore from them was indexed. Both halves are pinned here because either alone is a
+    /// bug — never releasing wastes the memory, and releasing without a way back makes every
+    /// workspace-folder change a cold index.
+    /// </summary>
+    [Fact]
+    public async Task RestoreSnapshot_IsReleasedAfterAPassAndReReadOnDemand()
+    {
+        FakeFileSystem files = new FakeFileSystem()
+            .AddFile(@$"{Raw}\scripts\a.gsc", "function alpha()\n{\n}\n")
+            .AddFile(@$"{Raw}\scripts\b.gsc", "function beta()\n{\n}\n");
+
+        // First cold start populates the cache.
+        (ScriptDatabase _, WorkspaceIndexer indexer1, _) = Build(files);
+        await using ( SqliteCache cache1 = SqliteCache.Open(_dbPath, "id") )
+        {
+            indexer1.UseCache(cache1, cache1.LoadAll());
+            await indexer1.IndexAsync(IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+        }
+
+        (ScriptDatabase _, WorkspaceIndexer indexer2, _) = Build(files);
+        await using ( SqliteCache cache2 = SqliteCache.Open(_dbPath, "id") )
+        {
+            indexer2.UseCache(cache2, cache2.LoadAll());
+
+            IndexOutcome warm = await indexer2.IndexAsync(
+                IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+            Assert.Equal(2, warm.Restored);
+
+            // Same indexer, same attached cache, no reload: the snapshot is gone, so this pass has
+            // nothing to restore from and analyses both files afresh.
+            IndexOutcome released = await indexer2.IndexAsync(
+                IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+            Assert.Equal(0, released.Restored);
+            Assert.Equal(2, released.Analysed);
+
+            // What the workspace-folder handler does before its second pass.
+            indexer2.ReloadRestoreSnapshot();
+
+            IndexOutcome reloaded = await indexer2.IndexAsync(
+                IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+            Assert.Equal(2, reloaded.Restored);
+        }
+    }
+
+    /// <summary>
     /// The restored/analysed split is what labels a run cold or warm in the memory report, and
     /// the two have very different allocation profiles, so the counts have to be truthful.
     /// </summary>

--- a/server/tests/GSCode.Workspace.Tests/Completion/CompletionEngineTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/CompletionEngineTests.cs
@@ -714,7 +714,13 @@ public class CompletionEngineTests
 
         Assert.True(HasLabel(entries, "function"));
         Assert.True(HasLabel(entries, "class"));
-        Assert.False(HasLabel(entries, "if"));
+
+        // The expression atoms come too, and `if` with them. A top-level macro invocation is a
+        // CALL, so file scope is not the declarations-only position it looks like: the shipped BO3
+        // scripts pass `undefined` to REGISTER_SYSTEM 467 times. Telling an atom apart from a
+        // control-flow word would be a rule to maintain in exchange for suppressing a word nobody
+        // types here by accident.
+        Assert.True(HasLabel(entries, "undefined"));
     }
 
     // --- Call punctuation ---
@@ -756,6 +762,38 @@ public class CompletionEngineTests
     public void AStatementCallGetsItsSemicolon(string line)
     {
         Assert.EndsWith("($0);", CallEntry(line).InsertText, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// File scope holds no statements, so nothing completed there takes a terminator. The construct
+    /// that stands alone at that position is a macro invocation expanding to a DECLARATION —
+    /// REGISTER_SYSTEM writes `function autoexec ...() { }` — and all 447 of its uses in the shipped
+    /// BO3 scripts are written without one. Left to itself IsStatementPosition scans back, finds the
+    /// previous function's '}' and answers true, which is right in a body and meaningless outside
+    /// one.
+    /// </summary>
+    [Fact]
+    public void AFileScopeCallTakesNoSemicolon()
+    {
+        FakeFileSystem files = new FakeFileSystem()
+            .AddFile(@$"{Raw}\scripts\util.gsc", "#namespace util;\nfunction foo()\n{\n}\n");
+
+        (CompletionEngine engine, _, _) = BuildWorld(files);
+
+        // The caret sits on the blank line after run()'s closing brace — where a REGISTER_SYSTEM
+        // line goes.
+        string text = "#namespace util;\nfunction run()\n{\n}\n\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+
+        ImmutableArray<CompletionEntry> entries = engine.Complete(
+            result, "raw", new Position(4, 0), callPunctuation: CallPunctuation.ParensAndSemicolon);
+
+        CompletionEntry entry = Assert.Single(
+            entries,
+            e => e.Kind == CompletionKind.Function && e.Label == "foo");
+
+        Assert.EndsWith("($0)", entry.InsertText, StringComparison.Ordinal);
+        Assert.DoesNotContain(";", entry.InsertText, StringComparison.Ordinal);
     }
 
     [Theory]

--- a/server/tests/GSCode.Workspace.Tests/Completion/CompletionEngineTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/CompletionEngineTests.cs
@@ -833,6 +833,69 @@ public class CompletionEngineTests
         Assert.EndsWith("($0)", CallEntry("x = get_ready() + ").InsertText, StringComparison.Ordinal);
     }
 
+    // --- Function pointers ---
+    //
+    // `&foo` NAMES a function; `&foo()` calls it and takes the address of the result. BO3 writes
+    // 4,564 pointers and only four `&name(` of any kind, so the parentheses this file adds
+    // everywhere else are a correction the user has to undo here.
+
+    [Theory]
+    [InlineData("level.on_death = &")]      // stored on an object
+    [InlineData("thread run( &")]           // passed as an argument
+    [InlineData("&")]                       // and at the start of a statement
+    public void AFunctionPointerTakesNoParentheses(string line)
+    {
+        Assert.Equal("foo", CallEntry(line).InsertText);
+    }
+
+    /// <summary>
+    /// The other 585: a pointer written through a namespace. The '::' arm produces the list, and it
+    /// reached CallSnippet by the same route the bare name does.
+    /// </summary>
+    [Fact]
+    public void ANamespaceQualifiedPointerTakesNoneEither()
+    {
+        Assert.Equal("foo", CallEntry("level.on_death = &util::").InsertText);
+    }
+
+    /// <summary>
+    /// Pre-BO3 an '&amp;' is arithmetic — a pointer there is a bare qualified name, with no operator to
+    /// key on — so the call after one is still a call and still takes its punctuation.
+    /// </summary>
+    [Fact]
+    public void AnAmpersandIsArithmeticInTheInfinityWardLine()
+    {
+        GameProfile cod4 = GameProfile.ByName("cod4")!;
+
+        (CompletionEngine engine, _, _) = BuildWorld(new FakeFileSystem());
+
+        // Asserted on a BUILTIN rather than a script function: the indexer parses the workspace
+        // with the active profile, so a merge dialect's `foo() { }` in a fixture file extracts to
+        // nothing and the store would have had no function to offer.
+        string text = "main()\n{\n    x = mask & \n}\n";
+        ParseResult result = ScriptAnalysis.Analyze(
+            @$"{Raw}\maps\mp\test.gsc",
+            ScriptAnalysis.LanguageFromPath(@$"{Raw}\maps\mp\test.gsc"),
+            SourceText.From(text),
+            GSCode.Parser.Preprocessing.NullInsertProvider.Instance,
+            new NameTable(),
+            cod4);
+
+        ImmutableArray<CompletionEntry> entries = engine.Complete(
+            result,
+            "raw",
+            new Position(2, 15),
+            callPunctuation: CallPunctuation.ParensAndSemicolon,
+            profile: cod4);
+
+        CompletionEntry entry = Assert.Single(entries, e => e.Label == "Vibrate");
+
+        // Parentheses, where the same position in BO3 would complete to the bare name. No
+        // semicolon, but that is the operand rule rather than the dialect: `x = a + f()` does not
+        // end a statement either.
+        Assert.Equal("Vibrate($0)", entry.InsertText);
+    }
+
     // --- Call-shaped keywords ---
     //
     // The distinction is expression-versus-statement, not keyword-versus-function: `isdefined` is

--- a/server/tests/GSCode.Workspace.Tests/Completion/DialectCompletionTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/DialectCompletionTests.cs
@@ -172,6 +172,33 @@ public class DialectCompletionTests
         Assert.DoesNotContain(entries, e => e.Detail == "global");
     }
 
+    /// <summary>
+    /// File scope now runs the same producers a body does, so the dialect gating has to hold at a
+    /// position it never used to reach. CoD4 has no preprocessor and no class system, so neither a
+    /// macro row nor a BO3 declaration keyword may appear there.
+    /// </summary>
+    [Fact]
+    public void Cod4FileScopeStaysWithinTheDialect()
+    {
+        CompletionEngine engine = BuildEngine();
+        ParseResult result = ScriptAnalysis.Analyze(
+            @$"{Raw}\maps\mp\test.gsc",
+            ScriptLanguage.Gsc,
+            SourceText.From("#define CAP 5\n\nmain()\n{\n}\n"),
+            GSCode.Parser.Preprocessing.NullInsertProvider.Instance,
+            new NameTable(),
+            Cod4);
+
+        ImmutableArray<CompletionEntry> entries = engine.Complete(result, "raw", new Position(1, 0), profile: Cod4);
+
+        Assert.DoesNotContain(entries, e => e.Kind == CompletionKind.Macro);
+        Assert.DoesNotContain(entries, e => e.Label == "class");
+        Assert.DoesNotContain(entries, e => e.Label == "#using");
+
+        // The dialect's own file-scope word is still there, so this is not passing on an empty list.
+        Assert.Contains(entries, e => e.Label == "#include");
+    }
+
     // --- Dialect-gated snippets ---
     //
     // These used to be contributed by the extension, which registers a snippet per LANGUAGE ID and

--- a/server/tests/GSCode.Workspace.Tests/Completion/DialectCompletionTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/DialectCompletionTests.cs
@@ -153,8 +153,11 @@ public class DialectCompletionTests
     [Fact]
     public void GlobalObjectsAreNotOfferedAtTopLevel()
     {
-        // Outside a function body only declarations and directives are legal, and `self` there is
-        // not a thing anyone can write.
+        // File scope is NOT declarations-only — a top-level macro invocation is a call, so it opens
+        // an expression there — but nothing at that position can be sent a call, so `self` is still
+        // not a thing anyone writes. They are held back on a second count as well: a global is a
+        // Variable, which is the first sort tier, so offering them would put them at the head of
+        // every file-scope list.
         CompletionEngine engine = BuildEngine();
         ParseResult result = ScriptAnalysis.Analyze(
             @$"{Raw}\maps\mp\test.gsc",

--- a/server/tests/GSCode.Workspace.Tests/Completion/FakeInserts.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/FakeInserts.cs
@@ -1,0 +1,41 @@
+using GSCode.Core.Text;
+using GSCode.Parser.Lexing;
+using GSCode.Parser.Preprocessing;
+
+namespace GSCode.Workspace.Tests.Completion;
+
+/// <summary>
+/// Serves a header's text to <c>#insert</c>, so a macro can come from outside the file under test.
+///
+/// Shared rather than nested in one fixture: completion and signature help both have to be asked
+/// about a macro a header supplies, which is where the macros that matter actually live — a shared
+/// .gsh, not the root file.
+/// </summary>
+internal sealed class FakeInserts : IInsertProvider
+{
+    private readonly Dictionary<string, InsertedFile> _files = new(StringComparer.OrdinalIgnoreCase);
+
+    public FakeInserts Add(string rawPath, string content)
+    {
+        SourceText text = SourceText.From(content);
+        _files[rawPath] = new InsertedFile(rawPath.ToLowerInvariant(), text, Lexer.Lex(text).Tokens);
+        return this;
+    }
+
+    public bool TryGetInsert(string rawInsertPath, out InsertedFile inserted)
+    {
+        return _files.TryGetValue(rawInsertPath, out inserted!);
+    }
+
+    public bool TryResolveInsertPath(string rawInsertPath, out string resolvedPath)
+    {
+        if ( _files.TryGetValue(rawInsertPath, out InsertedFile? file) )
+        {
+            resolvedPath = file.Path;
+            return true;
+        }
+
+        resolvedPath = "";
+        return false;
+    }
+}

--- a/server/tests/GSCode.Workspace.Tests/Completion/LocalScopeCompletionTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/LocalScopeCompletionTests.cs
@@ -397,4 +397,83 @@ public class LocalScopeCompletionTests
 
         Assert.NotNull(Entry(entries, "LOCAL_CAP"));
     }
+
+    // --- File scope ---
+    //
+    // Outside every function body the list used to be a static set of words: no macro, no function,
+    // no class reached it, because everything workspace-derived sat below a `!insideFunction`
+    // return. REGISTER_SYSTEM is written at column 0 in 477 of the shipped BO3 scripts and was
+    // never offered once.
+
+    /// <summary>The reported case, at the position it was reported from.</summary>
+    [Fact]
+    public void FileScope_OffersMacrosFromAnInsertedHeader()
+    {
+        CompletionEngine engine = BuildWorld(new FakeFileSystem());
+        FakeInserts inserts = new FakeInserts()
+            .Add(
+                @"scripts\shared\shared.gsh",
+                "#define REGISTER_SYSTEM( sys, func, reqs ) function autoexec __init__sytem__() { }\n#define MAX_PLAYERS 18\n");
+
+        ImmutableArray<CompletionEntry> entries = CompleteAtCaret(
+            engine,
+            @$"{Raw}\scripts\main.gsc",
+            "#insert scripts\\shared\\shared.gsh;\n#namespace game;\n|\nfunction run()\n{\n}\n",
+            inserts);
+
+        CompletionEntry? macro = Entry(entries, "REGISTER_SYSTEM");
+        Assert.NotNull(macro);
+        Assert.Equal(CompletionKind.Macro, macro!.Kind);
+        Assert.Equal("macro (shared.gsh)", macro.Detail);
+
+        // No terminator: the expansion is a declaration, and none of the 447 corpus uses carries one.
+        Assert.Equal("REGISTER_SYSTEM($0)", macro.InsertText);
+
+        // The object-like ones come too. File scope gets the list a body gets, rather than a
+        // narrowed one whose rule would have to grow an exception per construct.
+        Assert.NotNull(Entry(entries, "MAX_PLAYERS"));
+    }
+
+    /// <summary>
+    /// What a macro invocation's ARGUMENTS need. `REGISTER_SYSTEM( "aat", &amp;__init__, undefined )`
+    /// is a call, so file scope is an expression position too: the shipped BO3 scripts write 510
+    /// function pointers and 467 `undefined`s there, and neither was reachable.
+    /// </summary>
+    [Fact]
+    public void FileScope_OffersTheFunctionsInScopeAndTheExpressionAtoms()
+    {
+        CompletionEngine engine = BuildWorld(new FakeFileSystem()
+            .AddFile(@$"{Raw}\scripts\system.gsc", "#namespace game;\nfunction __init__()\n{\n}\n"));
+
+        ImmutableArray<CompletionEntry> entries = CompleteAtCaret(
+            engine,
+            @$"{Raw}\scripts\main.gsc",
+            "#namespace game;\n|\nfunction run()\n{\n}\n");
+
+        Assert.Contains(
+            entries,
+            e => e.Kind == CompletionKind.Function
+                && e.Label.StartsWith("__init__", StringComparison.Ordinal));
+
+        Assert.NotNull(Entry(entries, "undefined"));
+    }
+
+    /// <summary>
+    /// The one category deliberately held back. The engine globals are <c>CompletionKind.Variable</c>,
+    /// which sorts FIRST, so offering them at file scope would put `self` and `level` at the head of
+    /// every list at a position where nothing can be sent on them.
+    /// </summary>
+    [Fact]
+    public void FileScope_DoesNotOfferTheEngineGlobals()
+    {
+        CompletionEngine engine = BuildWorld(new FakeFileSystem());
+
+        ImmutableArray<CompletionEntry> entries = CompleteAtCaret(
+            engine,
+            @$"{Raw}\scripts\main.gsc",
+            "#namespace game;\n|\nfunction run()\n{\n}\n");
+
+        Assert.False(HasVariable(entries, "self"));
+        Assert.False(HasVariable(entries, "level"));
+    }
 }

--- a/server/tests/GSCode.Workspace.Tests/Completion/LocalScopeCompletionTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/LocalScopeCompletionTests.cs
@@ -2,7 +2,6 @@ using System.Collections.Immutable;
 using GSCode.Core;
 using GSCode.Core.Text;
 using GSCode.Parser;
-using GSCode.Parser.Lexing;
 using GSCode.Parser.Preprocessing;
 using GSCode.Workspace.Api;
 using GSCode.Workspace.Completion;
@@ -30,36 +29,6 @@ public class LocalScopeCompletionTests
 {
     private const string Raw = @"C:\bo3\share\raw";
     private static string ApiDirectory => Path.Combine(AppContext.BaseDirectory, "Api");
-
-    /// <summary>Serves one header's text to <c>#insert</c>, so a macro can come from outside the file.</summary>
-    private sealed class FakeInserts : IInsertProvider
-    {
-        private readonly Dictionary<string, InsertedFile> _files = new(StringComparer.OrdinalIgnoreCase);
-
-        public FakeInserts Add(string rawPath, string content)
-        {
-            SourceText text = SourceText.From(content);
-            _files[rawPath] = new InsertedFile(rawPath.ToLowerInvariant(), text, Lexer.Lex(text).Tokens);
-            return this;
-        }
-
-        public bool TryGetInsert(string rawInsertPath, out InsertedFile inserted)
-        {
-            return _files.TryGetValue(rawInsertPath, out inserted!);
-        }
-
-        public bool TryResolveInsertPath(string rawInsertPath, out string resolvedPath)
-        {
-            if ( _files.TryGetValue(rawInsertPath, out InsertedFile? file) )
-            {
-                resolvedPath = file.Path;
-                return true;
-            }
-
-            resolvedPath = "";
-            return false;
-        }
-    }
 
     private static CompletionEngine BuildWorld(FakeFileSystem files)
     {

--- a/server/tests/GSCode.Workspace.Tests/Completion/SignatureEngineTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/SignatureEngineTests.cs
@@ -136,11 +136,33 @@ public class SignatureEngineTests
         Assert.Equal("REGISTER_SYSTEM(sys, func, reqs)", signature!.Label);
         Assert.Equal(1, signature.ActiveParameter);
 
-        // The panel carries the define form, what it expands to, and the trailing comment — the same
-        // markdown hover renders, so the two cannot drift apart.
-        Assert.Contains("#define REGISTER_SYSTEM(sys, func, reqs)", signature.Documentation, StringComparison.Ordinal);
+        // The expansion and the trailing comment, and NOT the `#define` line: the label above is
+        // already the define form, so rendering it again printed the parameter list twice.
         Assert.Contains("autoexec", signature.Documentation, StringComparison.Ordinal);
         Assert.Contains("Registers a system.", signature.Documentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("#define", signature.Documentation, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// A #define with parameters and no body. The horizontal rule divides two things, so with only
+    /// the comment present it would be a rule above nothing.
+    /// </summary>
+    [Fact]
+    public void Macro_WithNoBody_ShowsTheCommentWithoutASeparator()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+
+        string text = "#define NOOP( a ) // Does nothing.\nfunction run()\n{\n    NOOP( \n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+        Position afterParen = new(3, 10);
+
+        SignatureResult? signature = engine.Resolve(result, "raw", afterParen);
+
+        Assert.NotNull(signature);
+        Assert.Equal("NOOP(a)", signature!.Label);
+        Assert.Contains("Does nothing.", signature.Documentation, StringComparison.Ordinal);
+        Assert.DoesNotContain("---", signature.Documentation, StringComparison.Ordinal);
     }
 
     /// <summary>

--- a/server/tests/GSCode.Workspace.Tests/Completion/SignatureEngineTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Completion/SignatureEngineTests.cs
@@ -29,7 +29,12 @@ public class SignatureEngineTests
 
     private static ParseResult Analyze(string path, string text)
     {
-        return ScriptAnalysis.Analyze(path, ScriptAnalysis.LanguageFromPath(path), SourceText.From(text), NullInsertProvider.Instance, new NameTable());
+        return Analyze(path, text, NullInsertProvider.Instance);
+    }
+
+    private static ParseResult Analyze(string path, string text, IInsertProvider inserts)
+    {
+        return ScriptAnalysis.Analyze(path, ScriptAnalysis.LanguageFromPath(path), SourceText.From(text), inserts, new NameTable());
     }
 
     [Fact]
@@ -81,6 +86,110 @@ public class SignatureEngineTests
         Position notInCall = new(2, 9);
 
         Assert.Null(engine.Resolve(result, "raw", notInCall));
+    }
+
+    // --- Macros ---
+    //
+    // A function-like #define is a call with named arguments and nothing described them: the panel
+    // answered nothing at all, in a body and at file scope alike. The names come from the parse in
+    // hand rather than the store, which is what makes a header inserted a keystroke ago count.
+
+    [Fact]
+    public void Macro_ShowsParametersAndActiveIndex()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+
+        string text = "#define GIVE( weapon, ammo ) self giveweapon( weapon )\nfunction run()\n{\n    GIVE( \"x\", \n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+        Position afterComma = new(3, 15);
+
+        SignatureResult? signature = engine.Resolve(result, "raw", afterComma);
+
+        Assert.NotNull(signature);
+        Assert.Equal("GIVE(weapon, ammo)", signature!.Label);
+        Assert.Equal(1, signature.ActiveParameter);
+    }
+
+    /// <summary>
+    /// The reported case: a macro from an <c>#insert</c>ed header, invoked at column 0. Both halves
+    /// were missing — file scope is where the shipped scripts write these, and the header is where
+    /// the macro lives.
+    /// </summary>
+    [Fact]
+    public void Macro_FromAnInsertedHeader_ResolvesAtFileScope()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+        FakeInserts inserts = new FakeInserts()
+            .Add(
+                @"scripts\shared\shared.gsh",
+                "#define REGISTER_SYSTEM( sys, func, reqs ) function autoexec __init__system__() { } // Registers a system.\n");
+
+        string text = "#insert scripts\\shared\\shared.gsh;\n#namespace game;\nREGISTER_SYSTEM( \"aat\", \nfunction run()\n{\n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text, inserts);
+        Position afterComma = new(2, 24);
+
+        SignatureResult? signature = engine.Resolve(result, "raw", afterComma);
+
+        Assert.NotNull(signature);
+        Assert.Equal("REGISTER_SYSTEM(sys, func, reqs)", signature!.Label);
+        Assert.Equal(1, signature.ActiveParameter);
+
+        // The panel carries the define form, what it expands to, and the trailing comment — the same
+        // markdown hover renders, so the two cannot drift apart.
+        Assert.Contains("#define REGISTER_SYSTEM(sys, func, reqs)", signature.Documentation, StringComparison.Ordinal);
+        Assert.Contains("autoexec", signature.Documentation, StringComparison.Ordinal);
+        Assert.Contains("Registers a system.", signature.Documentation, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// An object-like macro is not a call, so it must not answer with an empty signature and take
+    /// the position away from whatever the name would otherwise resolve to.
+    /// </summary>
+    [Fact]
+    public void ObjectLikeMacro_IsNotACall()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+
+        string text = "#define MAX_PLAYERS 18\nfunction run()\n{\n    x = MAX_PLAYERS( \n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+        Position afterParen = new(3, 21);
+
+        Assert.Null(engine.Resolve(result, "raw", afterParen));
+    }
+
+    /// <summary>
+    /// Macro names are the language's one case-SENSITIVE kind, so the lookup is ordinal: the
+    /// preprocessor would not expand <c>is_true(</c> either, and answering with IS_TRUE's parameters
+    /// would describe an expansion that never happens.
+    /// </summary>
+    [Fact]
+    public void Macro_LookupIsCaseSensitive()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+
+        string text = "#define IS_TRUE( value ) isdefined( value ) && value\nfunction run()\n{\n    x = is_true( \n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+        Position afterParen = new(3, 17);
+
+        Assert.Null(engine.Resolve(result, "raw", afterParen));
+    }
+
+    /// <summary>A qualified name is a namespace member, and the preprocessor expands no such thing.</summary>
+    [Fact]
+    public void QualifiedName_DoesNotReachAMacro()
+    {
+        FakeFileSystem files = new FakeFileSystem().AddFile(@$"{Raw}\scripts\d.gsc", "function d()\n{\n}\n");
+        SignatureEngine engine = BuildEngine(files);
+
+        string text = "#define IS_TRUE( value ) isdefined( value ) && value\nfunction run()\n{\n    x = util::IS_TRUE( \n}\n";
+        ParseResult result = Analyze(@$"{Raw}\scripts\main.gsc", text);
+        Position afterParen = new(3, 23);
+
+        Assert.Null(engine.Resolve(result, "raw", afterParen));
     }
 }
 

--- a/server/tests/GSCode.Workspace.Tests/Indexing/IndexerInsertCacheTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Indexing/IndexerInsertCacheTests.cs
@@ -1,0 +1,87 @@
+using GSCode.Core;
+using GSCode.Core.Paths;
+using GSCode.Core.Symbols;
+using GSCode.Workspace.Database;
+using GSCode.Workspace.Indexing;
+using GSCode.Workspace.Resolution;
+using GSCode.Workspace.Tests.Resolution;
+using Xunit;
+
+namespace GSCode.Workspace.Tests.Indexing;
+
+/// <summary>
+/// The indexer and the document path share ONE header cache.
+///
+/// They did not. The indexer kept a private <c>ConcurrentDictionary&lt;path,
+/// Lazy&lt;InsertedFile?&gt;&gt;</c> while the same constructor was already handed the
+/// <see cref="InsertCache"/> that the editor's providers use, so a workspace held BO3's 114 headers
+/// twice over and each side warmed the other's copy not at all. Every assertion below reads false
+/// against that shape.
+/// </summary>
+public class IndexerInsertCacheTests
+{
+    private const string Raw = @"C:\bo3\share\raw";
+
+    private static (WorkspaceIndexer Indexer, InsertCache Inserts) Build(FakeFileSystem files)
+    {
+        RootConfig config = RootConfig.Create(true, Raw, @"C:\bo3\mods", [], files);
+        PathResolver resolver = new(config, files);
+        ScriptDatabase database = new();
+        InsertCache inserts = new();
+        return (new WorkspaceIndexer(database, () => resolver, files, new NameTable(), inserts), inserts);
+    }
+
+    private static FakeFileSystem Workspace()
+    {
+        return new FakeFileSystem()
+            .AddFile(@$"{Raw}\scripts\shared\shared.gsh", "#define CAP 5\n")
+            .AddFile(@$"{Raw}\scripts\uses_it.gsc", "#insert scripts\\shared\\shared.gsh;\nfunction f()\n{\nx = CAP;\n}\n");
+    }
+
+    [Fact]
+    public async Task Indexing_FillsTheCacheTheDocumentPathReads()
+    {
+        FakeFileSystem files = Workspace();
+        (WorkspaceIndexer indexer, InsertCache inserts) = Build(files);
+
+        Assert.Equal(0, inserts.Count);
+
+        await indexer.IndexAsync(IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+
+        // One entry, not two, and in the cache the caller handed in rather than one the indexer
+        // kept to itself. A file opened after this restores the header from here instead of
+        // reading and lexing it again.
+        Assert.Equal(1, inserts.Count);
+    }
+
+    [Fact]
+    public async Task InvalidateGsh_ReachesTheSharedCache()
+    {
+        FakeFileSystem files = Workspace();
+        (WorkspaceIndexer indexer, InsertCache inserts) = Build(files);
+
+        await indexer.IndexAsync(IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+        Assert.Equal(1, inserts.Count);
+
+        // The watcher's fast path when a header changes on disk. It used to drop the indexer's
+        // private copy only, leaving the shared one to the timestamp check one call later.
+        indexer.InvalidateGsh(PathUtil.NormalizeAbsolute(@$"{Raw}\scripts\shared\shared.gsh"));
+
+        Assert.Equal(0, inserts.Count);
+    }
+
+    [Fact]
+    public async Task RemoveFile_DropsADeletedHeaderFromTheSharedCache()
+    {
+        FakeFileSystem files = Workspace();
+        (WorkspaceIndexer indexer, InsertCache inserts) = Build(files);
+
+        await indexer.IndexAsync(IndexingMode.Partial, NullIndexProgressListener.Instance, CancellationToken.None);
+        Assert.Equal(1, inserts.Count);
+
+        indexer.RemoveFile(
+            PathUtil.NormalizeAbsolute(@$"{Raw}\scripts\shared\shared.gsh"), ScriptLanguage.Gsh);
+
+        Assert.Equal(0, inserts.Count);
+    }
+}

--- a/server/tests/GSCode.Workspace.Tests/Resolution/FakeFileSystem.cs
+++ b/server/tests/GSCode.Workspace.Tests/Resolution/FakeFileSystem.cs
@@ -1,4 +1,4 @@
-using GSCode.Core.Paths;
+﻿using GSCode.Core.Paths;
 using GSCode.Workspace.Resolution;
 
 namespace GSCode.Workspace.Tests.Resolution;
@@ -45,11 +45,6 @@ public sealed class FakeFileSystem : IFileSystem
     public DateTime GetLastWriteTimeUtc(string absolutePath)
     {
         return FileExists(absolutePath) ? DateTime.UnixEpoch : DateTime.MinValue;
-    }
-
-    public IEnumerable<string> EnumerateFiles(string directory, string searchPattern)
-    {
-        return EnumerateFilesWithExtensions(directory, [searchPattern.TrimStart('*')]);
     }
 
     public IEnumerable<string> EnumerateFilesWithExtensions(

--- a/server/tests/GSCode.Workspace.Tests/Resolution/PathResolverTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Resolution/PathResolverTests.cs
@@ -1,4 +1,4 @@
-using GSCode.Core.Paths;
+﻿using GSCode.Core.Paths;
 using GSCode.Workspace.Resolution;
 using Xunit;
 
@@ -336,12 +336,6 @@ public class PathResolverTests
         public DateTime GetLastWriteTimeUtc(string absolutePath)
         {
             return _inner.GetLastWriteTimeUtc(absolutePath);
-        }
-
-        public IEnumerable<string> EnumerateFiles(string directory, string searchPattern)
-        {
-            EnumerationCount++;
-            return _inner.EnumerateFiles(directory, searchPattern);
         }
 
         public IEnumerable<string> EnumerateFilesWithExtensions(

--- a/server/tests/GSCode.Workspace.Tests/Typing/ScriptTypesTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Typing/ScriptTypesTests.cs
@@ -1,4 +1,4 @@
-using GSCode.Core;
+﻿using GSCode.Core;
 using GSCode.Core.Symbols;
 using GSCode.Core.Text;
 using GSCode.Parser;
@@ -226,13 +226,34 @@ public class ScriptTypesTests
     {
         // The hint and hover passes ask about one name or one position, and must not pay for a whole
         // file's map to answer it. Two passes on one instance must not interfere either.
+        //
+        // The two InferValues calls are given SEPARATE parses of the same source deliberately: one
+        // parse twice would be answered from the memo, and the property under test is that a real
+        // second recording pass is unaffected by the InferAssignments that ran between them.
+        FlowTyper typer = NewTyper();
+
+        ScriptTypes first = typer.InferValues(Parse("    x = 1;"));
+        typer.InferAssignments(Parse("    x = 1;"));
+        ScriptTypes second = typer.InferValues(Parse("    x = 1;"));
+
+        Assert.Equal(first.Count, second.Count);
+    }
+
+    [Fact]
+    public void OneParseIsTypedOnce()
+    {
+        // Three lints ask this typer for the same file's types. Asking twice for one parse must hand
+        // back the SAME object rather than walking again, and a different parse must not be answered
+        // from the first one's memo — reference identity is the whole of the invalidation rule.
         FlowTyper typer = NewTyper();
         ParseResult result = Parse("    x = 1;");
 
         ScriptTypes first = typer.InferValues(result);
-        typer.InferAssignments(result);
-        ScriptTypes second = typer.InferValues(result);
+        ScriptTypes again = typer.InferValues(result);
+        Assert.Same(first, again);
 
-        Assert.Equal(first.Count, second.Count);
+        ScriptTypes other = typer.InferValues(Parse("    x = 1;"));
+        Assert.NotSame(first, other);
+        Assert.Equal(first.Count, other.Count);
     }
 }

--- a/server/tests/GSCode.Workspace.Tests/Typing/ScriptTypesTests.cs
+++ b/server/tests/GSCode.Workspace.Tests/Typing/ScriptTypesTests.cs
@@ -1,4 +1,4 @@
-﻿using GSCode.Core;
+using GSCode.Core;
 using GSCode.Core.Symbols;
 using GSCode.Core.Text;
 using GSCode.Parser;


### PR DESCRIPTION
# Perf pass over indexing and the lint pipeline, dialect samples, a game picker, and macro-aware completion and signature help

41 commits, 142 files, +10,777 / −884 against `upstream/main`. Rebased onto it, so this
fast-forwards.

| area | files |
|---|---:|
| `server/src` | 50 |
| `server/samples` | 44 |
| `server/tests` | 35 |
| `client` | 8 |
| docs (`PERF.md`, `ARCHITECTURE.md`, `GAME_PROFILES.md`, `README.md`) | 4 |
| `.claude/skills` | 1 |

Five pieces of work. The first three share one theme: the server was fast enough that nobody could say *where*
it spent its time, correct enough that nobody could see *which dialect* a rule spoke for, and
configurable in a way nobody could reach. Each part measures the thing before changing it, and says
so when the measurement came back "no". The last two are feature asks that arrived on top: inlay
hints for macro arguments, and a completion list and a signature widget that know what a macro is.

---

## 1. Performance — measured, not guessed

Every number below is from a `GscodeInstrumentation` build over real stock corpora, recorded in
`PERF.md` beside the change that produced it. bo3 and cod4 are the two swept, since they cover both
dialect shapes; bo1 joins wherever the quantity scales with corpus size rather than grammar.

### Where the time went

| | before | after |
|---|---:|---:|
| lint pass, bo3, 980 files | 2,191 ms | **1,332 ms** |
| lint median / p99 / max | 0.61 / 23.1 / 95.1 ms | **0.31 / 19.0 / 47.0 ms** |
| completion, 6,381 requests | p99 4.22–4.26 ms | **p99 2.12 ms**, median 0.30 |
| cold index, 1,085 files | 1,714–1,732 ms | **1,620 ms** |
| file enumeration, a real game install | 741–792 ms | **231–233 ms** |
| retained after a warm index (bo3 / cod4) | 82.2 / 74.4 MB | **68.8 / 61.0 MB** |
| analysis, 980 files | 612 ms | 685 ms — unchanged within noise |

### What actually moved

**The lint pipeline was costing more than the parse.** Four changes, each measured on its own:

- **Nine per-node rules now share one AST walk** instead of nine. 1,151 → 703 ms on bo3 across three
  paired runs.
- **The three type rules share one inference walk.** The flow typer ran once per rule; it now types a
  file once. 851 → 467 ms, taking the type rules from 31% of the lint pass to 18%.
- **The child walk stopped allocating once per node visited.** The 14 rules that walk the AST went
  1,783 → 1,423 ms (−20%).
- **A namespace index**, built for `ArgumentCountLint` and paid off somewhere else entirely: completion
  total 5,633–5,794 → 2,996–3,030 ms, p99 halved. The store is indexed by namespace instead of walked
  once per namespace.

**Enumeration was the bottleneck the corpus fixtures could not see.** Every figure in `PERF.md` had
been taken with a `raw` folder as the root — but a modder routinely opens the game install, and then
the walk covers everything: **295,640 files walked to find 1,105 scripts.** It was reported as part of
"indexing", so it read as slow analysis, when the analysis was under half a second of a 2.8 s log
line. Fanning out across top-level subtrees plus pruning exactly two tool-output trees
(`assetconvert`, `texture_assets`, named in `GameProfile.ToolOutputDirectories`) takes it to
231–233 ms. `zone`, `sound` and `video` were measured too and are deliberately **not** pruned — they
cost nothing on top of those two, and each is a name a mod could plausibly give a scripts folder. A
directory wrongly skipped is a file that silently never gets indexed.

**Startup stopped deserializing the whole cache on one thread** before indexing could begin, and the
per-file index diff stopped serialising against every other file's. Cache blobs are released once the
index that needed them is done, and the workspace's headers live in one cache instead of two — the
private copy compared paths ordinally on a case-insensitive filesystem, never revalidated, and cached
a failed read as a permanent absence.

**The GC settled at eight heaps**, after going 1 → 8 → 4 → 8 with each step measured on the real
server rather than a harness. Resting after compaction: 125.0–126.8 MB.

### What was measured and deliberately NOT done

Three of these are the point of the pass as much as the wins are:

- **The cache open is 85–95% of startup's cache cost** (242.5 ms cold, 68.7–75.4 ms warm) and neither
  of the two things that look expensive — hashing 3.9 MB of JSON is 6 ms. Moving it off the startup
  thread needs a readiness handshake in `CacheHolder` first, or a `gscode/clearCache` arriving in the
  window gets told "No workspace cache is open" while the cache opens behind it, leaving a cache the
  user asked to delete.
- **Enumeration and analysis still do not overlap.** Worth ~1.25 s → ~0.8 s on an install-as-workspace.
  The obstacle is that `progress.Started(count)` needs a total up front and a streamed enumeration has
  none.
- **Two unsharded locks were left alone.** `NamespaceIndex` and `ClassGraph` hold one process-wide lock
  each; the scaling argument that justified sharding the other two applies on paper. Measured: 0.1–0.8%
  of cold-index thread time, nine or ten milliseconds a run. `PERF.md` now carries the row so the next
  person to notice the locks reads it before opening the file.
- **The flow typer's environment cloning is not worth attacking** — recorded so it does not get
  re-investigated.

### Two claims retracted

- `PERF.md` said extraction's share on the `#insert` dialect had "roughly doubled" and that the move
  "survives both runs and is therefore real". It does not survive four. Five sweeps inside twenty
  minutes, the last four on a byte-identical build, read bo3 extract at 21/13/18/15/18 and bo3 lex at
  26/40/30/31/35. The 6-point move called real was inside the instrument's spread.
- The header-cache merge freed **nothing** measurable. bo3 and cod4 read 68.8 and 61.0 MB with the
  blob release alone, and the same two numbers to the decimal with the merge on top. That change now
  stands on the duplicate it removes and the three defects the surviving cache does not have — not on
  memory, and `PERF.md` says so rather than leaving the reader to assume.

`MemoryProbeTests` is what made the second one answerable: the existing probes measured the cache
being *written*, never restored, and `GC.KeepAlive(indexer)` is the line that makes the probe answer
the question actually asked.

### Deletions

Nine lint walkers nothing but their own tests called; a dead enumeration and an orphaned comment on
the file-system seam; a reader nothing calls and three comments that contradicted the code. Perf
scopes now report at Debug rather than Information.

---

## 2. `server/samples` — a worked example per game, per language world

**There was no `.gsc` anywhere in the repository.** Every test built its source as a string, so
nothing showed a whole dialect on one page, and there was no file to open when the question was "does
hover still work here" or "is this token coloured right".

43 scripts across five games and three language worlds, with **253 asserted diagnostics**. The same
files are both the demo and the golden corpus — a demo with nothing asserting its output stops being
true within two releases and nobody notices. The specification lives in the sample:

```gsc
// expect 5008 — assigned and never read
unused_thing = 4;
```

Four roles per world, because errors and demonstration fight each other. The showcase produces **zero**
diagnostics and stays the file where "does hover still work" is a fair question. The lints file carries
one deliberate 4000/5000-range finding at a time and still parses cleanly. The broken file holds the
1000/2000/3000 ranges, kept apart because a syntax error puts the parser into recovery and several
lints stand down entirely on a file the parser could not read — mixed in, most of the 5000 range would
look tested and prove nothing.

`SampleScriptTests` asserts both directions. A missing diagnostic is a rule that regressed; an **extra**
one is the more valuable half, since the showcases declare none and any finding there is a false
positive caught on code written to be correct. `EveryLanguageWorldTheGameHasIsSampled` reads
`ScriptExtensions` off the profile, so a game that gains `.csc` fails until its showcase exists.

### Five things this settled that had never been written down

- **5009 suppresses 5001, 5012 and 5026.** One unresolvable import stands the whole import pass down, so
  it cannot share a file with them — it lives alone in each game's `gscode_unresolved.gsc`, and moved
  back it would delete those cases silently while the suite stayed green.
- **5026 is impossible on BO3.** It is the `#include` model's rule; under `#using` the same mistake is
  5000's.
- **5006 is dead on CoD4.** `cod4_api_gsc.json` carries an explicit `"devOnly": false` on every entry,
  which beats the fallback list in `DevOnlyBuiltins`.
- **5013/5014/5019/5023/5025 stand down on WaW, MW2 and BO1**, whose libraries are not marked complete
  or signature-reliable.
- **`.gsh` is the only world the parse forks on.** `Lexer.Lex` and `Syntax.Parser.Parse` take the profile
  and never the language, so a `.csc`'s 1000/2000/3000 output is byte-identical to a `.gsc`'s — but
  `lenient` in `ParseResult.Analyze` is set for headers alone and drops the whole 3000 range, which
  nothing covered. `bo3/gscode_broken.gsh` now pins both halves.

Where a rule cannot fire, the call that would trip it is left in place carrying **no** `expect`, so the
day that game's data is curated the sample fails and asks to be brought up to date. That is the only
reminder a gate like this ever gets.

---

## 3. `GSCode: Select Game`

The picker already existed and could not be reached. It appeared only when the server happened to
notice a file that did not look like the selected game, and then only once per session — so anyone who
dismissed it, or whose scripts are ambiguous enough that the shape detector says nothing, had to go
find `gscode.game` in settings. The one setting that decides what counts as a keyword, whether
`#include` or `#using` resolves, and which builtins exist, had no command.

- **The roster is asked for, never kept.** The client used to own that list and it drifted to nine
  games, four of them cores with no dialect implemented, so picking one wrote a value the setting's own
  enum rejects and the server resolved it back to BO3 with nothing said. A failed request is reported;
  there is deliberately no fallback list, because a fallback list *is* that failure mode. New
  `gscode/supportedGames` request; `GameRoster` is one list with two callers.
- **The tick follows `GameProfile.Active`, not `gscode.game`.** The two differ exactly when something is
  wrong, and ticking a game that is not in use rules out the very thing being looked for.
- **A window reload, not a server restart** — the game is a command-line argument and the launch
  arguments are captured when the client is constructed.

**Two bugs fixed on the way.** The mismatch offer was a second copy of pick-and-write and the copies had
diverged: it wrote to Workspace unconditionally (throws with no folder open) and never offered the
reload that makes the write do anything, so switching game from that prompt appeared to do nothing. It
calls the shared picker now.

---

## 4. Macro parameter-name inlay hints

Parameter-name hints stopped at function calls. A macro invocation got nothing, and on this code that
is a large share of the calls a reader looks at — `IS_TRUE( __a: value )` is exactly the case the
hints exist for, since the macro's definition is the only place the argument's meaning is written
down.

**It could not be had by relaxing the existing pass.** By the time there is a tree the invocation is
gone: the call was replaced by the body it expands to, and every token of that body reports the
*invocation's* range, which is why `IsFromMacroExpansion` skips them — hinting one would stamp the
whole expansion's names onto a single call site. That guard is still right and is untouched.
`PreprocessResult.MacroInvocations` is the only record the call site existed, so this is a second
pass over that list.

- **An invocation's range covers the NAME alone** — `IS_TRUE`, not `IS_TRUE( v )` — so the arguments
  are found by scanning the text after it. Hover already had that scan for its expansion preview; it
  now yields trimmed `MacroArgumentSpan` offsets and `ArgumentsFollowing` is a text view over them.
  One scan, two readers: a hint cannot land on an argument the hover splits differently.
- **Off by default** (`gscode.inlayHints.macroParameterNames`), independently of the call-site
  family. A macro parameter is named for the macro's body rather than for its caller, so `__a:` is
  worth less than a function's parameter name and the reader should opt in.
- **The flow typer is built only when a family that needs it is on.** The macro pass needs no
  inference, so turning the other two off now costs no analysis rather than an unused `InferValues`
  per request.

**The toggle now takes effect when you flip it**, which the first half would otherwise have looked
broken without. Hints are computed per request and then cached by the client, so toggling a family
changed nothing visible until a keystroke or scroll happened to invalidate the document — and
switching one *off* left its hints on screen, which reads as the setting being ignored outright. That
was already true of the two existing families and is fixed for all three: `ConfigurationHandler` asks
for `workspace/inlayHint/refresh` when `ServerSettings.InlayFamilies` moves across a settings push,
guarded on an actual change because clients push their whole configuration on any settings edit — an
unguarded send would refresh on a font-size change. The client half needed nothing;
`vscode-languageclient` already advertises `refreshSupport`.

---

## 5. Completion outside a function body, and signature help on a macro

Two reported cases with one root. **Everything the workspace knows sat behind a `!insideFunction`
early return** in the completion engine, so outside a function body the list was a static set of
words: no macro, no function, no class reached it. `REGISTER_SYSTEM` is written at column 0 in 477 of
the shipped BO3 scripts and was never offered once. Signature help, separately, had never known what
a macro was at all — it tried a script function, then a builtin, then gave up.

- **File scope gets the list a function body gets.** The early return was hiding categories that had
  no reason to be hidden: a macro table is built per parse from this file plus the headers it
  `#insert`s, and a function is in scope for the *file*, not for a body. Parameters and locals are
  the one category that genuinely is per-cursor, and outside a declaration there is nothing bound to
  collect rather than a list to suppress. The engine globals stay withheld — they sort first, and
  nothing can be sent on `self` at that position.
- **File scope takes BOTH keyword lists**, which is not the declarations-only position it looks
  like. A top-level macro invocation is a **call**, so it opens an expression outside every function
  body: the shipped BO3 scripts pass `undefined` to `REGISTER_SYSTEM` 467 times and write 510
  function pointers in those argument lists, and none of it was reachable. Splitting the statement
  list into expression atoms and control flow would buy nothing but a rule to maintain — `if` offered
  at file scope is noise, not a wrong answer.
- **Macros are offered only where the dialect has a preprocessor.** The preprocessor records a
  `#define` whatever game is active, but only BO3 has one; in the IW line the single `#define` in the
  corpus is a commented-out block of C in `_hud.gsc`. This was already true inside a body — the gate
  is not a consequence of file scope reaching the loop, only of the loop being read again.
- **Nothing completed at file scope carries a terminator**, and **a function pointer completes as
  `&foo`** rather than `&foo()` — `&foo()` calls the function and takes the address of the result.
  BO3 writes 4,564 pointers, 585 of them through a namespace, and both routes came through the arm
  that added parentheses. Both corrections are about the position rather than the list, so the
  punctuation is now decided once before the arms rather than inside each of them.

**Signature help now answers on a function-like macro** — its parameter names, the argument the caret
is in, what it expands to, and its trailing-comment documentation.

- **The macro is asked first**, before the function lookups. The preprocessor substitutes before the
  parser runs, so where a `#define` and a function share a name the invocation being typed is
  replaced before anything sees it and the function's parameters would describe code that never
  executes. They can only collide on exact case: the lookup is **ordinal**, because a macro name is
  the language's one case-sensitive kind.
- **Read from the parse in hand, not the store**, so a header inserted a keystroke ago counts.
- **Three positions must not answer with a macro.** An object-like one is not a call —
  `MAX_PLAYERS( x )` is a body followed by a parenthesised expression — so it hands the position back
  rather than showing an empty signature. An arrow call dispatches on an object and a qualified
  `util::NAME(` names a namespace member, and the preprocessor expands neither.
- **Deliberately not gated on `HasMacros`, unlike macro completion.** Completion decides what to
  *propose*, and proposing an expansion a pre-BO3 engine will not perform is a wrong answer. This
  describes a name already written, and the preprocessor expands a `#define` on every dialect by
  design — `ReportIfNoPreprocessor` reports the directive and then processes it anyway, so
  withholding help would leave the expansion happening with nothing on screen about it.
- **The widget does not print the parameter list twice.** It first rendered hover's markdown, which
  opens with the `#define` line — but signature help's *label* is the define form already, drawn by
  the client with the active argument highlighted. It now shows the expansion alone, with the
  separator emitted only when there is also a comment to divide it from.
- **The expansion keeps the lines the macro was written on**, which hover gains too. The body was
  joined into one line, so a macro that declares a function read as one very long statement. The
  structure was never lost: the backslashes are stripped during the `#define`, but each body token
  still carries the line it was written on, so a break is a token whose line is past the last one's.
  **Indentation is rendered as ranked levels four spaces apart rather than as the author's columns**
  — a tab is ONE character in a token's range, so subtracting columns gave a tab-indented header a
  one-space step, the structure present and unreadable.

### What it cost

File-scope completion used to short-circuit above every store query, so it was the cheap half of the
sample and is now an ordinary request. Measured as a before/after pair in one session, sampler change
in both halves so the request sets are identical (7,361 bo3, 7,838 cod4):

| | median | p90 | p99 |
|---|---:|---:|---:|
| bo3 before | 0.363 ms | 2.059 ms | 4.228 ms |
| bo3 after | **0.473 ms** | 2.094 ms | 4.207 ms |
| cod4 before | 0.195 ms | 0.342 ms | 1.008 ms |
| cod4 after | 0.203 ms | 0.337 ms | 1.096 ms |

**The median moves and the tail does not**, which is the expected shape: the p99 is set by the
per-namespace store walk this did not touch. **The noise floor is recorded beside it, because it is
the same size as the effect** — two later runs of identical code gave bo3 medians of 0.556 and 0.499
ms, so run-to-run spread is about ±0.06 ms at the median and ±0.7 ms at p99. The 0.11 ms is real but
only about twice the spread, and any future single-run comparison claiming less than that has
measured the machine. That pair is also the whole measurement of the function-pointer arm, which is
why it has no row: at one to three token lookbacks per request it sits well under the floor.

The namespace-index result in section 1 was measured with file scope still on the early return, and
`PERF.md` now says so — its 2x is a ratio between two runs of one tree and survives that, but its
millisecond values belong to the smaller list. `CorpusPerfTests` samples a file-scope position now,
so a rerun of the sweep exercises the arm rather than short-circuiting past it.

---

## Verification

- **2,337 unit tests green** (779 parser / 329 server / 1,229 workspace), Release, built in place on
  an uninstrumented build.
- **Re-measured after the rebase**, because `upstream/main` had rewritten the `t7` libraries by
  ~13,000 lines net with 115 corrected signatures — new data under the two paths that read it on
  every request. Neither moved: bo3 lint pass **1,168 ms** (was 1,332), completion **p99 1.64 ms**
  (was 2.12), `ArgumentCountLint` **144 ms** (was 162–205). The figures above stand.
- One re-measured figure is recorded in `PERF.md` as **unexplained rather than claimed**: analysis
  came back 30–60% below what that file records, on a branch that went nowhere near lex, preprocess
  or parse. No mechanism, warm file cache the likelier reading, and the same shape as the extract
  claim this branch already retracts — so it is not written down as a win.
- Perf figures reproduced with `--filter "Category=Perf"`; every table in `PERF.md` names its run.
- The two cross-file tests in `SupportedGamesHandlerTests` skip when `client/` is not found, so a green
  run is not evidence they ran — **verified by mutation** instead: injecting `ghosts` into the
  `gscode.game` enum and renaming the command fails them, with both lists printed side by side.
- The macro hints are tested **through the handler**, not around it: `InlayHintMacroTests` drives
  `InlayHintHandler.Handle` with a real document store and asserts the label lands on `level` rather
  than on the parenthesis before it, that an object-like macro is not labelled, that the request
  window still clips, and that the call-site pass keeps skipping the expansion when both families
  are on. `MacroArgumentSpanTests` pins the span math against real parse results, including a call
  broken across lines and the unterminated argument list that is the normal state while typing.
- `EachGame_WarmIndexWithCache_ThenWatchRetainedMemory` run against all three of the commits it
  arbitrates, which is what makes the attribution admissible rather than a guess about which half did
  the work.
- The file-scope completion cases assert names a real edit typed and the list did not contain, in
  `LocalScopeCompletionTests`: the macros an inserted header supplies offered outside a body, the
  functions in scope and the expression atoms a macro invocation's arguments need, and the engine
  globals still withheld there. `DialectCompletionTests` holds the negative half — a CoD4 file-scope
  list carries no macro rows for a preprocessor that game does not have.
- `SignatureEngineTests` covers the macro parameter names and active index, the reported case of an
  inserted macro invoked at column 0, the body-less define whose panel is a comment with no separator
  above it, and each of the three positions that must not answer with a macro.
- `MacroExpansionPreviewTests` pins both reported macro shapes line for line, and renders the same
  header written with tabs and with spaces to assert the two come out identical. The test that
  asserted the body collapses to one line is gone with the behaviour it described.

## Documentation

`ARCHITECTURE.md`'s lint count had drifted — it said `WorkspaceLints` runs twenty-five rules and it
runs **twenty-six**, because nine moved behind `NodeLintPass` earlier in this branch and the sentence
still described the shape from before that. Corrected, and it now says where the split falls rather
than giving a bare total that can go stale the same way. Verified as a set difference, not counted by
eye: every `*Lint.cs` on disk is wired to one of the two entry points.

`gscode.selectGame` was declared in the manifest and described in `ARCHITECTURE.md` and
`client/src/FOLDER.md` — the two files a *contributor* reads, and neither of them one a user looking
for the command would open. It is now in the changelog's 2.0.0 command list, the client README's
command list and game-selection paragraph, and both READMEs' pre-issue checklists, where it earns the
place twice: the thing being checked there is which game is actually in force, and the picker is the
only surface that answers with the server's answer rather than with what `gscode.game` says.

## Reviewer notes

- `GSCode.Server.Tests` no longer runs its collections in parallel. `SampleScriptTests` is the first
  class outside `Corpus/` to move `GameProfile.Active`, and ~300 classes read that global without saying
  so — leaving it on CoD4 failed 132 of them. Serializing alone still left 121, since a class running
  *after* a sample run reads the leftover as happily as one beside it; `SampleWorkspace` restores the
  profile as the other half. Costs ~1 s on 313 tests.
- `client/package.json` gains the command (four lines) and one settings key,
  `gscode.inlayHints.macroParameterNames`, defaulted **off**. No settings were removed or
  re-defaulted.
- No public API or protocol removals; `gscode/supportedGames` is additive.



