### PR TITLE
2.0.1: make format-on-type opt-in, fix unary spacing, add padding settings

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to the GSCode extension are documented in this file.
 
 This project follows [Keep a Changelog](http://keepachangelog.com/).
 
+## 2.0.1
+
+### Changed
+- On-type formatting is no longer enabled by default. 2.0.0 shipped `editor.formatOnType` on for
+  GSC, CSC and GSH, so typing `;` or `}` re-indented and re-aligned the surrounding lines. To opt
+  back in, add `"[gsc]": { "editor.formatOnType": true }` (and likewise `[csc]`, `[gsh]`) to your
+  settings; Format Document and Format Selection are unaffected. With it off, `}` no longer
+  auto-dedents as you type.
+
+### Added
+- Two more formatter spacing settings, so the padding is yours to choose per kind:
+  `gscode.format.padCallParens` (`foo( a )` vs `foo(a)`, separately from control-flow parens) and
+  `gscode.format.padBrackets` (`a[ i ]` vs `a[i]`). Both default to the 2.0.0 behaviour; set
+  `padCallParens` and `padBrackets` off, with `padParens` on, for `if ( foo(a[i]) )`.
+
+### Fixed
+- The formatter put a space after a unary minus or address-of — `( -150, -1024, 304 )` came out
+  `( - 150, - 1024, 304 )` and `&funcname` as `& funcname`. Sign and `&` now hug their operand;
+  binary `a - b` and `a & b` are unchanged.
+
 ## 2.0.0
 
 A complete ground-up rewrite of the language server and VS Code extension.

--- a/client/README.md
+++ b/client/README.md
@@ -178,7 +178,13 @@ guideline](../server/FORMATTING.md).
 
 ## Release Notes
 
-### 2.0.0 (latest)
+### 2.0.1 (latest)
+
+- Format-on-type is no longer enabled by default. 2.0.0 shipped `editor.formatOnType` on for GSC, CSC and GSH, so typing `;` or `}` re-indented and re-aligned the surrounding lines. To opt back in, add `"[gsc]": { "editor.formatOnType": true }` (and likewise `[csc]`, `[gsh]`) to your settings; Format Document and Format Selection are unaffected.
+- Two more formatter spacing settings: `gscode.format.padCallParens` (`foo( a )` vs `foo(a)`, separately from control-flow parens) and `gscode.format.padBrackets` (`a[ i ]` vs `a[i]`). Both default to the 2.0.0 behaviour.
+- Fixed the formatter putting a space after a unary minus or address-of: `( -150, -1024, 304 )` came out `( - 150, - 1024, 304 )` and `&funcname` as `& funcname`.
+
+### 2.0.0
 
 A complete ground-up rewrite of the language server and extension for speed, low memory use, and accuracy.
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "gscode",
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "gscode",
-			"version": "2.0.0",
+			"version": "2.0.1",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"dotenv": "^16.4.5",

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,7 @@
 		"color": "#07080C",
 		"theme": "dark"
 	},
-	"version": "2.0.0",
+	"version": "2.0.1",
 	"publisher": "blakintosh",
 	"license": "GPL-3.0-or-later",
 	"homepage": "https://www.gscode.net",
@@ -359,7 +359,19 @@
 					"gscode.format.padParens": {
 						"type": "boolean",
 						"default": true,
-						"description": "Pad the inside of control-flow parentheses: 'if ( x )' rather than 'if (x)'. Both appear in stock scripts, which are about 88% padded.",
+						"description": "Pad the inside of control-flow and grouping parentheses: 'if ( x )' rather than 'if (x)'. Both appear in stock scripts, which are about 88% padded. Call parentheses have their own setting, gscode.format.padCallParens.",
+						"scope": "window"
+					},
+					"gscode.format.padCallParens": {
+						"type": "boolean",
+						"default": true,
+						"description": "Pad the inside of call and declaration parentheses: 'foo( a, b )' rather than 'foo(a, b)'. Empty parentheses stay '()' either way. Turn this off and keep padParens on for the common 'if ( x )' with 'foo(x)' style.",
+						"scope": "window"
+					},
+					"gscode.format.padBrackets": {
+						"type": "boolean",
+						"default": true,
+						"description": "Pad the inside of subscript and array-literal brackets: 'a[ i ]' rather than 'a[i]'. Function-pointer brackets '[[ ptr ]]' and empty '[]' stay tight either way. Stock scripts lean tight, about 4 to 1.",
 						"scope": "window"
 					},
 					"gscode.format.maxBlankLines": {
@@ -431,8 +443,7 @@
 				},
 				"editor.insertSpaces": false,
 				"editor.tabSize": 4,
-				"editor.autoClosingOvertype": "always",
-				"editor.formatOnType": true
+				"editor.autoClosingOvertype": "always"
 			},
 			"[csc]": {
 				"editor.quickSuggestions": {
@@ -442,8 +453,7 @@
 				},
 				"editor.insertSpaces": false,
 				"editor.tabSize": 4,
-				"editor.autoClosingOvertype": "always",
-				"editor.formatOnType": true
+				"editor.autoClosingOvertype": "always"
 			},
 			"[gsh]": {
 				"editor.quickSuggestions": {
@@ -453,8 +463,7 @@
 				},
 				"editor.insertSpaces": false,
 				"editor.tabSize": 4,
-				"editor.autoClosingOvertype": "always",
-				"editor.formatOnType": true
+				"editor.autoClosingOvertype": "always"
 			}
 		}
 	},

--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -182,9 +182,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
  *
  * This lives client-side rather than in the server's on-type formatting handler, and stays there
  * UNCONDITIONALLY, because VSCode only sends `textDocument/onTypeFormatting` when
- * `editor.formatOnType` is enabled. We now ship that as a default for the GSC languages, so the
- * handler is usually reachable — but a default is not a guarantee: the setting resolves
- * per-language, per-workspace and per-folder, and can change mid-session.
+ * `editor.formatOnType` is enabled. That is off unless the user turns it on for the GSC languages
+ * (it is deliberately not shipped as a default: it rewrites neighbouring lines on every `;`), so
+ * the handler is usually NOT reachable — and even when it is, the setting resolves per-language,
+ * per-workspace and per-folder, and can change mid-session.
  *
  * Reading the setting to choose between a client- and server-side implementation is the tempting
  * alternative and is worse in the way that is hardest to notice. Running both costs nothing (this

--- a/client/src/settings.ts
+++ b/client/src/settings.ts
@@ -25,6 +25,8 @@ export interface GscodeSettings {
     "completion.parameterHints": boolean;
     "diagnostics.scope": string;
     "format.padParens": boolean;
+    "format.padCallParens": boolean;
+    "format.padBrackets": boolean;
     "format.maxBlankLines": number;
     "format.sortDirectives": boolean;
     "format.alignConsecutive": boolean;
@@ -52,6 +54,8 @@ export function readSettings(): GscodeSettings {
         "completion.parameterHints": config.get<boolean>("completion.parameterHints", true),
         "diagnostics.scope": config.get<string>("diagnostics.scope", "workspace"),
         "format.padParens": config.get<boolean>("format.padParens", true),
+        "format.padCallParens": config.get<boolean>("format.padCallParens", true),
+        "format.padBrackets": config.get<boolean>("format.padBrackets", true),
         "format.maxBlankLines": config.get<number>("format.maxBlankLines", 2),
         "format.sortDirectives": config.get<boolean>("format.sortDirectives", true),
         "format.alignConsecutive": config.get<boolean>("format.alignConsecutive", true),

--- a/server/Directory.Build.props
+++ b/server/Directory.Build.props
@@ -38,7 +38,7 @@
     <!-- The one place the server's version is stated. It must match client/package.json, since the
          two ship together as one extension and the server reports this in its startup log. Without
          it every assembly claimed 1.0.0 while the extension said 2.0.0. -->
-    <Version>2.0.0</Version>
+    <Version>2.0.1</Version>
   </PropertyGroup>
 
   <!-- Opt-in perf instrumentation: build with -p:GscodeInstrumentation=true to compile in

--- a/server/FOLLOWUPS.md
+++ b/server/FOLLOWUPS.md
@@ -603,7 +603,9 @@ to be noticed.
 The formatter does not wrap long lines and will not. Everything else the formatter follow-up once
 listed has shipped — `padParens`, `maxBlankLines`, per-request `tabSize`/`insertSpaces`, consecutive
 alignment (`alignConsecutive`), directive sorting, and on-type formatting scoped to the alignment
-group around the cursor with `editor.formatOnType` on by default.
+group around the cursor. On-type formatting is opt-in: it runs only where the user enables
+`editor.formatOnType` for the GSC languages, since a default that rewrites neighbouring lines on
+every `;` proved unwelcome in 2.0.0.
 
 Measured before deciding, across 390,434 BO3 lines and 335,608 CoD4 lines: the 95th percentile is 82
 and 85 characters, and only 1.3%/1.4% pass 120. The number that decided it is not the tail's size

--- a/server/src/GSCode.Server/Configuration/ServerSettings.cs
+++ b/server/src/GSCode.Server/Configuration/ServerSettings.cs
@@ -50,6 +50,12 @@ public sealed class ServerSettings
     /// <summary>Whether control-flow parentheses are padded: `if ( x )` against `if (x)`.</summary>
     public bool FormatPadParens { get; set; } = true;
 
+    /// <summary>Whether call parentheses are padded: `foo( a )` against `foo(a)`.</summary>
+    public bool FormatPadCallParens { get; set; } = true;
+
+    /// <summary>Whether subscript brackets are padded: `a[ i ]` against `a[i]`.</summary>
+    public bool FormatPadBrackets { get; set; } = true;
+
     /// <summary>The longest run of blank lines the formatter preserves.</summary>
     public int FormatMaxBlankLines { get; set; } = 2;
 
@@ -136,6 +142,12 @@ public sealed class ServerSettings
         FormatPadParens = section.Value<bool?>("format.padParens")
             ?? section["format"]?.Value<bool?>("padParens")
             ?? FormatPadParens;
+        FormatPadCallParens = section.Value<bool?>("format.padCallParens")
+            ?? section["format"]?.Value<bool?>("padCallParens")
+            ?? FormatPadCallParens;
+        FormatPadBrackets = section.Value<bool?>("format.padBrackets")
+            ?? section["format"]?.Value<bool?>("padBrackets")
+            ?? FormatPadBrackets;
         FormatMaxBlankLines = section.Value<int?>("format.maxBlankLines")
             ?? section["format"]?.Value<int?>("maxBlankLines")
             ?? FormatMaxBlankLines;

--- a/server/src/GSCode.Server/Formatting/FormatOptions.cs
+++ b/server/src/GSCode.Server/Formatting/FormatOptions.cs
@@ -24,6 +24,16 @@ namespace GSCode.Server.Formatting;
 /// in stock code (33,140 padded, 4,333 tight), so this is a genuine preference rather than a
 /// convention with one right answer.
 /// </param>
+/// <param name="PadCallParens">
+/// Whether a call's or declaration's parentheses are padded: <c>foo( a )</c> against <c>foo(a)</c>.
+/// Separate from <see cref="PadParens"/> because the two are mixed freely in stock code, and the
+/// tight-call, padded-condition combination is a common hand-written style.
+/// </param>
+/// <param name="PadBrackets">
+/// Whether subscript and array-literal brackets are padded: <c>a[ i ]</c> against <c>a[i]</c>.
+/// Adjacent brackets (<c>[[ ptr ]]</c>, <c>[]</c>) stay tight either way. Stock leans tight
+/// (19,175 to 4,686); padded is the default to match the parentheses, but it is a preference.
+/// </param>
 /// <param name="MaxBlankLines">
 /// The longest run of blank lines to preserve. Two by default, which keeps the 2,477 double blanks
 /// in the stock scripts while still collapsing the 152 longer runs.
@@ -45,6 +55,8 @@ public readonly record struct FormatOptions(
     int IndentWidth = 4,
     bool UseTabs = false,
     bool PadParens = true,
+    bool PadCallParens = true,
+    bool PadBrackets = true,
     int MaxBlankLines = 2,
     bool SortDirectives = true,
     bool AlignConsecutive = false)
@@ -58,7 +70,7 @@ public readonly record struct FormatOptions(
     /// blank lines, not the values declared above.
     /// </summary>
     public static FormatOptions Default { get; } = new(
-        IndentWidth: 4, UseTabs: false, PadParens: true, MaxBlankLines: 2,
+        IndentWidth: 4, UseTabs: false, PadParens: true, PadCallParens: true, PadBrackets: true, MaxBlankLines: 2,
         SortDirectives: true, AlignConsecutive: false);
 
     /// <summary>One level of indentation as text.</summary>
@@ -83,6 +95,8 @@ public readonly record struct FormatOptions(
             IndentWidth: tabSize > 0 ? tabSize : 4,
             UseTabs: !insertSpaces,
             PadParens: settings.FormatPadParens,
+            PadCallParens: settings.FormatPadCallParens,
+            PadBrackets: settings.FormatPadBrackets,
             MaxBlankLines: Math.Max(0, settings.FormatMaxBlankLines),
             SortDirectives: settings.FormatSortDirectives,
             AlignConsecutive: settings.FormatAlignConsecutive);

--- a/server/src/GSCode.Server/Formatting/GscFormatter.cs
+++ b/server/src/GSCode.Server/Formatting/GscFormatter.cs
@@ -466,10 +466,16 @@ public static class GscFormatter
         // column. This tracks bodies that are owed an indent without one.
         UnbracedBodyTracker unbraced = new();
 
+        // Whether each open parenthesis is a CALL's (`foo(`) or a control-flow/grouping one
+        // (`if (`, `= (`), so its interior can take the padding rule the user chose for that kind.
+        // The closer needs the same answer, hence a stack rather than a flag.
+        List<bool> callParens = new();
+
         for ( int index = 0; index < significant.Count; index++ )
         {
             Token token = significant[index].Token;
             int newlinesBefore = significant[index].NewlinesBefore;
+            bool insideCallParen = false;
 
             // Closers dedent before this line's indent is computed. A dev block is deliberately
             // absent: `/# … #/` is a compile-time switch, not a scope -- the engine jumps over it
@@ -483,6 +489,12 @@ public static class GscFormatter
             if ( token.Kind == TokenKind.CloseParen )
             {
                 parenDepth = Math.Max(0, parenDepth - 1);
+
+                if ( callParens.Count > 0 )
+                {
+                    insideCallParen = callParens[^1];
+                    callParens.RemoveAt(callParens.Count - 1);
+                }
             }
 
             if ( token.Kind == TokenKind.CloseBrace && blocks.Count > 0 )
@@ -505,6 +517,11 @@ public static class GscFormatter
                 Token previous = significant[index - 1].Token;
                 bool trailingComment = LineFacts.IsComment(token.Kind) && newlinesBefore == 0;
 
+                if ( previous.Kind == TokenKind.OpenParen && callParens.Count > 0 )
+                {
+                    insideCallParen = callParens[^1];
+                }
+
                 if ( ShouldBreak(previous.Kind, token.Kind, newlinesBefore, trailingComment, parenDepth) )
                 {
                     int blankLines = Math.Clamp(newlinesBefore - 1, 0, options.MaxBlankLines);
@@ -513,7 +530,9 @@ public static class GscFormatter
                 }
                 else
                 {
-                    output.Append(Separator(previous.Kind, token.Kind, options));
+                    // The token before the operator decides whether `-`, `+` and `&` are unary.
+                    TokenKind beforePrevious = index >= 2 ? significant[index - 2].Token.Kind : TokenKind.OpenBrace;
+                    output.Append(Separator(beforePrevious, previous.Kind, token.Kind, insideCallParen, options));
                 }
 
                 output.Append(token.GetText(text));
@@ -541,6 +560,7 @@ public static class GscFormatter
             if ( token.Kind == TokenKind.OpenParen )
             {
                 parenDepth++;
+                callParens.Add(index > 0 && !IsGroupingParen(significant[index - 1].Token.Kind));
             }
 
             unbraced.AfterToken(token.Kind);
@@ -767,17 +787,22 @@ public static class GscFormatter
         output.Append(' ', levels * options.IndentWidth);
     }
 
-    private static string Separator(TokenKind previous, TokenKind current, FormatOptions options)
+    private static string Separator(
+        TokenKind beforePrevious, TokenKind previous, TokenKind current, bool insideCallParen, FormatOptions options)
     {
-        // Parenthesis interior padding: "( x )", but "()" stays tight.
+        // Parenthesis interior padding: "( x )", but "()" stays tight. A call's parentheses and a
+        // control-flow/grouping pair each follow their own setting, so `if ( x )` with `foo(x)` --
+        // a common mix in stock code -- is expressible.
+        bool padParen = insideCallParen ? options.PadCallParens : options.PadParens;
+
         if ( previous == TokenKind.OpenParen )
         {
-            return current == TokenKind.CloseParen || !options.PadParens ? "" : " ";
+            return current == TokenKind.CloseParen || !padParen ? "" : " ";
         }
 
         if ( current == TokenKind.CloseParen )
         {
-            return options.PadParens ? " " : "";
+            return padParen ? " " : "";
         }
 
         // Bracket interiors are padded, matching parentheses: `a[ i ]`, `[[ ptr ]]`. Stock leans
@@ -789,12 +814,12 @@ public static class GscFormatter
         // token rather than as nested indexes, and an empty array stays `[]`.
         if ( previous == TokenKind.OpenBracket )
         {
-            return current is TokenKind.OpenBracket or TokenKind.CloseBracket ? "" : " ";
+            return current is TokenKind.OpenBracket or TokenKind.CloseBracket || !options.PadBrackets ? "" : " ";
         }
 
         if ( current == TokenKind.CloseBracket )
         {
-            return previous == TokenKind.CloseBracket ? "" : " ";
+            return previous == TokenKind.CloseBracket || !options.PadBrackets ? "" : " ";
         }
 
         // A '[' hugs its operand only when it SUBSCRIPTS one -- `a[ 0 ]`, `foo()[ 1 ]`. Opening an
@@ -806,6 +831,14 @@ public static class GscFormatter
         }
 
         if ( NoSpaceAfter(previous) )
+        {
+            return "";
+        }
+
+        // A sign or address-of hugs its operand: `-150`, `&funcname`, `-( a )`. The same tokens are
+        // binary when an operand precedes them (`a - b`, `flags & MASK`), and only then take the
+        // space. Reported as `(- 150, - 1024, 304)` and `& funcname` in 2.0.0.
+        if ( IsUnaryHere(beforePrevious, previous) )
         {
             return "";
         }
@@ -828,16 +861,22 @@ public static class GscFormatter
         // lose their hug under an allow-list.
         if ( current == TokenKind.OpenParen )
         {
-            // `return ( … )` and `case ( … )` group rather than call, so they take the space that
-            // any other keyword-followed-by-paren would not.
-            bool grouping = IsControlFlowKeyword(previous)
-                || IsBinaryOrAssignmentOperator(previous)
-                || previous is TokenKind.Return or TokenKind.Case;
-
-            return grouping ? " " : "";
+            return IsGroupingParen(previous) ? " " : "";
         }
 
         return " ";
+    }
+
+    /// <summary>
+    /// Whether a '(' after <paramref name="previous"/> opens a group rather than a call. `return ( … )`
+    /// and `case ( … )` group rather than call, so they take the space that any other
+    /// keyword-followed-by-paren would not.
+    /// </summary>
+    private static bool IsGroupingParen(TokenKind previous)
+    {
+        return IsControlFlowKeyword(previous)
+            || IsBinaryOrAssignmentOperator(previous)
+            || previous is TokenKind.Return or TokenKind.Case;
     }
 
     private static bool NoSpaceAfter(TokenKind kind)
@@ -940,6 +979,17 @@ public static class GscFormatter
             default:
                 return false;
         }
+    }
+
+    /// <summary>
+    /// Whether <paramref name="operatorKind"/> is a prefix operator in this position: minus, plus or ampersand
+    /// with nothing before it that could be an operand. `)` and `]` end operands too, so `(a) - 1`
+    /// and `a[ 0 ] - 1` stay binary.
+    /// </summary>
+    private static bool IsUnaryHere(TokenKind beforePrevious, TokenKind operatorKind)
+    {
+        return operatorKind is TokenKind.Minus or TokenKind.Plus or TokenKind.Ampersand
+            && !EndsAnOperand(beforePrevious);
     }
 
     private static bool IsControlFlowKeyword(TokenKind kind)

--- a/server/tests/GSCode.Server.Tests/Formatting/OperatorSpacingTests.cs
+++ b/server/tests/GSCode.Server.Tests/Formatting/OperatorSpacingTests.cs
@@ -57,6 +57,31 @@ public class OperatorSpacingTests
     }
 
     [Theory]
+    [InlineData("a = (-150, -1024, 304);", "a = ( -150, -1024, 304 );")]
+    [InlineData("a = -1;", "a = -1;")]
+    [InlineData("a = -(b);", "a = -( b );")]
+    [InlineData("a = b * -1;", "a = b * -1;")]
+    [InlineData("a = &foo;", "a = &foo;")]
+    [InlineData("foo( &bar, -1 );", "foo( &bar, -1 );")]
+    [InlineData("return -1;", "return -1;")]
+    public void AUnaryOperatorHugsItsOperand(string input, string expected)
+    {
+        // Reported in 2.0.0: `(- 150, - 1024, 304)` and `& funcname`.
+        Assert.Contains(expected, Body(input), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("a = b - 1;", "a = b - 1;")]
+    [InlineData("a = (b) - 1;", "a = ( b ) - 1;")]
+    [InlineData("a = b[0] - 1;", "a = b[ 0 ] - 1;")]
+    [InlineData("a = b & 1;", "a = b & 1;")]
+    [InlineData("a = 2 + 1;", "a = 2 + 1;")]
+    public void ABinaryOperatorKeepsItsSpaces(string input, string expected)
+    {
+        Assert.Contains(expected, Body(input), StringComparison.Ordinal);
+    }
+
+    [Theory]
     [InlineData("foo();", "foo();")]
     [InlineData("foo( a );", "foo( a );")]
     [InlineData("a = foo( b );", "a = foo( b );")]

--- a/server/tests/GSCode.Server.Tests/Formatting/PaddingOptionsTests.cs
+++ b/server/tests/GSCode.Server.Tests/Formatting/PaddingOptionsTests.cs
@@ -1,0 +1,95 @@
+using GSCode.Core;
+using GSCode.Core.Symbols;
+using GSCode.Core.Text;
+using GSCode.Parser;
+using GSCode.Parser.Preprocessing;
+using GSCode.Server.Formatting;
+using Xunit;
+
+namespace GSCode.Server.Tests.Formatting;
+
+/// <summary>
+/// The three padding knobs act on three different bracket kinds and nothing else: `PadParens` on
+/// control-flow and grouping parentheses, `PadCallParens` on call and declaration parentheses,
+/// `PadBrackets` on subscripts and array literals. Each may be off while the others stay on, which
+/// is how the common hand-written `if ( foo(a[i]) )` style is reached.
+/// </summary>
+public class PaddingOptionsTests
+{
+    private static string Format(string statement, FormatOptions options)
+    {
+        ParseResult result = ScriptAnalysis.Analyze(
+            @"c:\ws\scripts\t.gsc",
+            ScriptLanguage.Gsc,
+            SourceText.From("function f( a, i )\n{\n\t" + statement + "\n}\n"),
+            NullInsertProvider.Instance,
+            new NameTable());
+
+        string? formatted = GscFormatter.Format(result, options with { UseTabs = true });
+        Assert.NotNull(formatted);
+        return formatted;
+    }
+
+    private const string Input = "if (IS_EQUAL(GetDvarInt(a[i], 0), 3)) x = (a) + foo();";
+
+    [Fact]
+    public void EverythingPaddedByDefault()
+    {
+        Assert.Contains(
+            "if ( IS_EQUAL( GetDvarInt( a[ i ], 0 ), 3 ) ) x = ( a ) + foo();",
+            Format(Input, FormatOptions.Default), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TightCallsKeepPaddedConditions()
+    {
+        Assert.Contains(
+            "if ( IS_EQUAL(GetDvarInt(a[ i ], 0), 3) ) x = ( a ) + foo();",
+            Format(Input, FormatOptions.Default with { PadCallParens = false }), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TightBracketsLeaveParensAlone()
+    {
+        Assert.Contains(
+            "if ( IS_EQUAL( GetDvarInt( a[i], 0 ), 3 ) ) x = ( a ) + foo();",
+            Format(Input, FormatOptions.Default with { PadBrackets = false }), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void EverythingTight()
+    {
+        Assert.Contains(
+            "if (IS_EQUAL(GetDvarInt(a[i], 0), 3)) x = (a) + foo();",
+            Format(Input, FormatOptions.Default with { PadParens = false, PadCallParens = false, PadBrackets = false }),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void TightConditionsKeepPaddedCalls()
+    {
+        Assert.Contains(
+            "if (IS_EQUAL( GetDvarInt( a[ i ], 0 ), 3 )) x = (a) + foo();",
+            Format(Input, FormatOptions.Default with { PadParens = false }), StringComparison.Ordinal);
+    }
+
+    [Theory]
+    [InlineData("[[ptr]]();", "[[ptr]]();")]
+    [InlineData("a = [];", "a = [];")]
+    [InlineData("foo();", "foo();")]
+    public void AdjacentAndEmptyBracketsStayTightWhenUnpadded(string input, string expected)
+    {
+        Assert.Contains(
+            expected,
+            Format(input, FormatOptions.Default with { PadBrackets = false, PadCallParens = false }),
+            StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void DeclarationParensFollowTheCallSetting()
+    {
+        Assert.StartsWith(
+            "function f(a, i)\n",
+            Format("x = 1;", FormatOptions.Default with { PadCallParens = false }), StringComparison.Ordinal);
+    }
+}


### PR DESCRIPTION
## Why

2.0.0 shipped `editor.formatOnType: true` as a configuration default for GSC/CSC/GSH. Every `;` or `}` ran the formatter over the surrounding alignment group, so users who never invoked Format Document had paren padding and `=` alignment applied to their files as they typed — and were disabling auto-update over it.

## What

- **Format-on-type is opt-in.** The three `configurationDefaults` entries are removed. The server handler is unchanged, so `"[gsc]": { "editor.formatOnType": true }` restores exactly the 2.0.0 behaviour. The client-side semicolon de-dup was already independent of the setting and still works; `}` auto-dedent while typing is the one thing lost when off, and the changelog says so.
- **Unary `-`, `+`, `&` hug their operand.** `Separator()` only saw the (previous, current) pair and treated every sign as binary: `( - 150, - 1024, 304 )`, `& funcname`. It now also sees the token before the operator; when that cannot end an operand the sign hugs. Binary `a - b`, `( b ) - 1`, `b[ 0 ] - 1`, `a & 1` are covered by tests and unchanged.
- **Padding is per bracket kind.** `gscode.format.padParens` applied to calls too, contrary to its own description. It now covers control-flow/grouping parens only; new `gscode.format.padCallParens` (`foo( a )` vs `foo(a)`) and `gscode.format.padBrackets` (`a[ i ]` vs `a[i]`; `[[ptr]]` and `[]` stay tight) cover the rest. All three default to the 2.0.0 output, so no existing format changes unless a user opts in.
- Version 2.0.1 in `client/package.json`, `package-lock.json`, `server/Directory.Build.props`; release notes in `CHANGELOG.md` and `client/README.md`.

## Verification

- `GSCode.Server.Tests` formatting suite: 176/176, including new `PaddingOptionsTests` (every padding combination on one line) and 12 unary/binary cases in `OperatorSpacingTests`.
- Server builds clean in Release; client `tsc` passes.
- Not related: 7 `Handlers/` tests fail on Linux on a clean `next` (Windows-shaped fixture paths); CI on Windows is green.

## Not in this PR

#79 (perf pass, game picker, macro-aware completion) is 2.1 work and should land after this, rebased.



